### PR TITLE
feat(storage): establish durable job and transcript substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add the durable backend SQLite substrate for accepted transcription jobs,
+  transcript versions, ordered segments, current embeddings, owner scoping, and
+  the required operator `database_path` setting.
 - Establish independent backend and frontend CI gates for v0.1.0 pull requests
   and pushes to `main`.
 - Add the initial Rust backend runtime with explicit startup validation for

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -12,16 +12,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -76,10 +97,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -91,16 +127,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
@@ -110,6 +183,36 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -122,13 +225,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -144,7 +295,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -152,6 +325,23 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "foldhash"
@@ -175,6 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -182,6 +373,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -196,7 +421,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -213,13 +441,36 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -230,6 +481,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -240,10 +493,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -326,10 +621,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -350,10 +748,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -368,10 +779,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -395,6 +850,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,7 +879,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -423,7 +888,59 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -440,14 +957,55 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sqlx",
  "subtle",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "toml",
  "tower",
  "tracing",
  "tracing-subscriber",
+ "ulid",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -461,6 +1019,63 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -492,9 +1107,92 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex-automata"
@@ -514,6 +1212,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,14 +1241,26 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -614,6 +1344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +1375,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +1401,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -652,7 +1412,228 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -679,16 +1660,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -721,17 +1713,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -743,6 +1792,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -881,10 +1941,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -893,10 +1984,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -926,6 +2041,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -963,10 +2129,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -976,6 +2171,63 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
@@ -1081,6 +2333,115 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,12 +7,15 @@ edition = "2024"
 axum = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
+sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
 subtle = "2.6"
 thiserror = "2.0"
+time = { version = "0.3.47", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "net"] }
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+ulid = "1.2.1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,7 @@ Run the service with `ORACY_CONFIG` set to a TOML configuration file:
 ```toml
 listen_addr = "127.0.0.1:8080"
 accepted_audio_dir = "/var/lib/oracy/accepted-audio"
+database_path = "/var/lib/oracy/oracy.sqlite"
 
 [[api_keys]]
 api_key_id = "operator-issued-id"
@@ -15,8 +16,10 @@ key = "operator-issued-secret"
 ```
 
 Startup fails unless `api_keys` contains at least one valid operator-provisioned
-key and `accepted_audio_dir` already exists as a writable directory. Relative
-`accepted_audio_dir` values resolve from the real configuration file directory.
+key, `accepted_audio_dir` already exists as a writable directory, and
+`database_path` points to a SQLite database file whose parent directory exists
+and is writable. Relative storage paths resolve from the real configuration
+file directory.
 
 Every API route requires `Authorization: Bearer <api_key>`. The bearer scheme is
 case-insensitive, and missing or invalid keys return the shared JSON

--- a/backend/migrations/20260424000000_create_job_transcript_substrate.sql
+++ b/backend/migrations/20260424000000_create_job_transcript_substrate.sql
@@ -28,6 +28,7 @@ CREATE TABLE transcription_jobs (
     failure_message TEXT,
     retryable_by_client INTEGER CHECK (retryable_by_client IS NULL OR retryable_by_client IN (0, 1)),
     transcript_id TEXT REFERENCES transcripts(id) ON DELETE SET NULL,
+    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id),
     UNIQUE (api_key_id, idempotency_key)
 );
 
@@ -59,7 +60,7 @@ CREATE TABLE transcripts (
     session_id TEXT
 );
 
-CREATE INDEX transcripts_owner_id_idx
+CREATE UNIQUE INDEX transcripts_owner_id_idx
     ON transcripts (api_key_id, id);
 
 CREATE INDEX transcripts_history_idx
@@ -68,10 +69,11 @@ CREATE INDEX transcripts_history_idx
 CREATE TABLE transcript_versions (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL REFERENCES transcripts(id) ON DELETE CASCADE,
+    transcript_id TEXT NOT NULL,
     version_number INTEGER NOT NULL CHECK (version_number >= 1),
     transcript TEXT NOT NULL,
     created_at TEXT NOT NULL,
+    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
     UNIQUE (transcript_id, version_number)
 );
 
@@ -81,11 +83,12 @@ CREATE INDEX transcript_versions_current_idx
 CREATE TABLE segments (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL REFERENCES transcripts(id) ON DELETE CASCADE,
+    transcript_id TEXT NOT NULL,
     position INTEGER NOT NULL CHECK (position >= 0),
     start_ms INTEGER NOT NULL CHECK (start_ms >= 0),
     end_ms INTEGER NOT NULL CHECK (end_ms >= start_ms),
     text TEXT NOT NULL,
+    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
     UNIQUE (transcript_id, position)
 );
 
