### PR TITLE
Expand v0.1.0 spec for substrate, auth, history, and search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expand the v0.1.0 spec to define the full transcript substrate and HTTP
+  surface, including sessions, tags, transcript editing and version history,
+  segment retrieval, transcript deletion, unified history/search collection
+  semantics, required `recorded_at`, and the shared error envelope.
 - Rename the transcript schema field from `whisper_model` to `model` so the API
   describes the transcription engine without binding the contract to Whisper.
 - Clarify that `cost_cents` is always present on transcript resources but may be

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -76,6 +76,8 @@ Validation:
 
 - Accepted file formats are `m4a`, `mp3`, `wav`, and `webm`.
 - Maximum upload size is `25 MiB`.
+- `session_id`, when present on a new submission attempt, must identify an
+  existing session owned by the authenticated API key.
 - `language`, when present, constrains transcription to the supplied language.
   The backend does not auto-detect language for that submission.
 
@@ -86,8 +88,8 @@ Responses:
 - `200 OK`: replay of an existing terminal job
 - `400 Bad Request`: invalid idempotency header or invalid request fields
 - `401 Unauthorized`: missing or invalid API key
-- `404 Not Found`: supplied `session_id` does not exist for the authenticated
-  API key
+- `404 Not Found`: on a new submission attempt, supplied `session_id` does not
+  exist for the authenticated API key
 - `413 Payload Too Large`: file exceeds allowed size
 - `415 Unsupported Media Type`: unsupported audio format
 - `409 Conflict`: same API key and `Idempotency-Key`, but a mismatch on audio
@@ -119,8 +121,9 @@ Query parameters:
 - `limit` optional
 - `q` optional: search query text
 - `search_mode` optional when `q` is present: one of `keyword`, `semantic`,
-  `hybrid`
-- `tag_id` optional and repeatable
+  `hybrid`; defaults to `hybrid` when omitted
+- `tag_id` optional and repeatable; repeated values combine by intersection
+  (`AND`)
 - `session_id` optional
 - `recorded_after` optional
 - `recorded_before` optional
@@ -144,12 +147,15 @@ Notes:
   `Transcript` resource shape, filters, and collection envelope. This is an
   explicit `v0.1.0` governance decision to avoid duplicating transcript
   collection surface with no semantic gain.
+- If `q` is present and `search_mode` is omitted, the backend uses `hybrid`.
 - Search results are always transcript resources.
 - Keyword search may match current transcript text and historical
   `TranscriptVersion` text, but the returned item is always the parent
   `Transcript`.
 - Semantic and hybrid search use the current embedding. After a transcript
   text edit, semantic freshness is eventual rather than immediate.
+- Repeated `tag_id` filters combine by intersection: a transcript matches only
+  if it is associated with all supplied tags.
 - Failed jobs and in-flight jobs are not listed.
 
 Response body is a transcript collection envelope whose `items` are
@@ -275,10 +281,7 @@ Request body:
 
 ```json
 {
-  "tag_ids": [
-    "01JS9P0Q0THR2X3E4A5B6C7D8E",
-    "01JS9P0R6CK9M0N1P2Q3R4S5T6"
-  ]
+  "tag_ids": ["01JS9P0Q0THR2X3E4A5B6C7D8E", "01JS9P0R6CK9M0N1P2Q3R4S5T6"]
 }
 ```
 
@@ -480,6 +483,8 @@ Notes:
 
 - Deleting a session preserves contained transcripts and sets their
   `session_id` to `null`.
+- Deleting a session does not invalidate previously accepted replay records
+  whose stored submission tuple referenced that session.
 
 ### GET `/api/v1/sessions/{session_id}/transcripts`
 
@@ -491,8 +496,9 @@ Query parameters:
 - `limit` optional
 - `q` optional
 - `search_mode` optional when `q` is present: one of `keyword`, `semantic`,
-  `hybrid`
-- `tag_id` optional and repeatable
+  `hybrid`; defaults to `hybrid` when omitted
+- `tag_id` optional and repeatable; repeated values combine by intersection
+  (`AND`)
 - `recorded_after` optional
 - `recorded_before` optional
 - `created_after` optional
@@ -509,6 +515,9 @@ Notes:
 
 - This endpoint applies the same collection semantics as `GET /api/v1/transcripts`
   but with the session scope fixed by the path.
+- If `q` is present and `search_mode` is omitted, the backend uses `hybrid`.
+- Repeated `tag_id` filters combine by intersection: a transcript matches only
+  if it is associated with all supplied tags.
 
 Response body is a transcript collection envelope whose `items` are
 `Transcript` resources.
