### PR TITLE
feat(ci): establish v0.1.0 CI baseline

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,40 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend.yml"
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add rustfmt clippy
+
+      - name: Check formatting
+        working-directory: backend
+        run: cargo fmt --check
+
+      - name: Lint
+        working-directory: backend
+        run: cargo clippy -- -D warnings
+
+      - name: Test
+        working-directory: backend
+        run: cargo test

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,39 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "client/**"
+      - ".github/workflows/frontend.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "client/**"
+      - ".github/workflows/frontend.yml"
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        working-directory: client
+        run: flutter pub get
+
+      - name: Analyze
+        working-directory: client
+        run: flutter analyze
+
+      - name: Test
+        working-directory: client
+        run: flutter test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Establish independent backend and frontend CI gates for v0.1.0 pull requests
+  and pushes to `main`.
 - Add the initial Rust backend runtime with explicit startup validation for
   operator-provisioned API keys, durable accepted-audio storage, shared JSON
   errors, and bearer authentication.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-Oracy is the voice transcription product: `client/` contains the Flutter application, `spec/` defines the public API contract, and `backend/` contains the Rust backend service.
+Oracy is the voice transcription product: `client/` contains the Flutter
+application, `spec/` defines the public API contract, and `backend/` contains
+the Rust backend service.
+
+## Quality Gates
+
+CI runs backend and frontend gates independently for changes under `backend/`
+and `client/`.
+
+Backend:
+
+```sh
+cd backend
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+```
+
+Frontend:
+
+```sh
+cd client
+flutter analyze
+flutter test
+```

--- a/client/lib/app.dart
+++ b/client/lib/app.dart
@@ -25,7 +25,7 @@ class OracyApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (kDebugMode && kIsWeb) {
-      print('[APP] Building MaterialApp...');
+      debugPrint('[APP] Building MaterialApp...');
     }
     return MaterialApp(
       title: 'Oracy',
@@ -67,12 +67,12 @@ class _HomePageState extends ConsumerState<HomePage>
     WidgetsBinding.instance.addObserver(this);
 
     if (kDebugMode && kIsWeb) {
-      print('[HOME] initState called');
+      debugPrint('[HOME] initState called');
     }
     // Listen for transcription state changes
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (kDebugMode && kIsWeb) {
-        print('[HOME] PostFrameCallback executing...');
+        debugPrint('[HOME] PostFrameCallback executing...');
       }
       HomeWidgetService.setOnRecordCallback(_startRecordingFromWidget);
       _setupTranscriptionListener();
@@ -191,7 +191,7 @@ class _HomePageState extends ConsumerState<HomePage>
   void _onRecordingComplete(String filePath) {
     // Start transcription
     if (kDebugMode && kIsWeb) {
-      print('[HOME] _onRecordingComplete called with filePath: $filePath');
+      debugPrint('[HOME] _onRecordingComplete called with filePath: $filePath');
     }
     ref.read(transcriptionProvider.notifier).transcribe(filePath);
   }
@@ -199,11 +199,11 @@ class _HomePageState extends ConsumerState<HomePage>
   @override
   Widget build(BuildContext context) {
     if (kDebugMode && kIsWeb) {
-      print('[HOME] build called');
+      debugPrint('[HOME] build called');
     }
     final transcriptionState = ref.watch(transcriptionProvider);
     if (kDebugMode && kIsWeb) {
-      print('[HOME] transcriptionState: $transcriptionState');
+      debugPrint('[HOME] transcriptionState: $transcriptionState');
     }
 
     return Scaffold(

--- a/client/lib/db/connection/web.dart
+++ b/client/lib/db/connection/web.dart
@@ -12,7 +12,7 @@ QueryExecutor openConnection() {
 
     if (result.missingFeatures.isNotEmpty) {
       if (kDebugMode) {
-        print('Missing web features: ${result.missingFeatures}');
+        debugPrint('Missing web features: ${result.missingFeatures}');
       }
     }
 

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -14,7 +14,7 @@ void main() async {
 
   // Debug log for web
   if (kDebugMode && kIsWeb) {
-    print('[MAIN] Starting Oracy web app...');
+    debugPrint('[MAIN] Starting Oracy web app...');
   }
 
   // Initialize SharedPreferences
@@ -48,7 +48,7 @@ void main() async {
   }
 
   if (kDebugMode && kIsWeb) {
-    print('[MAIN] About to run app...');
+    debugPrint('[MAIN] About to run app...');
   }
 
   runApp(
@@ -61,6 +61,6 @@ void main() async {
   );
 
   if (kDebugMode && kIsWeb) {
-    print('[MAIN] App started!');
+    debugPrint('[MAIN] App started!');
   }
 }

--- a/client/lib/services/api_client.dart
+++ b/client/lib/services/api_client.dart
@@ -13,10 +13,7 @@ const kDefaultBaseUrl = 'https://api.oracy.app';
 class SecureStorageService {
   final FlutterSecureStorage _storage;
 
-  SecureStorageService()
-    : _storage = const FlutterSecureStorage(
-        aOptions: AndroidOptions(encryptedSharedPreferences: true),
-      );
+  SecureStorageService() : _storage = const FlutterSecureStorage();
 
   /// Get the stored API key.
   Future<String?> getApiKey() async {
@@ -125,7 +122,7 @@ class ApiClientFactory {
           responseBody: true,
           logPrint: (o) {
             if (kDebugMode) {
-              print('[DIO] $o');
+              debugPrint('[DIO] $o');
             }
           },
         ),

--- a/client/lib/services/background_sync_service.dart
+++ b/client/lib/services/background_sync_service.dart
@@ -188,10 +188,7 @@ bool _isConnected(List<ConnectivityResult> results) {
 class BackgroundSyncService {
   /// Initialize workmanager and register background tasks.
   static Future<void> initialize() async {
-    await Workmanager().initialize(
-      callbackDispatcher,
-      isInDebugMode: kDebugMode,
-    );
+    await Workmanager().initialize(callbackDispatcher);
 
     // Register periodic background sync task
     // Note: Android requires minimum 15 minutes between executions

--- a/client/lib/services/recording_service.dart
+++ b/client/lib/services/recording_service.dart
@@ -192,17 +192,17 @@ class RecordingNotifier extends Notifier<RecordingInfo> {
   /// Start recording.
   Future<void> startRecording() async {
     if (kDebugMode && kIsWeb) {
-      print('[RECORDING_SERVICE] startRecording called');
+      debugPrint('[RECORDING_SERVICE] startRecording called');
     }
     if (state.isRecording) return;
 
     try {
       if (kDebugMode && kIsWeb) {
-        print('[RECORDING_SERVICE] Calling _service.startRecording()...');
+        debugPrint('[RECORDING_SERVICE] Calling _service.startRecording()...');
       }
       final path = await _service.startRecording();
       if (kDebugMode && kIsWeb) {
-        print('[RECORDING_SERVICE] Got path: $path');
+        debugPrint('[RECORDING_SERVICE] Got path: $path');
       }
       state = RecordingInfo(
         state: RecordingState.recording,
@@ -210,7 +210,7 @@ class RecordingNotifier extends Notifier<RecordingInfo> {
         duration: Duration.zero,
       );
       if (kDebugMode && kIsWeb) {
-        print('[RECORDING_SERVICE] State updated to recording');
+        debugPrint('[RECORDING_SERVICE] State updated to recording');
       }
 
       // Mark recording as active for crash recovery
@@ -225,7 +225,7 @@ class RecordingNotifier extends Notifier<RecordingInfo> {
       );
     } catch (e) {
       if (kDebugMode && kIsWeb) {
-        print('[RECORDING_SERVICE] ERROR: $e');
+        debugPrint('[RECORDING_SERVICE] ERROR: $e');
       }
       state = RecordingInfo(
         state: RecordingState.error,

--- a/client/lib/services/transcription_service.dart
+++ b/client/lib/services/transcription_service.dart
@@ -328,18 +328,18 @@ class TranscriptionService {
     void Function(double progress)? onProgress,
   }) async {
     if (kDebugMode) {
-      print(
+      debugPrint(
         '[TRANSCRIPTION_SERVICE] transcribe() called with filePath: $filePath',
       );
     }
 
     // Get file data using platform-specific implementation
     if (kDebugMode) {
-      print('[TRANSCRIPTION_SERVICE] Calling platform.getFileData...');
+      debugPrint('[TRANSCRIPTION_SERVICE] Calling platform.getFileData...');
     }
     final fileData = await platform.getFileData(filePath);
     if (kDebugMode) {
-      print(
+      debugPrint(
         '[TRANSCRIPTION_SERVICE] Got ${fileData.bytes.length} bytes, filename: ${fileData.filename}',
       );
     }
@@ -410,7 +410,9 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
   /// Transcribe an audio file.
   Future<void> transcribe(String filePath, {String? language}) async {
     if (kDebugMode) {
-      print('[TRANSCRIPTION] transcribe() called with filePath: $filePath');
+      debugPrint(
+        '[TRANSCRIPTION] transcribe() called with filePath: $filePath',
+      );
     }
 
     final queuedUploadId = await _ensureQueuedForRetry(
@@ -431,7 +433,7 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
     final storage = ref.read(secureStorageProvider);
     final hasKey = await storage.hasApiKey();
     if (kDebugMode) {
-      print('[TRANSCRIPTION] hasApiKey: $hasKey');
+      debugPrint('[TRANSCRIPTION] hasApiKey: $hasKey');
     }
     if (!hasKey) {
       if (queuedUploadId != null) {
@@ -448,7 +450,7 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
 
     state = const TranscriptionUploading();
     if (kDebugMode) {
-      print('[TRANSCRIPTION] State set to TranscriptionUploading');
+      debugPrint('[TRANSCRIPTION] State set to TranscriptionUploading');
     }
 
     try {
@@ -502,8 +504,8 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
       );
 
       if (kDebugMode) {
-        print('[TRANSCRIPTION] Caught exception: $e');
-        print('[TRANSCRIPTION] Stack trace: $stackTrace');
+        debugPrint('[TRANSCRIPTION] Caught exception: $e');
+        debugPrint('[TRANSCRIPTION] Stack trace: $stackTrace');
       }
       state = TranscriptionError(
         classification.message,

--- a/client/lib/services/transcription_service_web.dart
+++ b/client/lib/services/transcription_service_web.dart
@@ -1,8 +1,8 @@
-// Web platform implementation
+import 'dart:js_interop';
 
-import 'dart:html' as html;
-import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
+import 'package:web/web.dart' as web;
+
 import 'transcription_service.dart';
 import 'web_recording_upload_metadata.dart';
 
@@ -11,31 +11,30 @@ Future<FileData> getFileData(String filePath) async {
   // We need to fetch the blob and convert it to bytes
 
   if (kDebugMode) {
-    print('[TRANSCRIPTION_WEB] Getting file data for: $filePath');
+    debugPrint('[TRANSCRIPTION_WEB] Getting file data for: $filePath');
   }
 
   // Fetch the blob URL
-  final response = await html.HttpRequest.request(
-    filePath,
-    responseType: 'arraybuffer',
-  );
+  final response = await web.window.fetch(filePath.toJS).toDart;
 
-  final buffer = response.response as ByteBuffer;
-  final bytes = Uint8List.view(buffer);
+  final buffer = await response.arrayBuffer().toDart;
+  final bytes = buffer.toDart.asUint8List();
 
   if (kDebugMode) {
-    print('[TRANSCRIPTION_WEB] Got ${bytes.length} bytes');
+    debugPrint('[TRANSCRIPTION_WEB] Got ${bytes.length} bytes');
   }
 
   // Generate a filename based on timestamp
   final timestamp = DateTime.now().millisecondsSinceEpoch;
   final uploadMetadata = webRecordingUploadMetadata(
     timestamp: timestamp,
-    blobContentType: response.getResponseHeader('content-type'),
+    blobContentType: response.headers.get('content-type'),
   );
 
   if (kDebugMode) {
-    print('[TRANSCRIPTION_WEB] Using filename: ${uploadMetadata.filename}');
+    debugPrint(
+      '[TRANSCRIPTION_WEB] Using filename: ${uploadMetadata.filename}',
+    );
   }
 
   return FileData(

--- a/client/lib/widgets/recording_button.dart
+++ b/client/lib/widgets/recording_button.dart
@@ -67,7 +67,7 @@ class RecordingButton extends ConsumerWidget {
     RecordingInfo recording,
   ) async {
     if (kDebugMode && kIsWeb) {
-      print(
+      debugPrint(
         '[RECORDING_BUTTON] _handleTap called! isRecording=${recording.isRecording}',
       );
     }
@@ -76,7 +76,7 @@ class RecordingButton extends ConsumerWidget {
     if (recording.isRecording) {
       // Stop recording
       if (kDebugMode && kIsWeb) {
-        print('[RECORDING_BUTTON] Stopping recording...');
+        debugPrint('[RECORDING_BUTTON] Stopping recording...');
       }
       final path = await notifier.stopRecording();
       if (path != null && onRecordingComplete != null) {
@@ -85,11 +85,11 @@ class RecordingButton extends ConsumerWidget {
     } else {
       // Check permission and start recording
       if (kDebugMode && kIsWeb) {
-        print('[RECORDING_BUTTON] Checking permission...');
+        debugPrint('[RECORDING_BUTTON] Checking permission...');
       }
       final started = await startRecordingWithPermission(context, ref);
       if (kDebugMode && kIsWeb) {
-        print('[RECORDING_BUTTON] Recording started: $started');
+        debugPrint('[RECORDING_BUTTON] Recording started: $started');
       }
     }
   }

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1070,7 +1070,7 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   home_widget: ^0.9.1
   shared_preferences: ^2.5.0
   uuid: ^4.5.1
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- Establishes independent backend and frontend GitHub Actions gates for v0.1.0 changes.
- Makes the inherited Flutter client analyzer-clean so the frontend gate starts enforceable.
- Documents the local quality gates and records the CI baseline in the changelog.

## Changes

- Adds backend CI for `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` on `backend/**` changes.
- Adds frontend CI for `flutter pub get`, `flutter analyze`, and `flutter test` on `client/**` changes.
- Replaces analyzer-blocking client debug prints and deprecated options, and migrates web transcription blob loading from `dart:html` to `package:web`.

## GitHub Issue(s)

Closes #12

## Test plan

- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `flutter analyze`
- `flutter test`