@@ -93,11 +96,12 @@ CREATE INDEX segments_order_idx
     ON segments (transcript_id, position ASC);
 
 CREATE TABLE embeddings (
-    transcript_id TEXT PRIMARY KEY REFERENCES transcripts(id) ON DELETE CASCADE,
+    transcript_id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
     model TEXT NOT NULL,
     vector BLOB NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX embeddings_owner_idx

--- a/backend/migrations/20260424000000_create_job_transcript_substrate.sql
+++ b/backend/migrations/20260424000000_create_job_transcript_substrate.sql
@@ -1,0 +1,104 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE transcription_jobs (
+    id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    audio_sha256_hex TEXT NOT NULL,
+    recorded_at TEXT NOT NULL,
+    session_id TEXT,
+    language TEXT,
+    accepted_audio_path TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('queued', 'processing', 'retry_waiting', 'succeeded', 'failed')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    max_retries INTEGER NOT NULL CHECK (max_retries >= 0),
+    next_attempt_at TEXT,
+    failure_code TEXT CHECK (
+        failure_code IS NULL OR failure_code IN (
+            'audio_invalid',
+            'engine_timeout',
+            'engine_rate_limited',
+            'engine_error',
+            'storage_error',
+            'internal_error'
+        )
+    ),
+    failure_message TEXT,
+    retryable_by_client INTEGER CHECK (retryable_by_client IS NULL OR retryable_by_client IN (0, 1)),
+    transcript_id TEXT REFERENCES transcripts(id) ON DELETE SET NULL,
+    UNIQUE (api_key_id, idempotency_key)
+);
+
+CREATE INDEX transcription_jobs_owner_id_idx
+    ON transcription_jobs (api_key_id, id);
+
+CREATE INDEX transcription_jobs_ready_idx
+    ON transcription_jobs (status, next_attempt_at, created_at, id);
+
+CREATE TRIGGER transcription_jobs_accepted_tuple_immutable
+BEFORE UPDATE OF api_key_id, idempotency_key, audio_sha256_hex, recorded_at, session_id, language
+ON transcription_jobs
+BEGIN
+    SELECT RAISE(ABORT, 'accepted submission tuple is immutable');
+END;
+
+CREATE TABLE transcripts (
+    id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    audio_duration_seconds REAL NOT NULL CHECK (audio_duration_seconds >= 0),
+    audio_format TEXT NOT NULL,
+    audio_size_bytes INTEGER NOT NULL CHECK (audio_size_bytes >= 0),
+    transcript_language TEXT,
+    model TEXT NOT NULL,
+    processing_time_ms INTEGER NOT NULL CHECK (processing_time_ms >= 0),
+    cost_cents INTEGER CHECK (cost_cents IS NULL OR cost_cents >= 0),
+    created_at TEXT NOT NULL,
+    recorded_at TEXT NOT NULL,
+    session_id TEXT
+);
+
+CREATE INDEX transcripts_owner_id_idx
+    ON transcripts (api_key_id, id);
+
+CREATE INDEX transcripts_history_idx
+    ON transcripts (api_key_id, created_at DESC, id DESC);
+
+CREATE TABLE transcript_versions (
+    id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    transcript_id TEXT NOT NULL REFERENCES transcripts(id) ON DELETE CASCADE,
+    version_number INTEGER NOT NULL CHECK (version_number >= 1),
+    transcript TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE (transcript_id, version_number)
+);
+
+CREATE INDEX transcript_versions_current_idx
+    ON transcript_versions (transcript_id, version_number DESC);
+
+CREATE TABLE segments (
+    id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    transcript_id TEXT NOT NULL REFERENCES transcripts(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL CHECK (position >= 0),
+    start_ms INTEGER NOT NULL CHECK (start_ms >= 0),
+    end_ms INTEGER NOT NULL CHECK (end_ms >= start_ms),
+    text TEXT NOT NULL,
+    UNIQUE (transcript_id, position)
+);
+
+CREATE INDEX segments_order_idx
+    ON segments (transcript_id, position ASC);
+
+CREATE TABLE embeddings (
+    transcript_id TEXT PRIMARY KEY REFERENCES transcripts(id) ON DELETE CASCADE,
+    api_key_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    vector BLOB NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX embeddings_owner_idx
+    ON embeddings (api_key_id, transcript_id);

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -9,6 +9,7 @@ use tracing::info;
 use crate::auth::AuthStore;
 use crate::config::Settings;
 use crate::state::AppState;
+use crate::storage::{Storage, StorageError};
 
 pub const CONFIG_ENV_VAR: &str = "ORACY_CONFIG";
 
@@ -40,14 +41,16 @@ pub enum BootstrapError {
         #[source]
         source: std::io::Error,
     },
+    #[error("{0}")]
+    Storage(#[from] StorageError),
 }
 
-pub fn load_runtime_from_env() -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
+pub async fn load_runtime_from_env() -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
     let config_path = std::env::var_os(CONFIG_ENV_VAR).ok_or(BootstrapError::MissingConfigEnv)?;
-    load_runtime_from_path(Path::new(&config_path))
+    load_runtime_from_path(Path::new(&config_path)).await
 }
 
-pub fn load_runtime_from_path(
+pub async fn load_runtime_from_path(
     config_path: &Path,
 ) -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
     let raw = fs::read_to_string(config_path).map_err(|source| BootstrapError::ReadConfig {
@@ -61,31 +64,38 @@ pub fn load_runtime_from_path(
         })?;
 
     settings.accepted_audio_dir =
-        resolve_accepted_audio_dir(config_path, &settings.accepted_audio_dir)?;
+        resolve_config_relative_path(config_path, &settings.accepted_audio_dir)?;
+    settings.database_path = resolve_config_relative_path(config_path, &settings.database_path)?;
     info!(
         "accepted audio storage directory resolved to {}",
         settings.accepted_audio_dir.display()
+    );
+    info!(
+        "database path resolved to {}",
+        settings.database_path.display()
     );
 
     validate_settings(&settings)?;
     ensure_writable_directory(&settings.accepted_audio_dir)?;
     let auth_store = AuthStore::try_from_configs(&settings.api_keys)
         .map_err(|error| BootstrapError::InvalidConfiguration(error.to_string()))?;
+    let storage = Storage::connect(&settings.database_path).await?;
 
     let state = AppState {
         accepted_audio_dir: settings.accepted_audio_dir.clone(),
         auth_store: Arc::new(auth_store),
+        storage,
     };
 
     Ok((settings.listen_addr, state))
 }
 
-fn resolve_accepted_audio_dir(
+fn resolve_config_relative_path(
     config_path: &Path,
-    accepted_audio_dir: &Path,
+    configured_path: &Path,
 ) -> Result<PathBuf, BootstrapError> {
-    if accepted_audio_dir.is_absolute() {
-        return Ok(accepted_audio_dir.to_path_buf());
+    if configured_path.is_absolute() {
+        return Ok(configured_path.to_path_buf());
     }
 
     let absolute_config_path = if config_path.is_absolute() {
@@ -113,7 +123,7 @@ fn resolve_accepted_audio_dir(
         ))
     })?;
 
-    Ok(config_dir.join(accepted_audio_dir))
+    Ok(config_dir.join(configured_path))
 }
 
 fn validate_settings(settings: &Settings) -> Result<(), BootstrapError> {

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -15,6 +15,7 @@ pub struct Settings {
     #[serde(default = "default_listen_addr")]
     pub listen_addr: SocketAddr,
     pub accepted_audio_dir: PathBuf,
+    pub database_path: PathBuf,
     pub api_keys: Vec<ApiKeyConfig>,
 }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -6,3 +6,4 @@ pub mod config;
 pub mod errors;
 pub mod router;
 pub mod state;
+pub mod storage;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let (listen_addr, state) = load_runtime_from_env()?;
+    let (listen_addr, state) = load_runtime_from_env().await?;
     serve(listen_addr, build_router(state)).await
 }
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -4,11 +4,13 @@ use std::sync::Arc;
 use axum::extract::FromRef;
 
 use crate::auth::AuthStore;
+use crate::storage::Storage;
 
 #[derive(Clone, Debug)]
 pub struct AppState {
     pub accepted_audio_dir: PathBuf,
     pub auth_store: Arc<AuthStore>,
+    pub storage: Storage,
 }
 
 impl FromRef<AppState> for Arc<AuthStore> {

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -45,6 +45,8 @@ pub enum StorageError {
     },
     #[error("storage query failed: {0}")]
     Query(#[from] sqlx::Error),
+    #[error("job is not eligible for transcript completion: {job_id}")]
+    JobNotCompletable { job_id: String },
     #[error("stored timestamp is invalid: {0}")]
     InvalidTimestamp(#[from] time::error::Parse),
     #[error("timestamp could not be formatted: {0}")]
@@ -217,25 +219,13 @@ impl Storage {
         &self,
         input: NewTranscriptionJob,
     ) -> Result<AcceptJobOutcome, StorageError> {
-        if let Some(existing) = self
-            .find_job_by_idempotency_key(&input.api_key_id, &input.idempotency_key)
-            .await?
-        {
-            return if existing.matches_submission(&input) {
-                Ok(AcceptJobOutcome::Replayed(existing))
-            } else {
-                Ok(AcceptJobOutcome::Conflict(SubmissionConflict {
-                    job_id: existing.id,
-                }))
-            };
-        }
-
+        let mut tx = self.pool.begin().await?;
         let id = new_id();
         let now = format_timestamp(input.now)?;
         let recorded_at = format_timestamp(input.recorded_at)?;
         let accepted_audio_path = input.accepted_audio_path.to_string_lossy().into_owned();
 
-        sqlx::query(
+        let result = sqlx::query(
             r#"
             INSERT INTO transcription_jobs (
                 id, api_key_id, idempotency_key, audio_sha256_hex, recorded_at,
@@ -243,6 +233,7 @@ impl Storage {
                 updated_at, retry_count, max_retries
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?)
+            ON CONFLICT(api_key_id, idempotency_key) DO NOTHING
             "#,
         )
         .bind(&id)
@@ -256,14 +247,44 @@ impl Storage {
         .bind(&now)
         .bind(&now)
         .bind(input.max_retries)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
 
-        let created = self
-            .get_job(&input.api_key_id, &id)
+        let row = if result.rows_affected() == 1 {
+            sqlx::query(
+                r#"
+                SELECT * FROM transcription_jobs
+                WHERE api_key_id = ? AND id = ?
+                "#,
+            )
+            .bind(&input.api_key_id)
+            .bind(&id)
+            .fetch_one(&mut *tx)
             .await?
-            .expect("inserted job should be readable");
-        Ok(AcceptJobOutcome::Created(created))
+        } else {
+            sqlx::query(
+                r#"
+                SELECT * FROM transcription_jobs
+                WHERE api_key_id = ? AND idempotency_key = ?
+                "#,
+            )
+            .bind(&input.api_key_id)
+            .bind(&input.idempotency_key)
+            .fetch_one(&mut *tx)
+            .await?
+        };
+        let job = job_from_row(row)?;
+        tx.commit().await?;
+
+        if result.rows_affected() == 1 {
+            Ok(AcceptJobOutcome::Created(job))
+        } else if job.matches_submission(&input) {
+            Ok(AcceptJobOutcome::Replayed(job))
+        } else {
+            Ok(AcceptJobOutcome::Conflict(SubmissionConflict {
+                job_id: job.id,
+            }))
+        }
     }
 
     pub async fn find_job_by_idempotency_key(
@@ -314,6 +335,27 @@ impl Storage {
         let transcript = materialization.transcript;
         let version = materialization.initial_version;
         let now = format_timestamp(transcript.created_at)?;
+
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET updated_at = ?
+            WHERE api_key_id = ?
+                AND id = ?
+                AND status IN ('processing', 'retry_waiting')
+                AND transcript_id IS NULL
+            "#,
+        )
+        .bind(&now)
+        .bind(api_key_id)
+        .bind(job_id)
+        .execute(&mut *tx)
+        .await?;
+        if result.rows_affected() != 1 {
+            return Err(StorageError::JobNotCompletable {
+                job_id: job_id.to_owned(),
+            });
+        }
 
         sqlx::query(
             r#"
@@ -394,17 +436,22 @@ impl Storage {
             r#"
             UPDATE transcription_jobs
             SET status = 'succeeded', transcript_id = ?, updated_at = ?
-            WHERE api_key_id = ? AND id = ?
+            WHERE api_key_id = ?
+                AND id = ?
+                AND status IN ('processing', 'retry_waiting')
+                AND transcript_id IS NULL
             "#,
         )
         .bind(&transcript.id)
-        .bind(now)
+        .bind(&now)
         .bind(api_key_id)
         .bind(job_id)
         .execute(&mut *tx)
         .await?;
         if result.rows_affected() != 1 {
-            return Err(StorageError::Query(sqlx::Error::RowNotFound));
+            return Err(StorageError::JobNotCompletable {
+                job_id: job_id.to_owned(),
+            });
         }
 
         tx.commit().await?;

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -6,6 +6,7 @@ use sqlx::{Row, SqlitePool};
 use thiserror::Error;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
+use time::macros::format_description;
 use ulid::Ulid;
 
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
@@ -635,7 +636,11 @@ fn new_id() -> String {
 }
 
 fn format_timestamp(value: OffsetDateTime) -> Result<String, StorageError> {
-    Ok(value.to_offset(time::UtcOffset::UTC).format(&Rfc3339)?)
+    Ok(value
+        .to_offset(time::UtcOffset::UTC)
+        .format(&format_description!(
+            "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
+        ))?)
 }
 
 fn parse_timestamp(value: String) -> Result<OffsetDateTime, StorageError> {

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -1,0 +1,665 @@
+use std::path::{Path, PathBuf};
+
+use sqlx::migrate::Migrator;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+use sqlx::{Row, SqlitePool};
+use thiserror::Error;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use ulid::Ulid;
+
+static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
+
+#[derive(Clone, Debug)]
+pub struct Storage {
+    pool: SqlitePool,
+}
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("database path has no parent directory: {0}")]
+    MissingParent(PathBuf),
+    #[error("database parent directory does not exist: {0}")]
+    MissingParentDirectory(PathBuf),
+    #[error("database parent path is not a directory: {0}")]
+    ParentNotDirectory(PathBuf),
+    #[error("database path is a directory: {0}")]
+    PathIsDirectory(PathBuf),
+    #[error("database parent directory is not writable: {path}: {source}")]
+    ParentNotWritable {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to open database {path}: {source}")]
+    Open {
+        path: PathBuf,
+        #[source]
+        source: sqlx::Error,
+    },
+    #[error("failed to migrate database {path}: {source}")]
+    Migrate {
+        path: PathBuf,
+        #[source]
+        source: sqlx::migrate::MigrateError,
+    },
+    #[error("storage query failed: {0}")]
+    Query(#[from] sqlx::Error),
+    #[error("stored timestamp is invalid: {0}")]
+    InvalidTimestamp(#[from] time::error::Parse),
+    #[error("timestamp could not be formatted: {0}")]
+    FormatTimestamp(#[from] time::error::Format),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcceptJobOutcome {
+    Created(TranscriptionJobRecord),
+    Replayed(TranscriptionJobRecord),
+    Conflict(SubmissionConflict),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubmissionConflict {
+    pub job_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewTranscriptionJob {
+    pub api_key_id: String,
+    pub idempotency_key: String,
+    pub audio_sha256_hex: String,
+    pub recorded_at: OffsetDateTime,
+    pub session_id: Option<String>,
+    pub language: Option<String>,
+    pub accepted_audio_path: PathBuf,
+    pub max_retries: i64,
+    pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptionJobRecord {
+    pub id: String,
+    pub api_key_id: String,
+    pub idempotency_key: String,
+    pub audio_sha256_hex: String,
+    pub recorded_at: OffsetDateTime,
+    pub session_id: Option<String>,
+    pub language: Option<String>,
+    pub accepted_audio_path: PathBuf,
+    pub status: String,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+    pub retry_count: i64,
+    pub max_retries: i64,
+    pub next_attempt_at: Option<OffsetDateTime>,
+    pub failure_code: Option<String>,
+    pub failure_message: Option<String>,
+    pub retryable_by_client: Option<bool>,
+    pub transcript_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptMaterialization {
+    pub transcript: NewTranscript,
+    pub initial_version: NewTranscriptVersion,
+    pub segments: Vec<NewSegment>,
+    pub embedding: NewEmbedding,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewTranscript {
+    pub id: String,
+    pub audio_duration_seconds: f64,
+    pub audio_format: String,
+    pub audio_size_bytes: i64,
+    pub transcript_language: Option<String>,
+    pub model: String,
+    pub processing_time_ms: i64,
+    pub cost_cents: Option<i64>,
+    pub created_at: OffsetDateTime,
+    pub recorded_at: OffsetDateTime,
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewTranscriptVersion {
+    pub id: String,
+    pub transcript: String,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewSegment {
+    pub id: String,
+    pub position: i64,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewEmbedding {
+    pub model: String,
+    pub vector: Vec<u8>,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TranscriptRecord {
+    pub id: String,
+    pub api_key_id: String,
+    pub current_version_id: String,
+    pub transcript: String,
+    pub audio_duration_seconds: f64,
+    pub audio_format: String,
+    pub audio_size_bytes: i64,
+    pub transcript_language: Option<String>,
+    pub model: String,
+    pub processing_time_ms: i64,
+    pub cost_cents: Option<i64>,
+    pub created_at: OffsetDateTime,
+    pub recorded_at: OffsetDateTime,
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentRecord {
+    pub id: String,
+    pub transcript_id: String,
+    pub position: i64,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingRecord {
+    pub transcript_id: String,
+    pub model: String,
+    pub vector: Vec<u8>,
+    pub created_at: OffsetDateTime,
+}
+
+impl Storage {
+    pub async fn connect(database_path: &Path) -> Result<Self, StorageError> {
+        validate_database_path(database_path)?;
+
+        let options = SqliteConnectOptions::new()
+            .filename(database_path)
+            .create_if_missing(true)
+            .foreign_keys(true)
+            .journal_mode(SqliteJournalMode::Wal);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect_with(options)
+            .await
+            .map_err(|source| StorageError::Open {
+                path: database_path.to_path_buf(),
+                source,
+            })?;
+
+        MIGRATOR
+            .run(&pool)
+            .await
+            .map_err(|source| StorageError::Migrate {
+                path: database_path.to_path_buf(),
+                source,
+            })?;
+
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    pub async fn accept_job(
+        &self,
+        input: NewTranscriptionJob,
+    ) -> Result<AcceptJobOutcome, StorageError> {
+        if let Some(existing) = self
+            .find_job_by_idempotency_key(&input.api_key_id, &input.idempotency_key)
+            .await?
+        {
+            return if existing.matches_submission(&input) {
+                Ok(AcceptJobOutcome::Replayed(existing))
+            } else {
+                Ok(AcceptJobOutcome::Conflict(SubmissionConflict {
+                    job_id: existing.id,
+                }))
+            };
+        }
+
+        let id = new_id();
+        let now = format_timestamp(input.now)?;
+        let recorded_at = format_timestamp(input.recorded_at)?;
+        let accepted_audio_path = input.accepted_audio_path.to_string_lossy().into_owned();
+
+        sqlx::query(
+            r#"
+            INSERT INTO transcription_jobs (
+                id, api_key_id, idempotency_key, audio_sha256_hex, recorded_at,
+                session_id, language, accepted_audio_path, status, created_at,
+                updated_at, retry_count, max_retries
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?)
+            "#,
+        )
+        .bind(&id)
+        .bind(&input.api_key_id)
+        .bind(&input.idempotency_key)
+        .bind(&input.audio_sha256_hex)
+        .bind(recorded_at)
+        .bind(&input.session_id)
+        .bind(&input.language)
+        .bind(accepted_audio_path)
+        .bind(&now)
+        .bind(&now)
+        .bind(input.max_retries)
+        .execute(&self.pool)
+        .await?;
+
+        let created = self
+            .get_job(&input.api_key_id, &id)
+            .await?
+            .expect("inserted job should be readable");
+        Ok(AcceptJobOutcome::Created(created))
+    }
+
+    pub async fn find_job_by_idempotency_key(
+        &self,
+        api_key_id: &str,
+        idempotency_key: &str,
+    ) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+        let row = sqlx::query(
+            r#"
+            SELECT * FROM transcription_jobs
+            WHERE api_key_id = ? AND idempotency_key = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(idempotency_key)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(job_from_row).transpose()
+    }
+
+    pub async fn get_job(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+    ) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+        let row = sqlx::query(
+            r#"
+            SELECT * FROM transcription_jobs
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(job_from_row).transpose()
+    }
+
+    pub async fn complete_job_with_transcript(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        materialization: TranscriptMaterialization,
+    ) -> Result<(), StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let transcript = materialization.transcript;
+        let version = materialization.initial_version;
+        let now = format_timestamp(transcript.created_at)?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO transcripts (
+                id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+                transcript_language, model, processing_time_ms, cost_cents,
+                created_at, recorded_at, session_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&transcript.id)
+        .bind(api_key_id)
+        .bind(transcript.audio_duration_seconds)
+        .bind(&transcript.audio_format)
+        .bind(transcript.audio_size_bytes)
+        .bind(&transcript.transcript_language)
+        .bind(&transcript.model)
+        .bind(transcript.processing_time_ms)
+        .bind(transcript.cost_cents)
+        .bind(&now)
+        .bind(format_timestamp(transcript.recorded_at)?)
+        .bind(&transcript.session_id)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO transcript_versions (
+                id, api_key_id, transcript_id, version_number, transcript, created_at
+            )
+            VALUES (?, ?, ?, 1, ?, ?)
+            "#,
+        )
+        .bind(&version.id)
+        .bind(api_key_id)
+        .bind(&transcript.id)
+        .bind(&version.transcript)
+        .bind(format_timestamp(version.created_at)?)
+        .execute(&mut *tx)
+        .await?;
+
+        for segment in materialization.segments {
+            sqlx::query(
+                r#"
+                INSERT INTO segments (
+                    id, api_key_id, transcript_id, position, start_ms, end_ms, text
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(&segment.id)
+            .bind(api_key_id)
+            .bind(&transcript.id)
+            .bind(segment.position)
+            .bind(segment.start_ms)
+            .bind(segment.end_ms)
+            .bind(&segment.text)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&transcript.id)
+        .bind(api_key_id)
+        .bind(&materialization.embedding.model)
+        .bind(&materialization.embedding.vector)
+        .bind(format_timestamp(materialization.embedding.created_at)?)
+        .execute(&mut *tx)
+        .await?;
+
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'succeeded', transcript_id = ?, updated_at = ?
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(&transcript.id)
+        .bind(now)
+        .bind(api_key_id)
+        .bind(job_id)
+        .execute(&mut *tx)
+        .await?;
+        if result.rows_affected() != 1 {
+            return Err(StorageError::Query(sqlx::Error::RowNotFound));
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn get_transcript(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+    ) -> Result<Option<TranscriptRecord>, StorageError> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                transcripts.*,
+                transcript_versions.id AS current_version_id,
+                transcript_versions.transcript AS current_transcript
+            FROM transcripts
+            JOIN transcript_versions
+                ON transcript_versions.transcript_id = transcripts.id
+            WHERE transcripts.api_key_id = ?
+                AND transcripts.id = ?
+                AND transcript_versions.version_number = (
+                    SELECT MAX(version_number)
+                    FROM transcript_versions
+                    WHERE transcript_id = transcripts.id
+                )
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(transcript_from_row).transpose()
+    }
+
+    pub async fn list_segments(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+    ) -> Result<Vec<SegmentRecord>, StorageError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, transcript_id, position, start_ms, end_ms, text
+            FROM segments
+            WHERE api_key_id = ? AND transcript_id = ?
+            ORDER BY position ASC
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(segment_from_row).collect()
+    }
+
+    pub async fn replace_current_embedding(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+        embedding: NewEmbedding,
+    ) -> Result<bool, StorageError> {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+            SELECT ?, ?, ?, ?, ?
+            WHERE EXISTS (
+                SELECT 1 FROM transcripts WHERE api_key_id = ? AND id = ?
+            )
+            ON CONFLICT(transcript_id) DO UPDATE SET
+                model = excluded.model,
+                vector = excluded.vector,
+                created_at = excluded.created_at
+            WHERE embeddings.api_key_id = excluded.api_key_id
+            "#,
+        )
+        .bind(transcript_id)
+        .bind(api_key_id)
+        .bind(&embedding.model)
+        .bind(&embedding.vector)
+        .bind(format_timestamp(embedding.created_at)?)
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    pub async fn get_current_embedding(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+    ) -> Result<Option<EmbeddingRecord>, StorageError> {
+        let row = sqlx::query(
+            r#"
+            SELECT transcript_id, model, vector, created_at
+            FROM embeddings
+            WHERE api_key_id = ? AND transcript_id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(embedding_from_row).transpose()
+    }
+
+    pub async fn delete_transcript(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+    ) -> Result<bool, StorageError> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM transcripts
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+impl TranscriptionJobRecord {
+    fn matches_submission(&self, input: &NewTranscriptionJob) -> bool {
+        self.audio_sha256_hex == input.audio_sha256_hex
+            && self.recorded_at == input.recorded_at
+            && self.session_id == input.session_id
+            && self.language == input.language
+    }
+}
+
+fn validate_database_path(database_path: &Path) -> Result<(), StorageError> {
+    if database_path.is_dir() {
+        return Err(StorageError::PathIsDirectory(database_path.to_path_buf()));
+    }
+
+    let parent = database_path
+        .parent()
+        .ok_or_else(|| StorageError::MissingParent(database_path.to_path_buf()))?;
+
+    if !parent.exists() {
+        return Err(StorageError::MissingParentDirectory(parent.to_path_buf()));
+    }
+
+    if !parent.is_dir() {
+        return Err(StorageError::ParentNotDirectory(parent.to_path_buf()));
+    }
+
+    let probe_path = parent.join(format!(".oracy-db-write-probe-{}", new_id()));
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_path)
+    {
+        Ok(_) => {
+            std::fs::remove_file(&probe_path).map_err(|source| {
+                StorageError::ParentNotWritable {
+                    path: parent.to_path_buf(),
+                    source,
+                }
+            })?;
+            Ok(())
+        }
+        Err(source) => Err(StorageError::ParentNotWritable {
+            path: parent.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn new_id() -> String {
+    Ulid::new().to_string()
+}
+
+fn format_timestamp(value: OffsetDateTime) -> Result<String, StorageError> {
+    Ok(value.to_offset(time::UtcOffset::UTC).format(&Rfc3339)?)
+}
+
+fn parse_timestamp(value: String) -> Result<OffsetDateTime, StorageError> {
+    Ok(OffsetDateTime::parse(&value, &Rfc3339)?)
+}
+
+fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, StorageError> {
+    let retryable_by_client = row
+        .try_get::<Option<i64>, _>("retryable_by_client")?
+        .map(|value| value != 0);
+
+    Ok(TranscriptionJobRecord {
+        id: row.try_get("id")?,
+        api_key_id: row.try_get("api_key_id")?,
+        idempotency_key: row.try_get("idempotency_key")?,
+        audio_sha256_hex: row.try_get("audio_sha256_hex")?,
+        recorded_at: parse_timestamp(row.try_get("recorded_at")?)?,
+        session_id: row.try_get("session_id")?,
+        language: row.try_get("language")?,
+        accepted_audio_path: PathBuf::from(row.try_get::<String, _>("accepted_audio_path")?),
+        status: row.try_get("status")?,
+        created_at: parse_timestamp(row.try_get("created_at")?)?,
+        updated_at: parse_timestamp(row.try_get("updated_at")?)?,
+        retry_count: row.try_get("retry_count")?,
+        max_retries: row.try_get("max_retries")?,
+        next_attempt_at: row
+            .try_get::<Option<String>, _>("next_attempt_at")?
+            .map(parse_timestamp)
+            .transpose()?,
+        failure_code: row.try_get("failure_code")?,
+        failure_message: row.try_get("failure_message")?,
+        retryable_by_client,
+        transcript_id: row.try_get("transcript_id")?,
+    })
+}
+
+fn transcript_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptRecord, StorageError> {
+    Ok(TranscriptRecord {
+        id: row.try_get("id")?,
+        api_key_id: row.try_get("api_key_id")?,
+        current_version_id: row.try_get("current_version_id")?,
+        transcript: row.try_get("current_transcript")?,
+        audio_duration_seconds: row.try_get("audio_duration_seconds")?,
+        audio_format: row.try_get("audio_format")?,
+        audio_size_bytes: row.try_get("audio_size_bytes")?,
+        transcript_language: row.try_get("transcript_language")?,
+        model: row.try_get("model")?,
+        processing_time_ms: row.try_get("processing_time_ms")?,
+        cost_cents: row.try_get("cost_cents")?,
+        created_at: parse_timestamp(row.try_get("created_at")?)?,
+        recorded_at: parse_timestamp(row.try_get("recorded_at")?)?,
+        session_id: row.try_get("session_id")?,
+    })
+}
+
+fn segment_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SegmentRecord, StorageError> {
+    Ok(SegmentRecord {
+        id: row.try_get("id")?,
+        transcript_id: row.try_get("transcript_id")?,
+        position: row.try_get("position")?,
+        start_ms: row.try_get("start_ms")?,
+        end_ms: row.try_get("end_ms")?,
+        text: row.try_get("text")?,
+    })
+}
+
+fn embedding_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EmbeddingRecord, StorageError> {
+    Ok(EmbeddingRecord {
+        transcript_id: row.try_get("transcript_id")?,
+        model: row.try_get("model")?,
+        vector: row.try_get("vector")?,
+        created_at: parse_timestamp(row.try_get("created_at")?)?,
+    })
+}

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -342,7 +342,7 @@ impl Storage {
             SET updated_at = ?
             WHERE api_key_id = ?
                 AND id = ?
-                AND status IN ('processing', 'retry_waiting')
+                AND status = 'processing'
                 AND transcript_id IS NULL
             "#,
         )
@@ -438,7 +438,7 @@ impl Storage {
             SET status = 'succeeded', transcript_id = ?, updated_at = ?
             WHERE api_key_id = ?
                 AND id = ?
-                AND status IN ('processing', 'retry_waiting')
+                AND status = 'processing'
                 AND transcript_id IS NULL
             "#,
         )

--- a/backend/tests/auth.rs
+++ b/backend/tests/auth.rs
@@ -208,18 +208,22 @@ async fn protected_router() -> Router {
         format!(
             r#"
 accepted_audio_dir = "{}"
+database_path = "{}"
 
 [[api_keys]]
 api_key_id = "alpha"
 key = "alpha-secret"
 "#,
-            audio_dir.display()
+            audio_dir.display(),
+            tempdir.path().join("oracy.sqlite").display()
         )
         .trim_start(),
     )
     .expect("write config");
 
-    let (_, state) = load_runtime_from_path(&config_path).expect("valid runtime");
+    let (_, state) = load_runtime_from_path(&config_path)
+        .await
+        .expect("valid runtime");
 
     Router::new()
         .route("/protected", get(protected_handler))

--- a/backend/tests/responses.rs
+++ b/backend/tests/responses.rs
@@ -76,18 +76,22 @@ async fn unmatched_route_returns_shared_json_404() {
         format!(
             r#"
 accepted_audio_dir = "{}"
+database_path = "{}"
 
 [[api_keys]]
 api_key_id = "alpha"
 key = "alpha-secret"
 "#,
-            audio_dir.display()
+            audio_dir.display(),
+            tempdir.path().join("oracy.sqlite").display()
         )
         .trim_start(),
     )
     .expect("write config");
 
-    let (_, state) = load_runtime_from_path(&config_path).expect("valid runtime");
+    let (_, state) = load_runtime_from_path(&config_path)
+        .await
+        .expect("valid runtime");
     let app = build_router(state);
 
     let response = app

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -5,23 +5,25 @@ use tempfile::TempDir;
 
 mod support;
 
-#[test]
-fn startup_rejects_missing_oracy_config_env() {
+#[tokio::test]
+async fn startup_rejects_missing_oracy_config_env() {
     support::assert_ignored_test_passes_with_env_missing(
         "startup_rejects_missing_oracy_config_env_helper",
         "ORACY_CONFIG",
     );
 }
 
-#[test]
+#[tokio::test]
 #[ignore = "helper subprocess only"]
-fn startup_rejects_missing_oracy_config_env_helper() {
-    let error = load_runtime_from_env().expect_err("missing env should fail");
+async fn startup_rejects_missing_oracy_config_env_helper() {
+    let error = load_runtime_from_env()
+        .await
+        .expect_err("missing env should fail");
     assert!(matches!(error, BootstrapError::MissingConfigEnv));
 }
 
-#[test]
-fn startup_rejects_when_no_api_keys_are_configured() {
+#[tokio::test]
+async fn startup_rejects_when_no_api_keys_are_configured() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -34,7 +36,9 @@ api_keys = []
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("empty key list should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("empty key list should fail");
     assert!(
         error
             .to_string()
@@ -42,8 +46,8 @@ api_keys = []
     );
 }
 
-#[test]
-fn startup_rejects_invalid_toml() {
+#[tokio::test]
+async fn startup_rejects_invalid_toml() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -60,12 +64,14 @@ key = "key-one"
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("invalid toml should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("invalid toml should fail");
     assert!(error.to_string().contains("failed to parse config file"));
 }
 
-#[test]
-fn startup_rejects_duplicate_api_key_ids() {
+#[tokio::test]
+async fn startup_rejects_duplicate_api_key_ids() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -85,12 +91,14 @@ key = "key-two"
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("duplicate ids should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("duplicate ids should fail");
     assert!(error.to_string().contains("duplicate api_key_id"));
 }
 
-#[test]
-fn startup_rejects_blank_api_key_ids() {
+#[tokio::test]
+async fn startup_rejects_blank_api_key_ids() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -106,12 +114,14 @@ key = "key-one"
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("blank ids should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("blank ids should fail");
     assert!(error.to_string().contains("api_key_id must not be blank"));
 }
 
-#[test]
-fn startup_rejects_api_key_id_with_surrounding_whitespace() {
+#[tokio::test]
+async fn startup_rejects_api_key_id_with_surrounding_whitespace() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -127,8 +137,9 @@ key = "key-one"
         ),
     );
 
-    let error =
-        load_runtime_from_path(&config_path).expect_err("whitespace-padded ids should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("whitespace-padded ids should fail");
     match error {
         BootstrapError::InvalidConfiguration(message) => {
             assert!(message.contains("default "));
@@ -138,8 +149,8 @@ key = "key-one"
     }
 }
 
-#[test]
-fn startup_rejects_blank_api_key_material() {
+#[tokio::test]
+async fn startup_rejects_blank_api_key_material() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -155,7 +166,9 @@ key = "   "
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("blank key material should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("blank key material should fail");
     match error {
         BootstrapError::InvalidConfiguration(message) => {
             assert!(message.contains("alpha"));
@@ -166,8 +179,8 @@ key = "   "
     }
 }
 
-#[test]
-fn startup_rejects_api_key_with_surrounding_whitespace() {
+#[tokio::test]
+async fn startup_rejects_api_key_with_surrounding_whitespace() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -183,8 +196,9 @@ key = "alpha-secret "
         ),
     );
 
-    let error =
-        load_runtime_from_path(&config_path).expect_err("whitespace-padded keys should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("whitespace-padded keys should fail");
     match error {
         BootstrapError::InvalidConfiguration(message) => {
             assert!(message.contains("default"));
@@ -195,8 +209,8 @@ key = "alpha-secret "
     }
 }
 
-#[test]
-fn startup_rejects_api_key_with_non_ascii_bytes() {
+#[tokio::test]
+async fn startup_rejects_api_key_with_non_ascii_bytes() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -212,7 +226,9 @@ key = "sëcret"
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("non-ascii keys should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("non-ascii keys should fail");
     match error {
         BootstrapError::InvalidConfiguration(message) => {
             assert!(message.contains("alpha"));
@@ -223,8 +239,8 @@ key = "sëcret"
     }
 }
 
-#[test]
-fn startup_rejects_api_key_with_control_characters() {
+#[tokio::test]
+async fn startup_rejects_api_key_with_control_characters() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -234,8 +250,9 @@ fn startup_rejects_api_key_with_control_characters() {
         ),
     );
 
-    let error =
-        load_runtime_from_path(&config_path).expect_err("control-character keys should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("control-character keys should fail");
     match error {
         BootstrapError::InvalidConfiguration(message) => {
             assert!(message.contains("alpha"));
@@ -246,8 +263,8 @@ fn startup_rejects_api_key_with_control_characters() {
     }
 }
 
-#[test]
-fn startup_rejects_duplicate_api_key_material() {
+#[tokio::test]
+async fn startup_rejects_duplicate_api_key_material() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(
         &tempdir,
@@ -267,13 +284,14 @@ key = "shared-key"
         ),
     );
 
-    let error =
-        load_runtime_from_path(&config_path).expect_err("duplicate key material should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("duplicate key material should fail");
     assert!(error.to_string().contains("duplicate api key material"));
 }
 
-#[test]
-fn startup_rejects_missing_accepted_audio_directory() {
+#[tokio::test]
+async fn startup_rejects_missing_accepted_audio_directory() {
     let tempdir = TempDir::new().expect("tempdir");
     let missing_dir = tempdir.path().join("missing");
     let config_path = write_config(
@@ -290,7 +308,9 @@ key = "key-one"
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("missing storage should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("missing storage should fail");
     assert!(
         error
             .to_string()
@@ -298,8 +318,166 @@ key = "key-one"
     );
 }
 
-#[test]
-fn startup_accepts_relative_accepted_audio_dir_resolved_against_config() {
+#[tokio::test]
+async fn startup_rejects_missing_database_path() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config_without_database_path(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display()
+        ),
+    );
+
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("missing database path should fail");
+    assert!(error.to_string().contains("missing field `database_path`"));
+}
+
+#[tokio::test]
+async fn startup_rejects_database_path_with_missing_parent() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let missing_parent = tempdir.path().join("missing");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+database_path = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display(),
+            missing_parent.join("oracy.sqlite").display()
+        ),
+    );
+
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("missing database parent should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("database parent directory does not exist")
+    );
+}
+
+#[tokio::test]
+async fn startup_rejects_database_path_that_is_a_directory() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let database_dir = tempdir.path().join("oracy.sqlite");
+    fs::create_dir(&database_dir).expect("create database dir");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+database_path = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display(),
+            database_dir.display()
+        ),
+    );
+
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("directory database path should fail");
+    assert!(error.to_string().contains("database path is a directory"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn startup_rejects_unwritable_database_parent_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Some(reason) = support::skip_reason_for_unwritable_directory_test() {
+        eprintln!("{reason}");
+        return;
+    }
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let database_parent = tempdir.path().join("database");
+    fs::create_dir(&database_parent).expect("create database parent");
+    let mut permissions = fs::metadata(&database_parent)
+        .expect("metadata")
+        .permissions();
+    permissions.set_mode(0o500);
+    fs::set_permissions(&database_parent, permissions).expect("chmod");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+database_path = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display(),
+            database_parent.join("oracy.sqlite").display()
+        ),
+    );
+
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("unwritable database parent should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("database parent directory is not writable")
+    );
+}
+
+#[tokio::test]
+async fn startup_creates_database_file_and_runs_migrations() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let database_path = tempdir.path().join("oracy.sqlite");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+database_path = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display(),
+            database_path.display()
+        ),
+    );
+
+    let (_, state) = load_runtime_from_path(&config_path)
+        .await
+        .expect("valid runtime");
+
+    assert!(database_path.exists());
+    let table_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'transcription_jobs'",
+    )
+    .fetch_one(state.storage.pool())
+    .await
+    .expect("query migrated schema");
+    assert_eq!(table_count, 1);
+}
+
+#[tokio::test]
+async fn startup_accepts_relative_accepted_audio_dir_resolved_against_config() {
     let tempdir = TempDir::new().expect("tempdir");
     let expected_dir = tempdir.path().join("accepted-audio");
     fs::create_dir(&expected_dir).expect("create accepted audio dir");
@@ -315,13 +493,15 @@ key = "key-one"
         .to_owned(),
     );
 
-    let (_, state) = load_runtime_from_path(&config_path).expect("relative path should resolve");
+    let (_, state) = load_runtime_from_path(&config_path)
+        .await
+        .expect("relative path should resolve");
 
     assert_eq!(state.accepted_audio_dir, expected_dir);
 }
 
-#[test]
-fn startup_rejects_relative_accepted_audio_dir_when_target_missing() {
+#[tokio::test]
+async fn startup_rejects_relative_accepted_audio_dir_when_target_missing() {
     let tempdir = TempDir::new().expect("tempdir");
     let expected_dir = tempdir.path().join("accepted-audio");
     let config_path = write_config(
@@ -336,8 +516,9 @@ key = "key-one"
         .to_owned(),
     );
 
-    let error =
-        load_runtime_from_path(&config_path).expect_err("missing relative path should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("missing relative path should fail");
 
     match error {
         BootstrapError::MissingAcceptedAudioDir(path) => assert_eq!(path, expected_dir),
@@ -346,8 +527,8 @@ key = "key-one"
 }
 
 #[cfg(unix)]
-#[test]
-fn startup_resolves_relative_accepted_audio_dir_through_config_symlink() {
+#[tokio::test]
+async fn startup_resolves_relative_accepted_audio_dir_through_config_symlink() {
     use std::os::unix::fs::symlink;
 
     let tempdir = TempDir::new().expect("tempdir");
@@ -365,6 +546,7 @@ fn startup_resolves_relative_accepted_audio_dir_through_config_symlink() {
         &real_config_path,
         r#"
 accepted_audio_dir = "../accepted-audio"
+database_path = "../oracy.sqlite"
 
 [[api_keys]]
 api_key_id = "alpha"
@@ -376,6 +558,7 @@ key = "key-one"
 
     let symlinked_config_path = symlink_config_dir.join("oracy.toml");
     let (_, state) = load_runtime_from_path(&symlinked_config_path)
+        .await
         .expect("relative path should resolve through symlink target");
 
     let expected_dir =
@@ -390,8 +573,8 @@ key = "key-one"
 }
 
 #[cfg(unix)]
-#[test]
-fn startup_resolves_relative_accepted_audio_dir_from_real_config_file() {
+#[tokio::test]
+async fn startup_resolves_relative_accepted_audio_dir_from_real_config_file() {
     use std::os::unix::fs::symlink;
 
     let tempdir = TempDir::new().expect("tempdir");
@@ -409,6 +592,7 @@ fn startup_resolves_relative_accepted_audio_dir_from_real_config_file() {
         &real_config_path,
         r#"
 accepted_audio_dir = "accepted-audio"
+database_path = "oracy.sqlite"
 
 [[api_keys]]
 api_key_id = "alpha"
@@ -422,14 +606,15 @@ key = "key-one"
     symlink(&real_config_path, &symlinked_config_path).expect("create config file symlink");
 
     let (_, state) = load_runtime_from_path(&symlinked_config_path)
+        .await
         .expect("relative path should resolve through real config file");
 
     assert_eq!(state.accepted_audio_dir, real_accepted_audio_dir);
     assert_ne!(state.accepted_audio_dir, decoy_accepted_audio_dir);
 }
 
-#[test]
-fn startup_rejects_when_accepted_audio_path_is_a_file() {
+#[tokio::test]
+async fn startup_rejects_when_accepted_audio_path_is_a_file() {
     let tempdir = TempDir::new().expect("tempdir");
     let file_path = tempdir.path().join("accepted-audio");
     fs::write(&file_path, "not a directory").expect("write file");
@@ -447,7 +632,9 @@ key = "key-one"
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("file path should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("file path should fail");
     assert!(
         error
             .to_string()
@@ -456,8 +643,8 @@ key = "key-one"
 }
 
 #[cfg(unix)]
-#[test]
-fn startup_rejects_unwritable_accepted_audio_directory() {
+#[tokio::test]
+async fn startup_rejects_unwritable_accepted_audio_directory() {
     use std::os::unix::fs::PermissionsExt;
 
     if let Some(reason) = support::skip_reason_for_unwritable_directory_test() {
@@ -486,7 +673,9 @@ key = "key-one"
         ),
     );
 
-    let error = load_runtime_from_path(&config_path).expect_err("unwritable dir should fail");
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("unwritable dir should fail");
     match error {
         BootstrapError::AcceptedAudioDirNotWritable { path, .. } => assert_eq!(path, audio_dir),
         other => panic!("expected unwritable accepted audio dir error, got {other}"),
@@ -494,6 +683,21 @@ key = "key-one"
 }
 
 fn write_config(tempdir: &TempDir, contents: String) -> std::path::PathBuf {
+    let path = tempdir.path().join("oracy.toml");
+    let mut contents = contents.trim_start().to_owned();
+    if !contents.contains("database_path") {
+        let database_path = tempdir.path().join("oracy.sqlite");
+        contents = contents.replacen(
+            '\n',
+            &format!("\ndatabase_path = \"{}\"\n", database_path.display()),
+            1,
+        );
+    }
+    fs::write(&path, contents).expect("write config");
+    path
+}
+
+fn write_config_without_database_path(tempdir: &TempDir, contents: String) -> std::path::PathBuf {
     let path = tempdir.path().join("oracy.toml");
     fs::write(&path, contents.trim_start()).expect("write config");
     path

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -287,6 +287,43 @@ async fn duplicate_completion_fails_without_orphaning_materialized_rows() {
 }
 
 #[tokio::test]
+async fn retry_waiting_jobs_are_not_eligible_for_transcript_completion() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    mark_job_retry_waiting(&storage, &job.id).await;
+
+    let error = storage
+        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .await
+        .expect_err("retry-waiting completion should fail");
+    assert!(matches!(
+        error,
+        StorageError::JobNotCompletable { job_id } if job_id == job.id
+    ));
+
+    let job = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(job.status, "retry_waiting");
+    assert_eq!(job.transcript_id, None);
+    assert_eq!(row_count(&storage, "transcripts", "transcript-a").await, 0);
+    assert_eq!(
+        child_row_count(&storage, "transcript_versions", "transcript-a").await,
+        0
+    );
+    assert_eq!(
+        child_row_count(&storage, "segments", "transcript-a").await,
+        0
+    );
+    assert_eq!(
+        child_row_count(&storage, "embeddings", "transcript-a").await,
+        0
+    );
+}
+
+#[tokio::test]
 async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
@@ -408,6 +445,22 @@ async fn mark_job_processing(storage: &Storage, job_id: &str) {
     .execute(storage.pool())
     .await
     .expect("mark job processing");
+    assert_eq!(result.rows_affected(), 1);
+}
+
+async fn mark_job_retry_waiting(storage: &Storage, job_id: &str) {
+    let result = sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET status = 'retry_waiting',
+            next_attempt_at = '2026-04-24T18:05:00Z'
+        WHERE api_key_id = 'owner-a' AND id = ?
+        "#,
+    )
+    .bind(job_id)
+    .execute(storage.pool())
+    .await
+    .expect("mark job retry waiting");
     assert_eq!(result.rows_affected(), 1);
 }
 

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -2,10 +2,12 @@ use std::path::PathBuf;
 
 use oracy_backend::storage::{
     AcceptJobOutcome, NewEmbedding, NewSegment, NewTranscript, NewTranscriptVersion,
-    NewTranscriptionJob, Storage, TranscriptMaterialization,
+    NewTranscriptionJob, Storage, StorageError, TranscriptMaterialization,
 };
+use sqlx::Row;
 use tempfile::TempDir;
 use time::macros::datetime;
+use tokio::time::{Duration, sleep};
 
 #[tokio::test]
 async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
@@ -53,6 +55,43 @@ async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
 }
 
 #[tokio::test]
+async fn racing_acceptance_resolves_unique_conflicts_as_replay_or_submission_conflict() {
+    let (_tempdir, storage) = storage().await;
+    let input = new_job("owner-a", "attempt-1", "hash-a");
+
+    let replayed = accept_while_uncommitted_row_exists(
+        &storage,
+        "racing-replay-job",
+        input.clone(),
+        input.clone(),
+    )
+    .await
+    .expect("racing replay should not return storage error");
+    assert!(matches!(
+        replayed,
+        AcceptJobOutcome::Replayed(job) if job.id == "racing-replay-job"
+    ));
+
+    let conflict = accept_while_uncommitted_row_exists(
+        &storage,
+        "racing-conflict-job",
+        new_job("owner-a", "attempt-2", "hash-a"),
+        new_job("owner-a", "attempt-2", "hash-b"),
+    )
+    .await
+    .expect("racing conflict should not return storage error");
+    assert_eq!(
+        conflict,
+        AcceptJobOutcome::Conflict(oracy_backend::storage::SubmissionConflict {
+            job_id: "racing-conflict-job".to_owned()
+        })
+    );
+
+    assert_eq!(job_count_by_key(&storage, "owner-a", "attempt-1").await, 1);
+    assert_eq!(job_count_by_key(&storage, "owner-a", "attempt-2").await, 1);
+}
+
+#[tokio::test]
 async fn accepted_submission_tuple_is_immutable_in_storage() {
     let (_tempdir, storage) = storage().await;
     let created = match storage
@@ -93,6 +132,7 @@ async fn accepted_submission_tuple_is_immutable_in_storage() {
 async fn transcript_materialization_is_transactional() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
+    mark_job_processing(&storage, &job.id).await;
     let mut materialization = materialization("transcript-a");
     materialization.segments[1].position = materialization.segments[0].position;
 
@@ -113,7 +153,7 @@ async fn transcript_materialization_is_transactional() {
         .await
         .expect("job lookup")
         .expect("job exists");
-    assert_eq!(job.status, "queued");
+    assert_eq!(job.status, "processing");
     assert_eq!(job.transcript_id, None);
 }
 
@@ -121,6 +161,7 @@ async fn transcript_materialization_is_transactional() {
 async fn completed_transcripts_expose_current_version_ordered_segments_and_current_embedding() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
+    mark_job_processing(&storage, &job.id).await;
     storage
         .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
         .await
@@ -204,9 +245,52 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
 }
 
 #[tokio::test]
+async fn duplicate_completion_fails_without_orphaning_materialized_rows() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    mark_job_processing(&storage, &job.id).await;
+
+    storage
+        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .await
+        .expect("first materialization succeeds");
+
+    let error = storage
+        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-b"))
+        .await
+        .expect_err("duplicate materialization should fail");
+    assert!(matches!(
+        error,
+        StorageError::JobNotCompletable { job_id } if job_id == job.id
+    ));
+
+    let job = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(job.status, "succeeded");
+    assert_eq!(job.transcript_id.as_deref(), Some("transcript-a"));
+    assert_eq!(row_count(&storage, "transcripts", "transcript-b").await, 0);
+    assert_eq!(
+        child_row_count(&storage, "transcript_versions", "transcript-b").await,
+        0
+    );
+    assert_eq!(
+        child_row_count(&storage, "segments", "transcript-b").await,
+        0
+    );
+    assert_eq!(
+        child_row_count(&storage, "embeddings", "transcript-b").await,
+        0
+    );
+}
+
+#[tokio::test]
 async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
+    mark_job_processing(&storage, &job.id).await;
     storage
         .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
         .await
@@ -273,6 +357,96 @@ async fn created_job(
     }
 }
 
+async fn accept_while_uncommitted_row_exists(
+    storage: &Storage,
+    existing_job_id: &str,
+    stored: NewTranscriptionJob,
+    attempted: NewTranscriptionJob,
+) -> Result<AcceptJobOutcome, oracy_backend::storage::StorageError> {
+    let mut tx = storage.pool().begin().await.expect("begin transaction");
+    sqlx::query(
+        r#"
+        INSERT INTO transcription_jobs (
+            id, api_key_id, idempotency_key, audio_sha256_hex, recorded_at,
+            session_id, language, accepted_audio_path, status, created_at,
+            updated_at, retry_count, max_retries
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?)
+        "#,
+    )
+    .bind(existing_job_id)
+    .bind(&stored.api_key_id)
+    .bind(&stored.idempotency_key)
+    .bind(&stored.audio_sha256_hex)
+    .bind("2026-04-24T17:59:00Z")
+    .bind(&stored.session_id)
+    .bind(&stored.language)
+    .bind(stored.accepted_audio_path.to_string_lossy().into_owned())
+    .bind("2026-04-24T18:00:00Z")
+    .bind("2026-04-24T18:00:00Z")
+    .bind(stored.max_retries)
+    .execute(&mut *tx)
+    .await
+    .expect("insert uncommitted accepted row");
+
+    let racing_storage = storage.clone();
+    let handle = tokio::spawn(async move { racing_storage.accept_job(attempted).await });
+    sleep(Duration::from_millis(100)).await;
+    tx.commit().await.expect("commit accepted row");
+    handle.await.expect("accept task should not panic")
+}
+
+async fn mark_job_processing(storage: &Storage, job_id: &str) {
+    let result = sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET status = 'processing'
+        WHERE api_key_id = 'owner-a' AND id = ?
+        "#,
+    )
+    .bind(job_id)
+    .execute(storage.pool())
+    .await
+    .expect("mark job processing");
+    assert_eq!(result.rows_affected(), 1);
+}
+
+async fn job_count_by_key(storage: &Storage, owner: &str, idempotency_key: &str) -> i64 {
+    sqlx::query(
+        r#"
+        SELECT COUNT(*) AS count
+        FROM transcription_jobs
+        WHERE api_key_id = ? AND idempotency_key = ?
+        "#,
+    )
+    .bind(owner)
+    .bind(idempotency_key)
+    .fetch_one(storage.pool())
+    .await
+    .expect("count jobs")
+    .get("count")
+}
+
+async fn row_count(storage: &Storage, table: &str, id: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) AS count FROM {table} WHERE id = ?");
+    sqlx::query(&sql)
+        .bind(id)
+        .fetch_one(storage.pool())
+        .await
+        .expect("count rows")
+        .get("count")
+}
+
+async fn child_row_count(storage: &Storage, table: &str, transcript_id: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) AS count FROM {table} WHERE transcript_id = ?");
+    sqlx::query(&sql)
+        .bind(transcript_id)
+        .fetch_one(storage.pool())
+        .await
+        .expect("count child rows")
+        .get("count")
+}
+
 fn new_job(owner: &str, idempotency_key: &str, hash: &str) -> NewTranscriptionJob {
     NewTranscriptionJob {
         api_key_id: owner.to_owned(),
@@ -303,20 +477,20 @@ fn materialization(transcript_id: &str) -> TranscriptMaterialization {
             session_id: Some("session-a".to_owned()),
         },
         initial_version: NewTranscriptVersion {
-            id: "version-1".to_owned(),
+            id: format!("{transcript_id}-version-1"),
             transcript: "initial text".to_owned(),
             created_at: datetime!(2026-04-24 18:00:30 UTC),
         },
         segments: vec![
             NewSegment {
-                id: "segment-1".to_owned(),
+                id: format!("{transcript_id}-segment-1"),
                 position: 0,
                 start_ms: 0,
                 end_ms: 1_000,
                 text: "first segment".to_owned(),
             },
             NewSegment {
-                id: "segment-2".to_owned(),
+                id: format!("{transcript_id}-segment-2"),
                 position: 1,
                 start_ms: 1_000,
                 end_ms: 2_000,

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -1,0 +1,332 @@
+use std::path::PathBuf;
+
+use oracy_backend::storage::{
+    AcceptJobOutcome, NewEmbedding, NewSegment, NewTranscript, NewTranscriptVersion,
+    NewTranscriptionJob, Storage, TranscriptMaterialization,
+};
+use tempfile::TempDir;
+use time::macros::datetime;
+
+#[tokio::test]
+async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
+    let (_tempdir, storage) = storage().await;
+    let input = new_job("owner-a", "attempt-1", "hash-a");
+
+    let created = match storage.accept_job(input.clone()).await.expect("accept job") {
+        AcceptJobOutcome::Created(job) => job,
+        other => panic!("expected created job, got {other:?}"),
+    };
+    assert_eq!(created.status, "queued");
+
+    let replayed = match storage.accept_job(input.clone()).await.expect("replay job") {
+        AcceptJobOutcome::Replayed(job) => job,
+        other => panic!("expected replayed job, got {other:?}"),
+    };
+    assert_eq!(replayed.id, created.id);
+
+    let different_owner = match storage
+        .accept_job(new_job("owner-b", "attempt-1", "hash-a"))
+        .await
+    {
+        Ok(AcceptJobOutcome::Created(job)) => job,
+        other => panic!("expected owner-isolated creation, got {other:?}"),
+    };
+    assert_ne!(different_owner.id, created.id);
+    assert!(
+        storage
+            .get_job("owner-b", &created.id)
+            .await
+            .expect("lookup")
+            .is_none()
+    );
+
+    let conflict = storage
+        .accept_job(new_job("owner-a", "attempt-1", "hash-b"))
+        .await
+        .expect("conflict outcome");
+    assert_eq!(
+        conflict,
+        AcceptJobOutcome::Conflict(oracy_backend::storage::SubmissionConflict {
+            job_id: created.id
+        })
+    );
+}
+
+#[tokio::test]
+async fn accepted_submission_tuple_is_immutable_in_storage() {
+    let (_tempdir, storage) = storage().await;
+    let created = match storage
+        .accept_job(new_job("owner-a", "attempt-1", "hash-a"))
+        .await
+        .expect("accept job")
+    {
+        AcceptJobOutcome::Created(job) => job,
+        other => panic!("expected created job, got {other:?}"),
+    };
+
+    let error = sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET recorded_at = '2026-04-25T00:00:00Z'
+        WHERE id = ?
+        "#,
+    )
+    .bind(&created.id)
+    .execute(storage.pool())
+    .await
+    .expect_err("accepted tuple update should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("accepted submission tuple is immutable")
+    );
+
+    let unchanged = storage
+        .get_job("owner-a", &created.id)
+        .await
+        .expect("lookup")
+        .expect("job exists");
+    assert_eq!(unchanged.recorded_at, created.recorded_at);
+}
+
+#[tokio::test]
+async fn transcript_materialization_is_transactional() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    let mut materialization = materialization("transcript-a");
+    materialization.segments[1].position = materialization.segments[0].position;
+
+    storage
+        .complete_job_with_transcript("owner-a", &job.id, materialization)
+        .await
+        .expect_err("duplicate segment position should fail");
+
+    assert!(
+        storage
+            .get_transcript("owner-a", "transcript-a")
+            .await
+            .expect("transcript lookup")
+            .is_none()
+    );
+    let job = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(job.status, "queued");
+    assert_eq!(job.transcript_id, None);
+}
+
+#[tokio::test]
+async fn completed_transcripts_expose_current_version_ordered_segments_and_current_embedding() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    storage
+        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .await
+        .expect("materialize transcript");
+
+    sqlx::query(
+        r#"
+        INSERT INTO transcript_versions (
+            id, api_key_id, transcript_id, version_number, transcript, created_at
+        )
+        VALUES ('version-2', 'owner-a', 'transcript-a', 2, 'edited text', '2026-04-24T18:01:00Z')
+        "#,
+    )
+    .execute(storage.pool())
+    .await
+    .expect("insert edited version");
+
+    let transcript = storage
+        .get_transcript("owner-a", "transcript-a")
+        .await
+        .expect("transcript lookup")
+        .expect("transcript exists");
+    assert_eq!(transcript.current_version_id, "version-2");
+    assert_eq!(transcript.transcript, "edited text");
+
+    let segments = storage
+        .list_segments("owner-a", "transcript-a")
+        .await
+        .expect("segments");
+    assert_eq!(
+        segments
+            .iter()
+            .map(|segment| (segment.position, segment.text.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(0, "first segment"), (1, "second segment")]
+    );
+
+    let initial_embedding = storage
+        .get_current_embedding("owner-a", "transcript-a")
+        .await
+        .expect("embedding lookup")
+        .expect("embedding exists");
+    assert_eq!(initial_embedding.vector, vec![1, 2, 3]);
+
+    assert!(
+        storage
+            .replace_current_embedding(
+                "owner-a",
+                "transcript-a",
+                NewEmbedding {
+                    model: "embedding-v2".to_owned(),
+                    vector: vec![4, 5, 6],
+                    created_at: datetime!(2026-04-24 18:02:00 UTC),
+                },
+            )
+            .await
+            .expect("replace embedding")
+    );
+    assert!(
+        !storage
+            .replace_current_embedding(
+                "owner-b",
+                "transcript-a",
+                NewEmbedding {
+                    model: "wrong-owner".to_owned(),
+                    vector: vec![9],
+                    created_at: datetime!(2026-04-24 18:03:00 UTC),
+                },
+            )
+            .await
+            .expect("wrong-owner replacement is ignored")
+    );
+
+    let replaced = storage
+        .get_current_embedding("owner-a", "transcript-a")
+        .await
+        .expect("embedding lookup")
+        .expect("embedding exists");
+    assert_eq!(replaced.model, "embedding-v2");
+    assert_eq!(replaced.vector, vec![4, 5, 6]);
+}
+
+#[tokio::test]
+async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    storage
+        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .await
+        .expect("materialize transcript");
+
+    assert!(
+        storage
+            .delete_transcript("owner-a", "transcript-a")
+            .await
+            .expect("delete transcript")
+    );
+    assert!(
+        storage
+            .get_transcript("owner-a", "transcript-a")
+            .await
+            .expect("transcript lookup")
+            .is_none()
+    );
+    assert!(
+        storage
+            .list_segments("owner-a", "transcript-a")
+            .await
+            .expect("segments")
+            .is_empty()
+    );
+    assert!(
+        storage
+            .get_current_embedding("owner-a", "transcript-a")
+            .await
+            .expect("embedding lookup")
+            .is_none()
+    );
+
+    let job = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job survives");
+    assert_eq!(job.status, "succeeded");
+    assert_eq!(job.transcript_id, None);
+}
+
+async fn storage() -> (TempDir, Storage) {
+    let tempdir = TempDir::new().expect("tempdir");
+    let database_path = tempdir.path().join("oracy.sqlite");
+    let storage = Storage::connect(&database_path)
+        .await
+        .expect("connect storage");
+    (tempdir, storage)
+}
+
+async fn created_job(
+    storage: &Storage,
+    owner: &str,
+    idempotency_key: &str,
+) -> oracy_backend::storage::TranscriptionJobRecord {
+    match storage
+        .accept_job(new_job(owner, idempotency_key, "hash-a"))
+        .await
+        .expect("accept job")
+    {
+        AcceptJobOutcome::Created(job) => job,
+        other => panic!("expected created job, got {other:?}"),
+    }
+}
+
+fn new_job(owner: &str, idempotency_key: &str, hash: &str) -> NewTranscriptionJob {
+    NewTranscriptionJob {
+        api_key_id: owner.to_owned(),
+        idempotency_key: idempotency_key.to_owned(),
+        audio_sha256_hex: hash.to_owned(),
+        recorded_at: datetime!(2026-04-24 17:59:00 UTC),
+        session_id: Some("session-a".to_owned()),
+        language: Some("en".to_owned()),
+        accepted_audio_path: PathBuf::from("/var/lib/oracy/accepted-audio/job-a"),
+        max_retries: 3,
+        now: datetime!(2026-04-24 18:00:00 UTC),
+    }
+}
+
+fn materialization(transcript_id: &str) -> TranscriptMaterialization {
+    TranscriptMaterialization {
+        transcript: NewTranscript {
+            id: transcript_id.to_owned(),
+            audio_duration_seconds: 12.5,
+            audio_format: "wav".to_owned(),
+            audio_size_bytes: 401_280,
+            transcript_language: Some("en".to_owned()),
+            model: "general-transcription-v1".to_owned(),
+            processing_time_ms: 1_843,
+            cost_cents: Some(1),
+            created_at: datetime!(2026-04-24 18:00:30 UTC),
+            recorded_at: datetime!(2026-04-24 17:59:00 UTC),
+            session_id: Some("session-a".to_owned()),
+        },
+        initial_version: NewTranscriptVersion {
+            id: "version-1".to_owned(),
+            transcript: "initial text".to_owned(),
+            created_at: datetime!(2026-04-24 18:00:30 UTC),
+        },
+        segments: vec![
+            NewSegment {
+                id: "segment-1".to_owned(),
+                position: 0,
+                start_ms: 0,
+                end_ms: 1_000,
+                text: "first segment".to_owned(),
+            },
+            NewSegment {
+                id: "segment-2".to_owned(),
+                position: 1,
+                start_ms: 1_000,
+                end_ms: 2_000,
+                text: "second segment".to_owned(),
+            },
+        ],
+        embedding: NewEmbedding {
+            model: "embedding-v1".to_owned(),
+            vector: vec![1, 2, 3],
+            created_at: datetime!(2026-04-24 18:00:31 UTC),
+        },
+    }
+}

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -6,6 +6,8 @@ use oracy_backend::storage::{
 };
 use sqlx::Row;
 use tempfile::TempDir;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 use time::macros::datetime;
 use tokio::time::{Duration, sleep};
 
@@ -324,6 +326,97 @@ async fn retry_waiting_jobs_are_not_eligible_for_transcript_completion() {
 }
 
 #[tokio::test]
+async fn persisted_timestamps_order_and_filter_chronologically_under_sql_text_comparisons() {
+    let (_tempdir, storage) = storage().await;
+    let cases = [
+        ("after-fraction", timestamp("2026-04-24T18:00:00.1Z")),
+        ("whole-second", timestamp("2026-04-24T18:00:00Z")),
+        (
+            "before-fraction",
+            timestamp("2026-04-24T17:59:59.999999999Z"),
+        ),
+        (
+            "after-nanosecond",
+            timestamp("2026-04-24T18:00:00.000000001Z"),
+        ),
+    ];
+
+    for (idempotency_key, now) in cases {
+        let mut input = new_job("owner-a", idempotency_key, idempotency_key);
+        input.now = now;
+        storage.accept_job(input).await.expect("accept job");
+    }
+
+    let ordered_keys: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT idempotency_key
+        FROM transcription_jobs
+        WHERE api_key_id = 'owner-a'
+        ORDER BY created_at ASC
+        "#,
+    )
+    .fetch_all(storage.pool())
+    .await
+    .expect("order jobs by stored timestamp");
+    assert_eq!(
+        ordered_keys,
+        vec![
+            "before-fraction",
+            "whole-second",
+            "after-nanosecond",
+            "after-fraction"
+        ]
+    );
+
+    let range_keys: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT idempotency_key
+        FROM transcription_jobs
+        WHERE api_key_id = 'owner-a'
+            AND created_at BETWEEN ? AND ?
+        ORDER BY created_at ASC
+        "#,
+    )
+    .bind("2026-04-24T18:00:00.000000000Z")
+    .bind("2026-04-24T18:00:00.100000000Z")
+    .fetch_all(storage.pool())
+    .await
+    .expect("filter jobs by stored timestamp range");
+    assert_eq!(
+        range_keys,
+        vec!["whole-second", "after-nanosecond", "after-fraction"]
+    );
+
+    let mut equivalent_whole = new_job("owner-a", "equivalent-whole", "equivalent-whole");
+    equivalent_whole.now = timestamp("2026-04-24T18:01:00Z");
+    storage
+        .accept_job(equivalent_whole)
+        .await
+        .expect("accept whole-second job");
+
+    let mut equivalent_fraction = new_job("owner-a", "equivalent-fraction", "equivalent-fraction");
+    equivalent_fraction.now = timestamp("2026-04-24T18:01:00.000000000Z");
+    storage
+        .accept_job(equivalent_fraction)
+        .await
+        .expect("accept equivalent fractional job");
+
+    let equivalent_values: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT created_at
+        FROM transcription_jobs
+        WHERE api_key_id = 'owner-a'
+            AND idempotency_key IN ('equivalent-whole', 'equivalent-fraction')
+        ORDER BY idempotency_key ASC
+        "#,
+    )
+    .fetch_all(storage.pool())
+    .await
+    .expect("read equivalent stored timestamps");
+    assert_eq!(equivalent_values[0], equivalent_values[1]);
+}
+
+#[tokio::test]
 async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
@@ -556,4 +649,8 @@ fn materialization(transcript_id: &str) -> TranscriptMaterialization {
             created_at: datetime!(2026-04-24 18:00:31 UTC),
         },
     }
+}
+
+fn timestamp(value: &str) -> OffsetDateTime {
+    OffsetDateTime::parse(value, &Rfc3339).expect("valid RFC3339 timestamp")
 }

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -463,6 +463,74 @@ async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
     assert_eq!(job.transcript_id, None);
 }
 
+#[tokio::test]
+async fn transcript_child_rows_must_match_the_parent_transcript_owner() {
+    let (_tempdir, storage) = storage().await;
+    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+
+    sqlx::query(
+        r#"
+        INSERT INTO transcript_versions (
+            id, api_key_id, transcript_id, version_number, transcript, created_at
+        )
+        VALUES (
+            'owner-mismatched-version', 'owner-b', 'transcript-a', 1,
+            'cross-owner version', '2026-04-24T18:00:30.000000000Z'
+        )
+        "#,
+    )
+    .execute(storage.pool())
+    .await
+    .expect_err("mismatched transcript version owner should fail");
+
+    sqlx::query(
+        r#"
+        INSERT INTO segments (
+            id, api_key_id, transcript_id, position, start_ms, end_ms, text
+        )
+        VALUES (
+            'owner-mismatched-segment', 'owner-b', 'transcript-a', 0, 0, 1000,
+            'cross-owner segment'
+        )
+        "#,
+    )
+    .execute(storage.pool())
+    .await
+    .expect_err("mismatched segment owner should fail");
+
+    sqlx::query(
+        r#"
+        INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+        VALUES (
+            'transcript-a', 'owner-b', 'embedding-v1', x'010203',
+            '2026-04-24T18:00:31.000000000Z'
+        )
+        "#,
+    )
+    .execute(storage.pool())
+    .await
+    .expect_err("mismatched embedding owner should fail");
+}
+
+#[tokio::test]
+async fn completed_job_transcript_link_must_match_the_job_owner() {
+    let (_tempdir, storage) = storage().await;
+    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    let job = created_job(&storage, "owner-b", "attempt-1").await;
+
+    sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET transcript_id = 'transcript-a'
+        WHERE id = ?
+        "#,
+    )
+    .bind(&job.id)
+    .execute(storage.pool())
+    .await
+    .expect_err("mismatched job transcript owner should fail");
+}
+
 async fn storage() -> (TempDir, Storage) {
     let tempdir = TempDir::new().expect("tempdir");
     let database_path = tempdir.path().join("oracy.sqlite");
@@ -524,6 +592,29 @@ async fn accept_while_uncommitted_row_exists(
     sleep(Duration::from_millis(100)).await;
     tx.commit().await.expect("commit accepted row");
     handle.await.expect("accept task should not panic")
+}
+
+async fn insert_transcript_only(storage: &Storage, owner: &str, transcript_id: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO transcripts (
+            id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+            transcript_language, model, processing_time_ms, cost_cents,
+            created_at, recorded_at, session_id
+        )
+        VALUES (
+            ?, ?, 12.5, 'wav', 401280, 'en', 'general-transcription-v1', 1843, 1,
+            '2026-04-24T18:00:30.000000000Z',
+            '2026-04-24T17:59:00.000000000Z',
+            'session-a'
+        )
+        "#,
+    )
+    .bind(transcript_id)
+    .bind(owner)
+    .execute(storage.pool())
+    .await
+    .expect("insert transcript");
 }
 
 async fn mark_job_processing(storage: &Storage, job_id: &str) {


### PR DESCRIPTION
## Summary

- Adds the SQLite-backed durable storage substrate for accepted transcription jobs and completed transcripts.
- Enforces owner scoping, immutable accepted submission tuples, current transcript version derivation, ordered segments, one current embedding, and succeeded-job nulling after transcript deletion.
- Makes `database_path` a required backend runtime setting and documents the operator-facing storage requirement.

## Changes

- Adds SQLx SQLite migrations and a `Storage` module for accepted job replay/conflict handling, transcript materialization, segment reads, current embedding replacement, and transcript deletion.
- Updates startup to resolve, validate, open, and migrate the configured database path before serving requests.
- Extends startup and storage tests around database prerequisites, ownership isolation, replay immutability, transactional rollback, segment ordering, embedding replacement, and delete/nulling invariants.
- Updates backend configuration docs and the changelog for the new durable substrate.

## GitHub Issue(s)

Closes #14

## Test plan

- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy -- -D warnings`
- `cd backend && cargo test`