@@ -678,12 +687,17 @@ Fields:
 ## Idempotency Rules
 
 - The backend matches a replay by `API key + Idempotency-Key + accepted audio
-  content hash + recorded_at + session_id + language`.
+content hash + recorded_at + session_id + language`.
+- The accepted submission tuple is an immutable acceptance-time record, not a
+  live reference to current resource state.
 - Omitted optional `session_id` and `language` values participate as `null`.
 - Same API key + same `Idempotency-Key` + same accepted submission tuple
   returns the same `TranscriptionJob`.
 - Same API key + same `Idempotency-Key` + a mismatch on any accepted
   submission dimension returns `409 Conflict`.
+- If the session referenced by an accepted `session_id` is later deleted,
+  idempotent replays still return the original `TranscriptionJob` matched by
+  the stored accepted tuple.
 - If the transcript created by a succeeded job is later deleted, idempotent
   replays still return the original succeeded `TranscriptionJob` with
   `transcript_id=null`.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -9,7 +9,49 @@ long-poll versus short-poll behavior are deferred to a later revision.
 ## Authentication
 
 - All endpoints below require `Authorization: Bearer <api_key>`.
+- API keys are provisioned out-of-band by the operator.
 - Idempotency is scoped per authenticated API key.
+- Every resource lookup is scoped to the authenticated API key.
+- `v0.1.0` exposes no public endpoint for API-key creation, rotation,
+  revocation, or deletion.
+
+## Shared Conventions
+
+- Timestamps use RFC 3339 UTC strings.
+- Resource IDs are opaque strings.
+- Collection endpoints return the same envelope shape:
+
+```json
+{
+  "items": [],
+  "next_cursor": null
+}
+```
+
+- `next_cursor` is `null` when no additional page exists.
+- `limit` defaults to `50` and must not exceed `100`.
+- All `4xx` and `5xx` responses use the same `ErrorResponse` envelope.
+
+### `ErrorResponse`
+
+```json
+{
+  "error_code": "validation_error",
+  "message": "One or more request fields are invalid.",
+  "details": [
+    {
+      "field": "language",
+      "message": "Must be a valid ISO 639-1 code."
+    }
+  ]
+}
+```
+
+Fields:
+
+- `error_code`: stable machine-readable error identifier
+- `message`: human-readable summary
+- `details`: optional structured context for validation or conflict errors
 
 ## Endpoint Inventory
 
@@ -22,9 +64,20 @@ Request:
 - Content type: `multipart/form-data`
 - Fields:
   - `file` required: uploaded audio file
-  - `language` optional: language hint
+  - `recorded_at` required: RFC 3339 UTC timestamp describing when the audio
+    was recorded
+  - `session_id` optional: existing session identifier owned by the
+    authenticated API key
+  - `language` optional: ISO 639-1 language hint
 - Headers:
   - `Idempotency-Key` required
+
+Validation:
+
+- Accepted file formats are `m4a`, `mp3`, `wav`, and `webm`.
+- Maximum upload size is `25 MiB`.
+- `language`, when present, constrains transcription to the supplied language.
+  The backend does not auto-detect language for that submission.
 
 Responses:
 
@@ -33,6 +86,8 @@ Responses:
 - `200 OK`: replay of an existing terminal job
 - `400 Bad Request`: invalid idempotency header or invalid request fields
 - `401 Unauthorized`: missing or invalid API key
+- `404 Not Found`: supplied `session_id` does not exist for the authenticated
+  API key
 - `413 Payload Too Large`: file exceeds allowed size
 - `415 Unsupported Media Type`: unsupported audio format
 - `409 Conflict`: same API key and `Idempotency-Key`, but different audio
@@ -57,15 +112,47 @@ Response body is a `TranscriptionJob` resource.
 
 List completed transcripts for the authenticated API key.
 
+Query parameters:
+
+- `cursor` optional
+- `limit` optional
+- `q` optional: search query text
+- `search_mode` optional when `q` is present: one of `keyword`, `semantic`,
+  `hybrid`
+- `tag_id` optional and repeatable
+- `session_id` optional
+- `recorded_after` optional
+- `recorded_before` optional
+- `created_after` optional
+- `created_before` optional
+
 Responses:
 
 - `200 OK`
+- `400 Bad Request`: invalid query parameter values, or `search_mode` supplied
+  without `q`
 - `401 Unauthorized`
 
 Notes:
 
-- Only completed transcripts appear here.
+- This endpoint is the unified transcript collection for both history and
+  search.
+- Without `q`, the endpoint returns transcript history ordered newest-first by
+  transcript `created_at`.
+- With `q`, the endpoint returns transcript search results using the same
+  `Transcript` resource shape, filters, and collection envelope. This is an
+  explicit `v0.1.0` governance decision to avoid duplicating transcript
+  collection surface with no semantic gain.
+- Search results are always transcript resources.
+- Keyword search may match current transcript text and historical
+  `TranscriptVersion` text, but the returned item is always the parent
+  `Transcript`.
+- Semantic and hybrid search use the current embedding. After a transcript
+  text edit, semantic freshness is eventual rather than immediate.
 - Failed jobs and in-flight jobs are not listed.
+
+Response body is a transcript collection envelope whose `items` are
+`Transcript` resources.
 
 ### GET `/api/v1/transcripts/{transcript_id}`
 
@@ -82,6 +169,346 @@ Notes:
 - Only completed transcripts are addressable here.
 - A job ID is never valid on this endpoint.
 
+Response body is a `Transcript` resource.
+
+### PATCH `/api/v1/transcripts/{transcript_id}`
+
+Replace the current transcript text.
+
+Request body:
+
+```json
+{
+  "transcript": "Updated transcript text."
+}
+```
+
+Responses:
+
+- `200 OK`
+- `400 Bad Request`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Notes:
+
+- The request changes transcript text only.
+- A successful edit creates one new `TranscriptVersion` and moves
+  `Transcript.current_version_id` to the new version.
+- Prior versions remain available through the version-history endpoint.
+- Segment timing remains unchanged by text edits.
+- Embedding regeneration is asynchronous. Full-text reads return the edited
+  text immediately; semantic and hybrid search may lag until regeneration
+  completes.
+
+Response body is the updated `Transcript` resource.
+
+### DELETE `/api/v1/transcripts/{transcript_id}`
+
+Hard-delete a transcript.
+
+Responses:
+
+- `204 No Content`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Notes:
+
+- Deletion cascades to transcript versions, segments, the current embedding,
+  tag associations, and the originating transcription job.
+
+### GET `/api/v1/transcripts/{transcript_id}/versions`
+
+List transcript versions for one transcript.
+
+Query parameters:
+
+- `cursor` optional
+- `limit` optional
+
+Responses:
+
+- `200 OK`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Notes:
+
+- Versions are returned newest-first by `created_at`.
+- Version history is linear and append-only.
+
+Response body is a collection envelope whose `items` are
+`TranscriptVersion` resources.
+
+### GET `/api/v1/transcripts/{transcript_id}/segments`
+
+List timing segments for one transcript.
+
+Query parameters:
+
+- `cursor` optional
+- `limit` optional
+
+Responses:
+
+- `200 OK`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Notes:
+
+- Segments are returned in ascending `position` order.
+- Segment content is stable across transcript text edits.
+
+Response body is a collection envelope whose `items` are `Segment` resources.
+
+### PUT `/api/v1/transcripts/{transcript_id}/tags`
+
+Replace the transcript's entire tag set.
+
+Request body:
+
+```json
+{
+  "tag_ids": [
+    "01JS9P0Q0THR2X3E4A5B6C7D8E",
+    "01JS9P0R6CK9M0N1P2Q3R4S5T6"
+  ]
+}
+```
+
+Responses:
+
+- `200 OK`
+- `400 Bad Request`
+- `401 Unauthorized`
+- `404 Not Found`: transcript or one or more referenced tags not found for the
+  authenticated API key
+
+Notes:
+
+- `PUT` replaces the transcript's entire tag set. The request body is the full
+  desired set.
+- Duplicate `tag_ids` are invalid.
+- Replacing tags does not create a new `TranscriptVersion`.
+
+Response body is the updated `Transcript` resource.
+
+### GET `/api/v1/tags`
+
+List tags for the authenticated API key.
+
+Query parameters:
+
+- `cursor` optional
+- `limit` optional
+
+Responses:
+
+- `200 OK`
+- `401 Unauthorized`
+
+Response body is a collection envelope whose `items` are `Tag` resources.
+
+### POST `/api/v1/tags`
+
+Create a tag, or return the existing tag with the same case-insensitive name.
+
+Request body:
+
+```json
+{
+  "name": "Meeting"
+}
+```
+
+Responses:
+
+- `201 Created`: new tag created
+- `200 OK`: a tag with the same case-insensitive name already exists for the
+  authenticated API key
+- `400 Bad Request`
+- `401 Unauthorized`
+
+Notes:
+
+- Tag identity is case-insensitive within one API-key scope.
+- The returned `Tag.name` preserves the stored spelling.
+
+Response body is a `Tag` resource.
+
+### GET `/api/v1/tags/{tag_id}`
+
+Fetch one tag.
+
+Responses:
+
+- `200 OK`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Response body is a `Tag` resource.
+
+### PATCH `/api/v1/tags/{tag_id}`
+
+Rename a tag.
+
+Request body:
+
+```json
+{
+  "name": "Planning"
+}
+```
+
+Responses:
+
+- `200 OK`
+- `400 Bad Request`
+- `401 Unauthorized`
+- `404 Not Found`
+- `409 Conflict`: another tag with the same case-insensitive name already
+  exists for the authenticated API key
+
+Notes:
+
+- A successful rename updates the visible tag name on every transcript
+  associated with that tag.
+
+Response body is the updated `Tag` resource.
+
+### DELETE `/api/v1/tags/{tag_id}`
+
+Delete a tag.
+
+Responses:
+
+- `204 No Content`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Notes:
+
+- Deleting a tag removes its transcript associations but does not delete any
+  transcript.
+
+### GET `/api/v1/sessions`
+
+List sessions for the authenticated API key.
+
+Query parameters:
+
+- `cursor` optional
+- `limit` optional
+
+Responses:
+
+- `200 OK`
+- `401 Unauthorized`
+
+Response body is a collection envelope whose `items` are `Session` resources.
+
+### POST `/api/v1/sessions`
+
+Create a session.
+
+Request body:
+
+```json
+{
+  "name": "Q2 Planning"
+}
+```
+
+Responses:
+
+- `201 Created`
+- `400 Bad Request`
+- `401 Unauthorized`
+
+Response body is a `Session` resource.
+
+### GET `/api/v1/sessions/{session_id}`
+
+Fetch one session.
+
+Responses:
+
+- `200 OK`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Response body is a `Session` resource.
+
+### PATCH `/api/v1/sessions/{session_id}`
+
+Rename a session.
+
+Request body:
+
+```json
+{
+  "name": "Customer Interviews"
+}
+```
+
+Responses:
+
+- `200 OK`
+- `400 Bad Request`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Response body is the updated `Session` resource.
+
+### DELETE `/api/v1/sessions/{session_id}`
+
+Delete a session.
+
+Responses:
+
+- `204 No Content`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Notes:
+
+- Deleting a session preserves contained transcripts and sets their
+  `session_id` to `null`.
+
+### GET `/api/v1/sessions/{session_id}/transcripts`
+
+List completed transcripts that belong to one session.
+
+Query parameters:
+
+- `cursor` optional
+- `limit` optional
+- `q` optional
+- `search_mode` optional when `q` is present: one of `keyword`, `semantic`,
+  `hybrid`
+- `tag_id` optional and repeatable
+- `recorded_after` optional
+- `recorded_before` optional
+- `created_after` optional
+- `created_before` optional
+
+Responses:
+
+- `200 OK`
+- `400 Bad Request`
+- `401 Unauthorized`
+- `404 Not Found`
+
+Notes:
+
+- This endpoint applies the same collection semantics as `GET /api/v1/transcripts`
+  but with the session scope fixed by the path.
+
+Response body is a transcript collection envelope whose `items` are
+`Transcript` resources.
+
 ## Resource Schemas
 
 ### `TranscriptionJob`
@@ -96,7 +523,7 @@ Notes:
   "max_retries": 3,
   "next_attempt_at": "2026-04-21T18:32:12Z",
   "failure_code": "engine_timeout",
-  "failure_message": "The transcription engine timed out while processing audio.",
+  "failure_message": "The transcription attempt timed out while processing audio.",
   "retryable_by_client": true,
   "transcript_id": null
 }
@@ -126,39 +553,121 @@ Semantics:
   client uses them for UX and polling suppression.
 - The same `TranscriptionJob` resource is returned for idempotent replays.
 
+### `Tag`
+
+```json
+{
+  "id": "01JS9P0Q0THR2X3E4A5B6C7D8E",
+  "name": "Meeting",
+  "created_at": "2026-04-21T18:31:30Z"
+}
+```
+
+Fields:
+
+- `id`: tag identifier
+- `name`: tag name, unique case-insensitively within one API-key scope
+- `created_at`: tag creation timestamp
+
+### `Session`
+
+```json
+{
+  "id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
+  "name": "Q2 Planning",
+  "created_at": "2026-04-21T18:31:35Z"
+}
+```
+
+Fields:
+
+- `id`: session identifier
+- `name`: session display name
+- `created_at`: session creation timestamp
+
 ### `Transcript`
 
 ```json
 {
   "id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
+  "current_version_id": "01JS9P1D6CK9M0N1P2Q3R4S5T6",
   "transcript": "Hello, this is a test recording.",
   "audio_duration_seconds": 12.5,
   "audio_format": "wav",
   "audio_size_bytes": 401280,
   "transcript_language": "en",
-  "model": "gpt-4o-transcribe",
+  "model": "general-transcription-v1",
   "processing_time_ms": 1843,
   "cost_cents": 1,
-  "created_at": "2026-04-21T18:31:19Z"
+  "created_at": "2026-04-21T18:31:19Z",
+  "recorded_at": "2026-04-21T18:29:55Z",
+  "session_id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
+  "tags": [
+    {
+      "id": "01JS9P0Q0THR2X3E4A5B6C7D8E",
+      "name": "Meeting",
+      "created_at": "2026-04-21T18:31:30Z"
+    }
+  ]
 }
 ```
 
 Fields:
 
 - `id`: transcript identifier
-- `transcript`: transcribed text
+- `current_version_id`: identifier of the current transcript version
+- `transcript`: current transcript text
 - `audio_duration_seconds`: source audio duration
 - `audio_format`: accepted audio format
 - `audio_size_bytes`: original uploaded size
 - `transcript_language`: detected or hinted language
-- `model`: the transcription engine/model used to produce this transcript
+- `model`: transcription engine identifier
 - `processing_time_ms`: total server-side processing time
-- `cost_cents`: the backend's cost estimate for producing this transcript, in
-  cents. Populated when the backend can compute it from engine-provided data
-  using straightforward fixed-rate pricing (for example, audio duration times a
-  fixed per-minute rate). `null` when the cost cannot be determined without
-  dynamic pricing infrastructure.
+- `cost_cents`: backend cost estimate in cents; always present and nullable
 - `created_at`: transcript creation timestamp
+- `recorded_at`: client-supplied audio capture timestamp
+- `session_id`: associated session identifier, or `null`
+- `tags`: associated `Tag` resources
+
+### `TranscriptVersion`
+
+```json
+{
+  "id": "01JS9P1D6CK9M0N1P2Q3R4S5T6",
+  "transcript_id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
+  "transcript": "Hello, this is a test recording.",
+  "created_at": "2026-04-21T18:31:19Z"
+}
+```
+
+Fields:
+
+- `id`: transcript-version identifier
+- `transcript_id`: parent transcript identifier
+- `transcript`: transcript text captured in this version
+- `created_at`: version creation timestamp
+
+### `Segment`
+
+```json
+{
+  "id": "01JS9P1K2AQ3B4C5D6E7F8G9H0",
+  "transcript_id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
+  "position": 0,
+  "start_ms": 0,
+  "end_ms": 1480,
+  "text": "Hello, this is a test recording."
+}
+```
+
+Fields:
+
+- `id`: segment identifier
+- `transcript_id`: parent transcript identifier
+- `position`: zero-based segment order
+- `start_ms`: segment start offset in milliseconds
+- `end_ms`: segment end offset in milliseconds
+- `text`: segment text captured from the transcription result
 
 ## Idempotency Rules
 
@@ -176,5 +685,9 @@ Fields:
 - This contract intentionally omits a synchronous transcript-returning upload
   endpoint.
 - This contract intentionally omits `prompt` from `v0.1.0`.
+- This contract intentionally omits public API-key management endpoints.
+- Speaker diarization, branching edit history, transcript-to-session
+  reassignment after submission, and embedding export are deferred beyond
+  `v0.1.0`.
 - Polling cadence, rate limits, and backoff advice are deferred to a later API
   contract revision.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -316,6 +316,11 @@ Responses:
 - `200 OK`
 - `401 Unauthorized`
 
+Notes:
+
+- Tags are returned newest-first by `created_at`, with descending `id` as the
+  deterministic tiebreaker for cursor pagination.
+
 Response body is a collection envelope whose `items` are `Tag` resources.
 
 ### POST `/api/v1/tags`
@@ -413,6 +418,11 @@ Responses:
 
 - `200 OK`
 - `401 Unauthorized`
+
+Notes:
+
+- Sessions are returned newest-first by `created_at`, with descending `id` as
+  the deterministic tiebreaker for cursor pagination.
 
 Response body is a collection envelope whose `items` are `Session` resources.
 
@@ -690,6 +700,9 @@ Fields:
 content hash + recorded_at + session_id + language`.
 - The accepted submission tuple is an immutable acceptance-time record, not a
   live reference to current resource state.
+- For `recorded_at`, replay matching compares the parsed instant normalized to
+  UTC, not the raw wire-format string. Any RFC 3339 UTC representation of the
+  same instant is a match.
 - Omitted optional `session_id` and `language` values participate as `null`.
 - Same API key + same `Idempotency-Key` + same accepted submission tuple
   returns the same `TranscriptionJob`.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -90,8 +90,9 @@ Responses:
   API key
 - `413 Payload Too Large`: file exceeds allowed size
 - `415 Unsupported Media Type`: unsupported audio format
-- `409 Conflict`: same API key and `Idempotency-Key`, but different audio
-  content than the accepted submission
+- `409 Conflict`: same API key and `Idempotency-Key`, but a mismatch on audio
+  content, `recorded_at`, `session_id`, or `language` relative to the accepted
+  submission
 - `5xx`: synchronous failure before durable acceptance
 
 Response body for `200` and `202` is a `TranscriptionJob` resource.
@@ -216,7 +217,10 @@ Responses:
 Notes:
 
 - Deletion cascades to transcript versions, segments, the current embedding,
-  tag associations, and the originating transcription job.
+  and tag associations.
+- The originating succeeded `TranscriptionJob` survives as the durable replay
+  record for the accepted submission attempt, and its `transcript_id` becomes
+  `null`.
 
 ### GET `/api/v1/transcripts/{transcript_id}/versions`
 
@@ -545,7 +549,9 @@ Fields:
 - `failure_message`: human-readable explanation aligned with `failure_code`
 - `retryable_by_client`: whether a terminal failed job should be retried by
   creating a fresh submission with a new `Idempotency-Key`
-- `transcript_id`: present when `status=succeeded`
+- `transcript_id`: present when `status=succeeded` and the transcript is still
+  addressable; `null` for non-succeeded jobs and for succeeded jobs whose
+  transcript has been deleted
 
 Semantics:
 
@@ -672,11 +678,15 @@ Fields:
 ## Idempotency Rules
 
 - The backend matches a replay by `API key + Idempotency-Key + accepted audio
-  content hash`.
-- Same API key + same `Idempotency-Key` + same audio content returns the same
-  `TranscriptionJob`.
-- Same API key + same `Idempotency-Key` + different audio content returns
-  `409 Conflict`.
+  content hash + recorded_at + session_id + language`.
+- Omitted optional `session_id` and `language` values participate as `null`.
+- Same API key + same `Idempotency-Key` + same accepted submission tuple
+  returns the same `TranscriptionJob`.
+- Same API key + same `Idempotency-Key` + a mismatch on any accepted
+  submission dimension returns `409 Conflict`.
+- If the transcript created by a succeeded job is later deleted, idempotent
+  replays still return the original succeeded `TranscriptionJob` with
+  `transcript_id=null`.
 - A new submission attempt after terminal failure must use a new
   `Idempotency-Key`.
 

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -240,12 +240,14 @@ Query parameters:
 Responses:
 
 - `200 OK`
+- `400 Bad Request`: malformed `cursor` or `limit` outside `1..100`
 - `401 Unauthorized`
 - `404 Not Found`
 
 Notes:
 
-- Versions are returned newest-first by `created_at`.
+- Versions are returned newest-first by `created_at`, with descending `id` as
+  the deterministic tiebreaker for cursor pagination.
 - Version history is linear and append-only.
 
 Response body is a collection envelope whose `items` are
@@ -263,6 +265,7 @@ Query parameters:
 Responses:
 
 - `200 OK`
+- `400 Bad Request`: malformed `cursor` or `limit` outside `1..100`
 - `401 Unauthorized`
 - `404 Not Found`
 
@@ -314,6 +317,7 @@ Query parameters:
 Responses:
 
 - `200 OK`
+- `400 Bad Request`: malformed `cursor` or `limit` outside `1..100`
 - `401 Unauthorized`
 
 Notes:
@@ -417,6 +421,7 @@ Query parameters:
 Responses:
 
 - `200 OK`
+- `400 Bad Request`: malformed `cursor` or `limit` outside `1..100`
 - `401 Unauthorized`
 
 Notes:

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -125,10 +125,10 @@ Query parameters:
 - `tag_id` optional and repeatable; repeated values combine by intersection
   (`AND`)
 - `session_id` optional
-- `recorded_after` optional
-- `recorded_before` optional
-- `created_after` optional
-- `created_before` optional
+- `recorded_after` optional: exclusive lower bound on `recorded_at`
+- `recorded_before` optional: inclusive upper bound on `recorded_at`
+- `created_after` optional: exclusive lower bound on `created_at`
+- `created_before` optional: inclusive upper bound on `created_at`
 
 Responses:
 
@@ -142,7 +142,8 @@ Notes:
 - This endpoint is the unified transcript collection for both history and
   search.
 - Without `q`, the endpoint returns transcript history ordered newest-first by
-  transcript `created_at`.
+  transcript `created_at`, with descending `id` as the deterministic
+  tiebreaker for cursor pagination.
 - With `q`, the endpoint returns transcript search results using the same
   `Transcript` resource shape, filters, and collection envelope. This is an
   explicit `v0.1.0` governance decision to avoid duplicating transcript
@@ -154,6 +155,9 @@ Notes:
   `Transcript`.
 - Semantic and hybrid search use the current embedding. After a transcript
   text edit, semantic freshness is eventual rather than immediate.
+- Search results are ordered by backend relevance score descending, then by
+  transcript `created_at` descending, then by descending `id` as the final
+  deterministic tiebreaker for cursor pagination.
 - Repeated `tag_id` filters combine by intersection: a transcript matches only
   if it is associated with all supplied tags.
 - Failed jobs and in-flight jobs are not listed.
@@ -529,7 +533,8 @@ Responses:
 Notes:
 
 - This endpoint applies the same collection semantics as `GET /api/v1/transcripts`
-  but with the session scope fixed by the path.
+  but with the session scope fixed by the path, including the same ordering
+  and time-bound semantics.
 - If `q` is present and `search_mode` is omitted, the backend uses `hybrid`.
 - Repeated `tag_id` filters combine by intersection: a transcript matches only
   if it is associated with all supplied tags.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -95,10 +95,12 @@ embeddings, free-text tags, optional sessions, and transcript search.
 #### Idempotency
 
 - One submission attempt is identified by `API key + Idempotency-Key +
-  accepted audio content hash + recorded_at + session_id + language`.
+accepted audio content hash + recorded_at + session_id + language`.
 - The backend computes and stores the accepted audio content hash and the
   accepted `recorded_at`, `session_id`, and `language` values at acceptance
   time.
+- The accepted submission tuple is an immutable acceptance-time record, not a
+  live reference to current resource state.
 - Omitted optional `session_id` and `language` values participate in
   idempotency as `null`.
 - Reusing the same API key and `Idempotency-Key` with the same accepted
@@ -106,6 +108,8 @@ embeddings, free-text tags, optional sessions, and transcript search.
 - Reusing the same API key and `Idempotency-Key` with a mismatch on any
   accepted submission dimension is a client conflict and must return
   `409 Conflict`.
+- Deletion of a session referenced by an accepted `session_id` does not mutate
+  the stored tuple or invalidate replay of that accepted submission attempt.
 - One `Idempotency-Key` names one attempt forever. Reusing it after terminal
   failure returns the same failed job. An intentional fresh attempt requires a
   new key.
@@ -266,8 +270,12 @@ Semantics:
 - Semantic search uses the current transcript embedding.
 - Hybrid search combines keyword and semantic ranking over the same transcript
   result set.
+- When `q` is present and `search_mode` is omitted, the backend defaults to
+  `hybrid`.
 - Search filters support tag, session, `recorded_at` time range, and
   `created_at` time range.
+- Repeated `tag_id` filters combine by intersection: a transcript matches only
+  if it is associated with all supplied tags.
 - Transcript history is ordered newest-first by transcript `created_at`.
 - Search results are ordered by backend relevance, with newest transcript
   `created_at` as the tiebreaker.
@@ -299,6 +307,8 @@ Semantics:
   `succeeded` and its `transcript_id` becomes `null`.
 - Deleting a session sets `session_id` to `null` on contained transcripts. The
   transcripts remain otherwise unchanged.
+- Deleting a session does not invalidate replay records for submissions that
+  were accepted with that `session_id`.
 - Deleting a tag removes its transcript associations. The transcripts remain
   otherwise unchanged.
 - The backend retains accepted audio only while a job is `queued`,
@@ -347,8 +357,9 @@ true:
   segments are first-class timing rows; embeddings are stored server-side and
   regenerated asynchronously after text edits.
 - Search behavior is explicit: history and search share one transcript
-  collection contract, results are transcript-only, and semantic search is
-  eventually consistent after edits.
+  collection contract, omitted `search_mode` with `q` defaults to `hybrid`,
+  repeated `tag_id` filters intersect, results are transcript-only, and
+  semantic search is eventually consistent after edits.
 - Deletion semantics are explicit and match resource ownership expectations.
 - Supported audio formats, maximum upload size, language-hint semantics,
   pagination shape, and error-envelope semantics are named concretely.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -180,7 +180,8 @@ Semantics:
 - Job claim order is FIFO by readiness: first by retry eligibility, then by
   acceptance time.
 - Completion order is not guaranteed and is not exposed as a contract.
-- Transcript history is ordered newest-first by transcript `created_at`.
+- Transcript history is ordered newest-first by transcript `created_at`, with
+  descending `id` as the deterministic tiebreaker.
 
 ### Data Substrate
 
@@ -276,18 +277,21 @@ Semantics:
 - When `q` is present and `search_mode` is omitted, the backend defaults to
   `hybrid`.
 - Search filters support tag, session, `recorded_at` time range, and
-  `created_at` time range.
+  `created_at` time range. `*_after` bounds are exclusive; `*_before` bounds
+  are inclusive.
 - Repeated `tag_id` filters combine by intersection: a transcript matches only
   if it is associated with all supplied tags.
-- Transcript history is ordered newest-first by transcript `created_at`.
+- Transcript history is ordered newest-first by transcript `created_at`, with
+  descending `id` as the deterministic tiebreaker.
 - Version-history listings are ordered newest-first by `created_at`, with
   descending `id` as the deterministic tiebreaker.
 - Tag listings are ordered newest-first by `created_at`, with descending `id`
   as the deterministic tiebreaker.
 - Session listings are ordered newest-first by `created_at`, with descending
   `id` as the deterministic tiebreaker.
-- Search results are ordered by backend relevance, with newest transcript
-  `created_at` as the tiebreaker.
+- Search results are ordered by backend relevance score descending, then by
+  transcript `created_at` descending, then by descending `id` as the final
+  deterministic tiebreaker.
 - Transcript collection pagination is cursor-based. The default page size is
   `50`; the maximum page size is `100`.
 - Transcript, session, tag, version-history, and segment listings use the same

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -2,44 +2,57 @@
 
 Target release: `v0.1.0`
 
-## Transcription Pipeline
-
-### Capability
+## Capability
 
 The backend accepts authenticated audio submissions, creates durable
 transcription jobs, drives those jobs to a terminal state without requiring
-client resubmission, and materializes successful jobs as searchable transcript
-records. The public workflow is asynchronous: submission creates a job
-resource, polling observes that job's progress, and transcript history/detail
-surfaces only completed transcripts.
+client resubmission, and materializes successful jobs as long-lived transcript
+records. Completed transcripts carry the data substrate required for `v0.1.0`:
+current text, linear edit history, timestamped segments, server-side
+embeddings, free-text tags, optional sessions, and transcript search.
 
-### Constraints
+## Constraints
+
+### Authentication and Ownership
+
+- `v0.1.0` is a single-user testbed authenticated by operator-provisioned API
+  keys.
+- No public endpoint creates, rotates, revokes, or deletes API keys in
+  `v0.1.0`.
+- Every public resource is scoped to the authenticated API key. A key can only
+  read or mutate its own jobs, transcripts, tags, and sessions.
+- Idempotency isolation is per API key. Different API keys may reuse the same
+  `Idempotency-Key` without colliding.
+- Tag name identity is case-insensitive within one API-key scope. Session
+  identity is by session ID, not by session name.
+
+### Transcription Pipeline
 
 #### Resource Model
 
 - A submission creates a `TranscriptionJob`, not a transcript placeholder.
 - A successful job creates exactly one `Transcript`.
 - Failed and in-flight jobs do not appear in transcript history, transcript
-  detail, or search results.
+  detail, session transcript listings, or search results.
 - Transcript resources are long-lived user artifacts. Job resources are
   workflow artifacts that may point to a transcript once complete.
 
 #### Cost Attribution
 
-- The transcript resource includes a `cost_cents` field recording the
+- The `Transcript` resource includes a `cost_cents` field recording the
   backend's estimated cost to produce the transcript. The field is present on
   every transcript resource; its value is nullable.
-- When the backend can compute cost from engine-provided data using
-  fixed-rate pricing, `cost_cents` carries a numeric estimate.
+- When the backend can compute cost from engine-provided data using fixed-rate
+  pricing, `cost_cents` carries a numeric estimate.
 - `cost_cents` is `null` when the cost cannot be determined without dynamic
   pricing infrastructure.
 
 #### Durable Acceptance
 
 - `202 Accepted` is a durability commitment, not an admission of best effort.
-- A request may return `202` only after the backend has durably persisted:
-  the job record, the accepted audio payload, and the accepted audio content
-  hash used for idempotency matching.
+- A request may return `202` only after the backend has durably persisted the
+  job record, the accepted audio payload, and the accepted audio content hash
+  used for idempotency matching.
 - If any persistence step fails, the request fails synchronously and no
   accepted job exists.
 - Accepted jobs must survive backend restart and continue progressing toward a
@@ -52,8 +65,8 @@ surfaces only completed transcripts.
   location for accepted audio and other job-associated durable artifacts.
 - This storage location is a required backend dependency, not an optional
   deployment optimization.
-- The backend must not advertise durable acceptance semantics when that
-  storage location is unavailable or not writable.
+- The backend must not advertise durable acceptance semantics when that storage
+  location is unavailable or not writable.
 - `spec/deployment.md` must later define the operator's persistent-storage
   responsibilities, including path provisioning, persistence across restart,
   and capacity implications.
@@ -62,19 +75,28 @@ surfaces only completed transcripts.
 
 - Every submission requires authentication by API key.
 - Every submission requires an `Idempotency-Key`, including web submissions.
-- The request body contains the uploaded audio file and may include an
-  optional language hint.
+- The request body contains the uploaded audio file, required `recorded_at`,
+  optional `session_id`, and optional `language`.
+- `recorded_at` is client-supplied and records when the audio was captured.
+- `language`, when present, is an ISO 639-1 language hint. It constrains the
+  transcription request to that language and disables engine-side
+  auto-detection for that submission.
+- `session_id`, when present, must identify an existing session owned by the
+  authenticated API key.
+- Supported upload formats are `m4a`, `mp3`, `wav`, and `webm`.
+- The maximum accepted upload size is `25 MiB`.
 - `prompt` is out of scope for `v0.1.0`.
 - Validation that can be performed before acceptance must remain synchronous:
   authentication, filename presence, supported format, file-size limit,
-  language syntax, and idempotency-header validity.
+  `recorded_at` syntax, session ownership, language syntax, and
+  idempotency-header validity.
 
 #### Idempotency
 
 - One submission attempt is identified by `API key + Idempotency-Key +
   accepted audio content hash`.
-- The backend computes and stores the accepted audio content hash at
-  acceptance time.
+- The backend computes and stores the accepted audio content hash at acceptance
+  time.
 - Reusing the same API key and `Idempotency-Key` with the same audio content
   returns the original job instead of creating duplicate work.
 - Reusing the same API key and `Idempotency-Key` with different audio content
@@ -82,8 +104,6 @@ surfaces only completed transcripts.
 - One `Idempotency-Key` names one attempt forever. Reusing it after terminal
   failure returns the same failed job. An intentional fresh attempt requires a
   new key.
-- Idempotency isolation is per API key. Different API keys may reuse the same
-  `Idempotency-Key` without colliding.
 
 #### Job State Machine
 
@@ -105,7 +125,8 @@ Permitted transitions:
 
 Constraints on transitions:
 
-- A job enters `succeeded` only after its transcript record is durably stored.
+- A job enters `succeeded` only after its transcript record, current
+  transcript version, segments, and current embedding have been durably stored.
 - A job enters `failed` only for a terminal classification or after exhausting
   backend-managed retries.
 - `processing` is leased work, not a terminal assumption. A crashed worker or
@@ -147,10 +168,130 @@ Semantics:
 - Job claim order is FIFO by readiness: first by retry eligibility, then by
   acceptance time.
 - Completion order is not guaranteed and is not exposed as a contract.
-- Transcript ordering for history is newest-first by transcript creation time.
+- Transcript history is ordered newest-first by transcript `created_at`.
 
-#### Retention
+### Data Substrate
 
+#### Transcript
+
+- The `Transcript` resource includes `id`, `current_version_id`, `transcript`,
+  `audio_duration_seconds`, `audio_format`, `audio_size_bytes`,
+  `transcript_language`, `model`, `processing_time_ms`, `cost_cents`,
+  `created_at`, `recorded_at`, `session_id`, and `tags`.
+- `transcript` is always the current transcript version's text.
+- `current_version_id` points to the latest `TranscriptVersion`.
+- `created_at` records when the transcript was first materialized from a
+  successful job.
+- `recorded_at` records when the client says the audio was captured.
+- `session_id` is nullable.
+- `tags` is an array of `Tag` resources owned by the authenticated API key.
+
+#### TranscriptVersion
+
+- The `TranscriptVersion` resource includes `id`, `transcript_id`,
+  `transcript`, and `created_at`.
+- Version history is linear and append-only. No branching or merging exists in
+  `v0.1.0`.
+- The initial transcription result becomes the first transcript version.
+- Each text edit creates one new `TranscriptVersion` and moves
+  `Transcript.current_version_id` to that new version.
+- Historical versions remain readable through the version-history endpoint.
+
+#### Segment
+
+- The `Segment` resource includes `id`, `transcript_id`, `position`,
+  `start_ms`, `end_ms`, and `text`.
+- Segments are stored as first-class rows joined to the transcript, not as a
+  blob embedded in transcript text.
+- Segment ordering is ascending by `position`.
+- Segments represent engine-ground-truth timing. They are not user-editable in
+  `v0.1.0`.
+- Segments remain anchored to the transcript across transcript text edits.
+- Speaker diarization is out of scope. No `speaker_label` field exists in
+  `v0.1.0`.
+
+#### Tag
+
+- The `Tag` resource includes `id`, `name`, and `created_at`.
+- Tags are free-text and many-to-many with transcripts.
+- Tag identity is case-insensitive within one API-key scope.
+- The stored `name` preserves the spelling of the latest create or rename
+  request that established the current tag value.
+- Creating a tag with a case-insensitive name that already exists for the
+  authenticated API key returns the existing `Tag` instead of creating a
+  duplicate.
+- Renaming a tag updates the visible name on every associated transcript
+  immediately because associations are by `tag_id`, not copied text.
+
+#### Session
+
+- The `Session` resource includes `id`, `name`, and `created_at`.
+- Sessions are optional groupings for related recordings.
+- A transcript may belong to at most one session in `v0.1.0`.
+- `session_id=null` is valid and means the transcript is ungrouped.
+- Session identity is by ID. Session names are not required to be unique.
+
+#### Embeddings
+
+- The backend stores one current embedding per transcript.
+- The first embedding is generated when a successful transcription job creates
+  the transcript.
+- A text edit triggers asynchronous regeneration of the transcript's current
+  embedding.
+- Full-text reads reflect the new transcript text immediately after the edit is
+  committed.
+- Semantic and hybrid search may return stale matches until embedding
+  regeneration completes.
+- Embeddings are not exposed on the default transcript resource and no public
+  endpoint returns embedding vectors in `v0.1.0`.
+
+### Search and Retrieval
+
+- Transcript history and transcript search share one collection contract:
+  `GET /api/v1/transcripts`.
+- Without `q`, the collection is transcript history with optional filters.
+- With `q`, the collection is transcript search with the same result shape,
+  filters, and pagination. This is an explicit `v0.1.0` governance decision to
+  avoid duplicating transcript-collection surface with no semantic gain.
+- Search results are always `Transcript` resources. Jobs, sessions, tags,
+  versions, and segments are not returned as search hits.
+- Keyword search supports full-text matching over current transcript text and
+  may additionally match historical transcript-version text, but results always
+  resolve to the parent `Transcript`.
+- Semantic search uses the current transcript embedding.
+- Hybrid search combines keyword and semantic ranking over the same transcript
+  result set.
+- Search filters support tag, session, `recorded_at` time range, and
+  `created_at` time range.
+- Transcript history is ordered newest-first by transcript `created_at`.
+- Search results are ordered by backend relevance, with newest transcript
+  `created_at` as the tiebreaker.
+- Transcript collection pagination is cursor-based. The default page size is
+  `50`; the maximum page size is `100`.
+- Transcript, session, tag, version-history, and segment listings use the same
+  collection envelope: `items` plus nullable `next_cursor`.
+
+### Mutation Semantics
+
+- `PATCH /api/v1/transcripts/{transcript_id}` changes transcript text only.
+- A transcript edit creates a new `TranscriptVersion`; it does not rewrite or
+  delete prior versions.
+- `PUT /api/v1/transcripts/{transcript_id}/tags` replaces the transcript's
+  entire tag set with the supplied `tag_ids`.
+- Replacing tags does not create a new `TranscriptVersion`.
+- Session membership is assigned only at transcription submission time in
+  `v0.1.0`. No later transcript-to-session reassignment endpoint exists.
+
+### Deletion and Retention
+
+- Transcript retention is indefinite until explicit transcript deletion.
+- Transcript deletion is a hard delete with no grace period.
+- Deleting a transcript cascades to its versions, segments, current embedding,
+  tag associations, and originating transcription job.
+- Deleting a session sets `session_id` to `null` on contained transcripts. The
+  transcripts remain otherwise unchanged.
+- Deleting a tag removes its transcript associations. The transcripts remain
+  otherwise unchanged.
 - The backend retains accepted audio only while a job is `queued`,
   `processing`, or `retry_waiting`.
 - Once a job reaches `succeeded` or `failed`, the backend must promptly delete
@@ -159,9 +300,20 @@ Semantics:
   job remains terminal while cleanup is retried internally and surfaced to
   operators through logs and metrics.
 
-### Acceptance
+### Error Contract
 
-The transcription pipeline is acceptable for `v0.1.0` when the following are
+- Every `4xx` and `5xx` response body is JSON with at least `error_code` and
+  `message`.
+- `details` is optional and carries structured validation or conflict context
+  when useful.
+- Validation errors use `details` to identify request fields that failed
+  validation.
+- Error response structure is shared across job, transcript, tag, and session
+  endpoints.
+
+## Acceptance
+
+The backend requirements are acceptable for `v0.1.0` when the following are
 true:
 
 - Valid submission returns a durable job resource instead of a blocking
@@ -176,5 +328,17 @@ true:
 - `retry_count` is always visible on the job resource, and `next_attempt_at`
   is visible during `retry_waiting`.
 - Successful jobs create one transcript each and only completed transcripts
-  appear in transcript history/detail/search.
-- Retained audio is not kept beyond terminal completion of the job.
+  appear in transcript history, detail, session transcript listings, and
+  search.
+- The transcript substrate is concrete: transcripts carry current text,
+  sessions, tags, and current version identity; versions are append-only;
+  segments are first-class timing rows; embeddings are stored server-side and
+  regenerated asynchronously after text edits.
+- Search behavior is explicit: history and search share one transcript
+  collection contract, results are transcript-only, and semantic search is
+  eventually consistent after edits.
+- Deletion semantics are explicit and match resource ownership expectations.
+- Supported audio formats, maximum upload size, language-hint semantics,
+  pagination shape, and error-envelope semantics are named concretely.
+- No vendor product names appear in contract shapes or response field names,
+  and no implementation substrate leaks into the backend requirements.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -51,8 +51,9 @@ embeddings, free-text tags, optional sessions, and transcript search.
 
 - `202 Accepted` is a durability commitment, not an admission of best effort.
 - A request may return `202` only after the backend has durably persisted the
-  job record, the accepted audio payload, and the accepted audio content hash
-  used for idempotency matching.
+  job record, the accepted audio payload, the accepted audio content hash, and
+  the accepted `recorded_at`, `session_id`, and `language` values used for
+  idempotency matching.
 - If any persistence step fails, the request fails synchronously and no
   accepted job exists.
 - Accepted jobs must survive backend restart and continue progressing toward a
@@ -94,13 +95,17 @@ embeddings, free-text tags, optional sessions, and transcript search.
 #### Idempotency
 
 - One submission attempt is identified by `API key + Idempotency-Key +
-  accepted audio content hash`.
-- The backend computes and stores the accepted audio content hash at acceptance
+  accepted audio content hash + recorded_at + session_id + language`.
+- The backend computes and stores the accepted audio content hash and the
+  accepted `recorded_at`, `session_id`, and `language` values at acceptance
   time.
-- Reusing the same API key and `Idempotency-Key` with the same audio content
-  returns the original job instead of creating duplicate work.
-- Reusing the same API key and `Idempotency-Key` with different audio content
-  is a client conflict and must return `409 Conflict`.
+- Omitted optional `session_id` and `language` values participate in
+  idempotency as `null`.
+- Reusing the same API key and `Idempotency-Key` with the same accepted
+  submission tuple returns the original job instead of creating duplicate work.
+- Reusing the same API key and `Idempotency-Key` with a mismatch on any
+  accepted submission dimension is a client conflict and must return
+  `409 Conflict`.
 - One `Idempotency-Key` names one attempt forever. Reusing it after terminal
   failure returns the same failed job. An intentional fresh attempt requires a
   new key.
@@ -287,7 +292,11 @@ Semantics:
 - Transcript retention is indefinite until explicit transcript deletion.
 - Transcript deletion is a hard delete with no grace period.
 - Deleting a transcript cascades to its versions, segments, current embedding,
-  tag associations, and originating transcription job.
+  and tag associations.
+- The originating `TranscriptionJob` survives transcript deletion as the durable
+  replay record for the accepted submission attempt.
+- If a deleted transcript came from a succeeded job, that job remains
+  `succeeded` and its `transcript_id` becomes `null`.
 - Deleting a session sets `session_id` to `null` on contained transcripts. The
   transcripts remain otherwise unchanged.
 - Deleting a tag removes its transcript associations. The transcripts remain
@@ -318,10 +327,11 @@ true:
 
 - Valid submission returns a durable job resource instead of a blocking
   transcript response.
-- Replaying a submission with the same API key, `Idempotency-Key`, and audio
-  content returns the same job in every state.
-- Reusing an accepted `Idempotency-Key` with different audio content returns
-  `409 Conflict` and leaves the original job unchanged.
+- Replaying a submission with the same API key, `Idempotency-Key`, and
+  accepted submission tuple returns the same job in every state.
+- Reusing an accepted `Idempotency-Key` with a mismatch on any accepted
+  submission dimension returns `409 Conflict` and leaves the original job
+  unchanged.
 - Accepted jobs survive backend restart and still reach a terminal state.
 - Backend-managed retries move transient failures through `retry_waiting`
   instead of forcing client resubmission.
@@ -330,6 +340,8 @@ true:
 - Successful jobs create one transcript each and only completed transcripts
   appear in transcript history, detail, session transcript listings, and
   search.
+- Deleting a transcript does not delete its originating job, and replay of the
+  same accepted submission tuple still returns that original job.
 - The transcript substrate is concrete: transcripts carry current text,
   sessions, tags, and current version identity; versions are append-only;
   segments are first-class timing rows; embeddings are stored server-side and

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -280,6 +280,8 @@ Semantics:
 - Repeated `tag_id` filters combine by intersection: a transcript matches only
   if it is associated with all supplied tags.
 - Transcript history is ordered newest-first by transcript `created_at`.
+- Version-history listings are ordered newest-first by `created_at`, with
+  descending `id` as the deterministic tiebreaker.
 - Tag listings are ordered newest-first by `created_at`, with descending `id`
   as the deterministic tiebreaker.
 - Session listings are ordered newest-first by `created_at`, with descending

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -101,6 +101,9 @@ accepted audio content hash + recorded_at + session_id + language`.
   time.
 - The accepted submission tuple is an immutable acceptance-time record, not a
   live reference to current resource state.
+- For `recorded_at`, replay matching compares the parsed instant normalized to
+  UTC, not the raw wire-format string. Any RFC 3339 UTC representation of the
+  same instant is a match.
 - Omitted optional `session_id` and `language` values participate in
   idempotency as `null`.
 - Reusing the same API key and `Idempotency-Key` with the same accepted
@@ -277,6 +280,10 @@ Semantics:
 - Repeated `tag_id` filters combine by intersection: a transcript matches only
   if it is associated with all supplied tags.
 - Transcript history is ordered newest-first by transcript `created_at`.
+- Tag listings are ordered newest-first by `created_at`, with descending `id`
+  as the deterministic tiebreaker.
+- Session listings are ordered newest-first by `created_at`, with descending
+  `id` as the deterministic tiebreaker.
 - Search results are ordered by backend relevance, with newest transcript
   `created_at` as the tiebreaker.
 - Transcript collection pagination is cursor-based. The default page size is


### PR DESCRIPTION
## Summary

- expand the v0.1.0 spec from a transcription-only slice to the full transcript substrate, covering versions, segments, tags, sessions, and search
- define the public HTTP contract for transcript editing, deletion, tag/session management, unified history/search collection semantics, and shared error envelopes
- record the spec-surface expansion in the changelog so the API-visible contract change is visible outside the diff

## Changes

- extend `spec/backend-requirements.md` with wave-1 auth/ownership rules, concrete submission defaults, transcript substrate semantics, search behavior, mutation rules, deletion cascades, and shared error semantics
- expand `spec/api-contract.md` with the new endpoint inventory, collection conventions, resource schemas, and explicit deferred items for out-of-scope behavior
- update `CHANGELOG.md` to note the v0.1.0 contract expansion

## GitHub Issue(s)

Closes #1

## Test plan

- `git diff --check`
- `rg -n "Whisper|OpenAI|gpt-|PostgreSQL|sqlx|axum|pgvector" spec/backend-requirements.md spec/api-contract.md`
- manually cross-check the endpoint/resource surface between `spec/backend-requirements.md` and `spec/api-contract.md`
