### PR TITLE
feat(metadata): establish durable tag and session substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add the durable backend SQLite substrate for accepted transcription jobs,
   transcript versions, ordered segments, current embeddings, owner scoping, and
   the required operator `database_path` setting.
+- Add the durable backend SQLite substrate for tags, sessions,
+  transcript-to-tag associations, transcript session membership, and metadata
+  deletion invariants.
 - Establish independent backend and frontend CI gates for v0.1.0 pull requests
   and pushes to `main`.
 - Add the initial Rust backend runtime with explicit startup validation for

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -145,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +963,7 @@ name = "oracy-backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "caseless",
  "serde",
  "serde_json",
  "sha2",
@@ -968,6 +978,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 axum = "0.8.9"
+caseless = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
@@ -16,6 +17,7 @@ toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ulid = "1.2.1"
+unicode-normalization = "0.1.25"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/backend/migrations/20260425010000_create_metadata_substrate.sql
+++ b/backend/migrations/20260425010000_create_metadata_substrate.sql
@@ -1,0 +1,71 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX sessions_owner_id_idx
+    ON sessions (api_key_id, id);
+
+CREATE INDEX sessions_list_idx
+    ON sessions (api_key_id, created_at DESC, id DESC);
+
+CREATE TABLE tags (
+    id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    name_folded TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE (api_key_id, name_folded)
+);
+
+CREATE UNIQUE INDEX tags_owner_id_idx
+    ON tags (api_key_id, id);
+
+CREATE INDEX tags_list_idx
+    ON tags (api_key_id, created_at DESC, id DESC);
+
+CREATE TABLE transcript_tags (
+    api_key_id TEXT NOT NULL,
+    transcript_id TEXT NOT NULL,
+    tag_id TEXT NOT NULL,
+    PRIMARY KEY (api_key_id, transcript_id, tag_id),
+    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (api_key_id, tag_id) REFERENCES tags(api_key_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX transcript_tags_tag_idx
+    ON transcript_tags (api_key_id, tag_id, transcript_id);
+
+CREATE TRIGGER transcripts_session_owner_insert
+BEFORE INSERT ON transcripts
+WHEN NEW.session_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'transcript session must belong to same owner')
+    WHERE NOT EXISTS (
+        SELECT 1 FROM sessions
+        WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
+    );
+END;
+
+CREATE TRIGGER transcripts_session_owner_update
+BEFORE UPDATE OF api_key_id, session_id ON transcripts
+WHEN NEW.session_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'transcript session must belong to same owner')
+    WHERE NOT EXISTS (
+        SELECT 1 FROM sessions
+        WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
+    );
+END;
+
+CREATE TRIGGER sessions_delete_null_transcripts
+AFTER DELETE ON sessions
+BEGIN
+    UPDATE transcripts
+    SET session_id = NULL
+    WHERE api_key_id = OLD.api_key_id AND session_id = OLD.id;
+END;

--- a/backend/migrations/20260425010000_create_metadata_substrate.sql
+++ b/backend/migrations/20260425010000_create_metadata_substrate.sql
@@ -40,6 +40,17 @@ CREATE TABLE transcript_tags (
 CREATE INDEX transcript_tags_tag_idx
     ON transcript_tags (api_key_id, tag_id, transcript_id);
 
+CREATE TRIGGER transcription_jobs_session_owner_insert
+BEFORE INSERT ON transcription_jobs
+WHEN NEW.session_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'job session must belong to same owner')
+    WHERE NOT EXISTS (
+        SELECT 1 FROM sessions
+        WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
+    );
+END;
+
 CREATE TRIGGER transcripts_session_owner_insert
 BEFORE INSERT ON transcripts
 WHEN NEW.session_id IS NOT NULL

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use caseless::Caseless;
 use sqlx::migrate::Migrator;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::{Row, SqlitePool};
@@ -9,6 +10,7 @@ use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use time::macros::format_description;
 use ulid::Ulid;
+use unicode_normalization::UnicodeNormalization;
 
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
 
@@ -817,6 +819,42 @@ impl Storage {
     ) -> Result<RenameTagOutcome, StorageError> {
         let mut tx = self.pool.begin().await?;
         let name_folded = fold_tag_name(name);
+        let update = sqlx::query(
+            r#"
+            UPDATE tags
+            SET name = ?, name_folded = ?
+            WHERE api_key_id = ? AND id = ?
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM tags AS existing
+                    WHERE existing.api_key_id = ?
+                        AND existing.name_folded = ?
+                        AND existing.id <> ?
+                )
+            RETURNING id, api_key_id, name, created_at
+            "#,
+        )
+        .bind(name)
+        .bind(&name_folded)
+        .bind(api_key_id)
+        .bind(tag_id)
+        .bind(api_key_id)
+        .bind(&name_folded)
+        .bind(tag_id)
+        .fetch_optional(&mut *tx)
+        .await;
+
+        match update {
+            Ok(Some(row)) => {
+                let tag = tag_from_row(row)?;
+                tx.commit().await?;
+                return Ok(RenameTagOutcome::Renamed(tag));
+            }
+            Ok(None) => {}
+            Err(sqlx::Error::Database(error)) if error.is_unique_violation() => {}
+            Err(error) => return Err(error.into()),
+        }
+
         let current: Option<String> = sqlx::query_scalar(
             r#"
             SELECT id
@@ -828,55 +866,13 @@ impl Storage {
         .bind(tag_id)
         .fetch_optional(&mut *tx)
         .await?;
-        if current.is_none() {
-            tx.commit().await?;
-            return Ok(RenameTagOutcome::NotFound);
-        }
 
-        let existing_id: Option<String> = sqlx::query_scalar(
-            r#"
-            SELECT id
-            FROM tags
-            WHERE api_key_id = ? AND name_folded = ?
-            "#,
-        )
-        .bind(api_key_id)
-        .bind(&name_folded)
-        .fetch_optional(&mut *tx)
-        .await?;
-        if existing_id.as_deref().is_some_and(|id| id != tag_id) {
-            tx.commit().await?;
-            return Ok(RenameTagOutcome::Conflict);
-        }
-
-        sqlx::query(
-            r#"
-            UPDATE tags
-            SET name = ?, name_folded = ?
-            WHERE api_key_id = ? AND id = ?
-            "#,
-        )
-        .bind(name)
-        .bind(&name_folded)
-        .bind(api_key_id)
-        .bind(tag_id)
-        .execute(&mut *tx)
-        .await?;
-
-        let row = sqlx::query(
-            r#"
-            SELECT id, api_key_id, name, created_at
-            FROM tags
-            WHERE api_key_id = ? AND id = ?
-            "#,
-        )
-        .bind(api_key_id)
-        .bind(tag_id)
-        .fetch_one(&mut *tx)
-        .await?;
-        let tag = tag_from_row(row)?;
         tx.commit().await?;
-        Ok(RenameTagOutcome::Renamed(tag))
+        if current.is_some() {
+            Ok(RenameTagOutcome::Conflict)
+        } else {
+            Ok(RenameTagOutcome::NotFound)
+        }
     }
 
     pub async fn replace_transcript_tags(
@@ -1035,7 +1031,7 @@ fn new_id() -> String {
 }
 
 fn fold_tag_name(value: &str) -> String {
-    value.to_lowercase()
+    value.chars().nfd().default_case_fold().nfd().collect()
 }
 
 fn format_timestamp(value: OffsetDateTime) -> Result<String, StorageError> {

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -62,6 +62,19 @@ pub enum AcceptJobOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CreateTagOutcome {
+    Created(TagRecord),
+    Existing(TagRecord),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenameTagOutcome {
+    Renamed(TagRecord),
+    NotFound,
+    Conflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmissionConflict {
     pub job_id: String,
 }
@@ -77,6 +90,22 @@ pub struct NewTranscriptionJob {
     pub accepted_audio_path: PathBuf,
     pub max_retries: i64,
     pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewTag {
+    pub id: String,
+    pub api_key_id: String,
+    pub name: String,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewSession {
+    pub id: String,
+    pub api_key_id: String,
+    pub name: String,
+    pub created_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -180,6 +209,22 @@ pub struct EmbeddingRecord {
     pub transcript_id: String,
     pub model: String,
     pub vector: Vec<u8>,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TagRecord {
+    pub id: String,
+    pub api_key_id: String,
+    pub name: String,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionRecord {
+    pub id: String,
+    pub api_key_id: String,
+    pub name: String,
     pub created_at: OffsetDateTime,
 }
 
@@ -581,6 +626,299 @@ impl Storage {
 
         Ok(result.rows_affected() > 0)
     }
+
+    pub async fn create_tag(&self, input: NewTag) -> Result<CreateTagOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let name_folded = fold_tag_name(&input.name);
+        let created_at = format_timestamp(input.created_at)?;
+        let result = sqlx::query(
+            r#"
+            INSERT INTO tags (id, api_key_id, name, name_folded, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(api_key_id, name_folded) DO NOTHING
+            "#,
+        )
+        .bind(&input.id)
+        .bind(&input.api_key_id)
+        .bind(&input.name)
+        .bind(&name_folded)
+        .bind(&created_at)
+        .execute(&mut *tx)
+        .await?;
+
+        let row = if result.rows_affected() == 1 {
+            sqlx::query(
+                r#"
+                SELECT id, api_key_id, name, created_at
+                FROM tags
+                WHERE api_key_id = ? AND id = ?
+                "#,
+            )
+            .bind(&input.api_key_id)
+            .bind(&input.id)
+            .fetch_one(&mut *tx)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                SELECT id, api_key_id, name, created_at
+                FROM tags
+                WHERE api_key_id = ? AND name_folded = ?
+                "#,
+            )
+            .bind(&input.api_key_id)
+            .bind(&name_folded)
+            .fetch_one(&mut *tx)
+            .await?
+        };
+        let tag = tag_from_row(row)?;
+        tx.commit().await?;
+
+        if result.rows_affected() == 1 {
+            Ok(CreateTagOutcome::Created(tag))
+        } else {
+            Ok(CreateTagOutcome::Existing(tag))
+        }
+    }
+
+    pub async fn create_session(&self, input: NewSession) -> Result<SessionRecord, StorageError> {
+        let created_at = format_timestamp(input.created_at)?;
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
+            r#"
+            INSERT INTO sessions (id, api_key_id, name, created_at)
+            VALUES (?, ?, ?, ?)
+            "#,
+        )
+        .bind(&input.id)
+        .bind(&input.api_key_id)
+        .bind(&input.name)
+        .bind(&created_at)
+        .execute(&mut *tx)
+        .await?;
+
+        let row = sqlx::query(
+            r#"
+            SELECT id, api_key_id, name, created_at
+            FROM sessions
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(&input.api_key_id)
+        .bind(&input.id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let session = session_from_row(row)?;
+        tx.commit().await?;
+        Ok(session)
+    }
+
+    pub async fn delete_session(
+        &self,
+        api_key_id: &str,
+        session_id: &str,
+    ) -> Result<bool, StorageError> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM sessions
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn delete_tag(&self, api_key_id: &str, tag_id: &str) -> Result<bool, StorageError> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM tags
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(tag_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn get_tag(
+        &self,
+        api_key_id: &str,
+        tag_id: &str,
+    ) -> Result<Option<TagRecord>, StorageError> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, api_key_id, name, created_at
+            FROM tags
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(tag_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(tag_from_row).transpose()
+    }
+
+    pub async fn rename_tag(
+        &self,
+        api_key_id: &str,
+        tag_id: &str,
+        name: &str,
+    ) -> Result<RenameTagOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let name_folded = fold_tag_name(name);
+        let existing_id: Option<String> = sqlx::query_scalar(
+            r#"
+            SELECT id
+            FROM tags
+            WHERE api_key_id = ? AND name_folded = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(&name_folded)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if existing_id.as_deref().is_some_and(|id| id != tag_id) {
+            tx.commit().await?;
+            return Ok(RenameTagOutcome::Conflict);
+        }
+
+        let result = sqlx::query(
+            r#"
+            UPDATE tags
+            SET name = ?, name_folded = ?
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(name)
+        .bind(&name_folded)
+        .bind(api_key_id)
+        .bind(tag_id)
+        .execute(&mut *tx)
+        .await?;
+        if result.rows_affected() == 0 {
+            tx.commit().await?;
+            return Ok(RenameTagOutcome::NotFound);
+        }
+
+        let row = sqlx::query(
+            r#"
+            SELECT id, api_key_id, name, created_at
+            FROM tags
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(tag_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let tag = tag_from_row(row)?;
+        tx.commit().await?;
+        Ok(RenameTagOutcome::Renamed(tag))
+    }
+
+    pub async fn replace_transcript_tags(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+        tag_ids: &[String],
+    ) -> Result<bool, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let transcript_exists: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT 1
+            FROM transcripts
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if transcript_exists.is_none() {
+            tx.commit().await?;
+            return Ok(false);
+        }
+
+        for tag_id in tag_ids {
+            let tag_exists: Option<i64> = sqlx::query_scalar(
+                r#"
+                SELECT 1
+                FROM tags
+                WHERE api_key_id = ? AND id = ?
+                "#,
+            )
+            .bind(api_key_id)
+            .bind(tag_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if tag_exists.is_none() {
+                tx.commit().await?;
+                return Ok(false);
+            }
+        }
+
+        sqlx::query(
+            r#"
+            DELETE FROM transcript_tags
+            WHERE api_key_id = ? AND transcript_id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .execute(&mut *tx)
+        .await?;
+
+        for tag_id in tag_ids {
+            sqlx::query(
+                r#"
+                INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+                VALUES (?, ?, ?)
+                "#,
+            )
+            .bind(api_key_id)
+            .bind(transcript_id)
+            .bind(tag_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    pub async fn list_transcript_tags(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+    ) -> Result<Vec<TagRecord>, StorageError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT tags.id, tags.api_key_id, tags.name, tags.created_at
+            FROM tags
+            JOIN transcript_tags
+                ON transcript_tags.api_key_id = tags.api_key_id
+                AND transcript_tags.tag_id = tags.id
+            WHERE transcript_tags.api_key_id = ?
+                AND transcript_tags.transcript_id = ?
+            ORDER BY tags.created_at DESC, tags.id DESC
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(tag_from_row).collect()
+    }
 }
 
 impl TranscriptionJobRecord {
@@ -633,6 +971,10 @@ fn validate_database_path(database_path: &Path) -> Result<(), StorageError> {
 
 fn new_id() -> String {
     Ulid::new().to_string()
+}
+
+fn fold_tag_name(value: &str) -> String {
+    value.to_lowercase()
 }
 
 fn format_timestamp(value: OffsetDateTime) -> Result<String, StorageError> {
@@ -712,6 +1054,24 @@ fn embedding_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EmbeddingRecord, S
         transcript_id: row.try_get("transcript_id")?,
         model: row.try_get("model")?,
         vector: row.try_get("vector")?,
+        created_at: parse_timestamp(row.try_get("created_at")?)?,
+    })
+}
+
+fn tag_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TagRecord, StorageError> {
+    Ok(TagRecord {
+        id: row.try_get("id")?,
+        api_key_id: row.try_get("api_key_id")?,
+        name: row.try_get("name")?,
+        created_at: parse_timestamp(row.try_get("created_at")?)?,
+    })
+}
+
+fn session_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SessionRecord, StorageError> {
+    Ok(SessionRecord {
+        id: row.try_get("id")?,
+        api_key_id: row.try_get("api_key_id")?,
+        name: row.try_get("name")?,
         created_at: parse_timestamp(row.try_get("created_at")?)?,
     })
 }

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use sqlx::migrate::Migrator;
@@ -59,6 +60,7 @@ pub enum AcceptJobOutcome {
     Created(TranscriptionJobRecord),
     Replayed(TranscriptionJobRecord),
     Conflict(SubmissionConflict),
+    SessionNotFound,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -72,6 +74,13 @@ pub enum RenameTagOutcome {
     Renamed(TagRecord),
     NotFound,
     Conflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplaceTranscriptTagsOutcome {
+    Replaced,
+    NotFound,
+    DuplicateTagIds,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -278,7 +287,12 @@ impl Storage {
                 session_id, language, accepted_audio_path, status, created_at,
                 updated_at, retry_count, max_retries
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?)
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?
+            WHERE ? IS NULL
+                OR EXISTS (
+                    SELECT 1 FROM sessions
+                    WHERE api_key_id = ? AND id = ?
+                )
             ON CONFLICT(api_key_id, idempotency_key) DO NOTHING
             "#,
         )
@@ -293,11 +307,14 @@ impl Storage {
         .bind(&now)
         .bind(&now)
         .bind(input.max_retries)
+        .bind(&input.session_id)
+        .bind(&input.api_key_id)
+        .bind(&input.session_id)
         .execute(&mut *tx)
         .await?;
 
-        let row = if result.rows_affected() == 1 {
-            sqlx::query(
+        let job = if result.rows_affected() == 1 {
+            let row = sqlx::query(
                 r#"
                 SELECT * FROM transcription_jobs
                 WHERE api_key_id = ? AND id = ?
@@ -306,9 +323,10 @@ impl Storage {
             .bind(&input.api_key_id)
             .bind(&id)
             .fetch_one(&mut *tx)
-            .await?
+            .await?;
+            job_from_row(row)?
         } else {
-            sqlx::query(
+            let row = sqlx::query(
                 r#"
                 SELECT * FROM transcription_jobs
                 WHERE api_key_id = ? AND idempotency_key = ?
@@ -316,10 +334,18 @@ impl Storage {
             )
             .bind(&input.api_key_id)
             .bind(&input.idempotency_key)
-            .fetch_one(&mut *tx)
+            .fetch_optional(&mut *tx)
             .await?
+            .map(job_from_row)
+            .transpose()?;
+            match row {
+                Some(job) => job,
+                None => {
+                    tx.commit().await?;
+                    return Ok(AcceptJobOutcome::SessionNotFound);
+                }
+            }
         };
-        let job = job_from_row(row)?;
         tx.commit().await?;
 
         if result.rows_affected() == 1 {
@@ -775,6 +801,22 @@ impl Storage {
     ) -> Result<RenameTagOutcome, StorageError> {
         let mut tx = self.pool.begin().await?;
         let name_folded = fold_tag_name(name);
+        let current: Option<String> = sqlx::query_scalar(
+            r#"
+            SELECT id
+            FROM tags
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(tag_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if current.is_none() {
+            tx.commit().await?;
+            return Ok(RenameTagOutcome::NotFound);
+        }
+
         let existing_id: Option<String> = sqlx::query_scalar(
             r#"
             SELECT id
@@ -791,7 +833,7 @@ impl Storage {
             return Ok(RenameTagOutcome::Conflict);
         }
 
-        let result = sqlx::query(
+        sqlx::query(
             r#"
             UPDATE tags
             SET name = ?, name_folded = ?
@@ -804,10 +846,6 @@ impl Storage {
         .bind(tag_id)
         .execute(&mut *tx)
         .await?;
-        if result.rows_affected() == 0 {
-            tx.commit().await?;
-            return Ok(RenameTagOutcome::NotFound);
-        }
 
         let row = sqlx::query(
             r#"
@@ -830,7 +868,14 @@ impl Storage {
         api_key_id: &str,
         transcript_id: &str,
         tag_ids: &[String],
-    ) -> Result<bool, StorageError> {
+    ) -> Result<ReplaceTranscriptTagsOutcome, StorageError> {
+        let mut seen = HashSet::with_capacity(tag_ids.len());
+        for tag_id in tag_ids {
+            if !seen.insert(tag_id) {
+                return Ok(ReplaceTranscriptTagsOutcome::DuplicateTagIds);
+            }
+        }
+
         let mut tx = self.pool.begin().await?;
         let transcript_exists: Option<i64> = sqlx::query_scalar(
             r#"
@@ -845,7 +890,7 @@ impl Storage {
         .await?;
         if transcript_exists.is_none() {
             tx.commit().await?;
-            return Ok(false);
+            return Ok(ReplaceTranscriptTagsOutcome::NotFound);
         }
 
         for tag_id in tag_ids {
@@ -862,7 +907,7 @@ impl Storage {
             .await?;
             if tag_exists.is_none() {
                 tx.commit().await?;
-                return Ok(false);
+                return Ok(ReplaceTranscriptTagsOutcome::NotFound);
             }
         }
 
@@ -892,7 +937,7 @@ impl Storage {
         }
 
         tx.commit().await?;
-        Ok(true)
+        Ok(ReplaceTranscriptTagsOutcome::Replaced)
     }
 
     pub async fn list_transcript_tags(

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -159,7 +159,6 @@ pub struct NewTranscript {
     pub cost_cents: Option<i64>,
     pub created_at: OffsetDateTime,
     pub recorded_at: OffsetDateTime,
-    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -429,6 +428,23 @@ impl Storage {
             });
         }
 
+        let transcript_session_id: Option<String> = sqlx::query(
+            r#"
+            SELECT sessions.id AS transcript_session_id
+            FROM transcription_jobs
+            LEFT JOIN sessions
+                ON sessions.api_key_id = transcription_jobs.api_key_id
+                AND sessions.id = transcription_jobs.session_id
+            WHERE transcription_jobs.api_key_id = ?
+                AND transcription_jobs.id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_one(&mut *tx)
+        .await?
+        .try_get("transcript_session_id")?;
+
         sqlx::query(
             r#"
             INSERT INTO transcripts (
@@ -450,7 +466,7 @@ impl Storage {
         .bind(transcript.cost_cents)
         .bind(&now)
         .bind(format_timestamp(transcript.recorded_at)?)
-        .bind(&transcript.session_id)
+        .bind(&transcript_session_id)
         .execute(&mut *tx)
         .await?;
 

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -761,6 +761,54 @@ async fn transcript_tag_replacement_collapses_missing_transcript_and_tag_to_not_
 }
 
 #[tokio::test]
+async fn complete_job_with_transcript_nulls_deleted_accepted_session_without_mutating_job_tuple() {
+    let (_tempdir, storage) = storage().await;
+    let input = new_job("owner-a", "attempt-deleted-session", "hash-a");
+    let job = created_job(&storage, "owner-a", "attempt-deleted-session").await;
+    mark_job_processing(&storage, &job.id).await;
+
+    assert!(
+        storage
+            .delete_session("owner-a", "session-a")
+            .await
+            .expect("delete session")
+    );
+
+    storage
+        .complete_job_with_transcript(
+            "owner-a",
+            &job.id,
+            materialization("transcript-deleted-session"),
+        )
+        .await
+        .expect("materialize transcript after session deletion");
+
+    assert_eq!(
+        storage
+            .get_transcript("owner-a", "transcript-deleted-session")
+            .await
+            .expect("transcript lookup")
+            .expect("transcript exists")
+            .session_id,
+        None
+    );
+
+    let completed_job = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(completed_job.session_id.as_deref(), Some("session-a"));
+
+    let replayed = match storage.accept_job(input).await.expect("replay job") {
+        AcceptJobOutcome::Replayed(job) => job,
+        other => panic!("expected replayed job, got {other:?}"),
+    };
+    assert_eq!(replayed.id, job.id);
+    assert_eq!(replayed.session_id.as_deref(), Some("session-a"));
+}
+
+#[tokio::test]
 async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_tuples() {
     let (_tempdir, storage) = storage().await;
     let session = storage
@@ -1144,7 +1192,6 @@ fn materialization(transcript_id: &str) -> TranscriptMaterialization {
             cost_cents: Some(1),
             created_at: datetime!(2026-04-24 18:00:30 UTC),
             recorded_at: datetime!(2026-04-24 17:59:00 UTC),
-            session_id: Some("session-a".to_owned()),
         },
         initial_version: NewTranscriptVersion {
             id: format!("{transcript_id}-version-1"),

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use oracy_backend::storage::{
     AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewSegment, NewSession, NewTag,
@@ -10,6 +11,7 @@ use tempfile::TempDir;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use time::macros::datetime;
+use tokio::sync::Barrier;
 use tokio::time::{Duration, sleep};
 
 #[tokio::test]
@@ -685,6 +687,37 @@ async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcript
 }
 
 #[tokio::test]
+async fn unicode_case_equivalent_tag_names_share_one_owner_scoped_identity() {
+    let (_tempdir, storage) = storage().await;
+
+    for (created_name, replayed_name, created_id, replayed_id) in [
+        ("Straße", "STRASSE", "tag-strasse-a", "tag-strasse-b"),
+        ("Teſt", "test", "tag-long-s-a", "tag-long-s-b"),
+    ] {
+        let created = match storage
+            .create_tag(new_tag("owner-a", created_id, created_name))
+            .await
+            .expect("create unicode tag")
+        {
+            CreateTagOutcome::Created(tag) => tag,
+            other => panic!("expected created tag, got {other:?}"),
+        };
+
+        let replayed = match storage
+            .create_tag(new_tag("owner-a", replayed_id, replayed_name))
+            .await
+            .expect("reuse unicode case-equivalent tag")
+        {
+            CreateTagOutcome::Existing(tag) => tag,
+            other => panic!("expected existing tag, got {other:?}"),
+        };
+
+        assert_eq!(replayed.id, created.id);
+        assert_eq!(replayed.name, created_name);
+    }
+}
+
+#[tokio::test]
 async fn duplicate_transcript_tag_ids_are_rejected_without_mutating_prior_tags() {
     let (_tempdir, storage) = storage().await;
     insert_transcript_only(&storage, "owner-a", "transcript-a").await;
@@ -937,6 +970,122 @@ async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collis
             .name,
         "Notes"
     );
+}
+
+#[tokio::test]
+async fn unicode_case_equivalent_tag_rename_targets_conflict() {
+    let (_tempdir, storage) = storage().await;
+    let strasse = match storage
+        .create_tag(new_tag("owner-a", "tag-strasse", "Straße"))
+        .await
+        .expect("create unicode tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+    let notes = match storage
+        .create_tag(new_tag("owner-a", "tag-notes", "Notes"))
+        .await
+        .expect("create notes tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+
+    assert_eq!(
+        storage
+            .rename_tag("owner-a", &notes.id, "STRASSE")
+            .await
+            .expect("unicode conflicting rename"),
+        RenameTagOutcome::Conflict
+    );
+    assert_eq!(
+        storage
+            .get_tag("owner-a", &strasse.id)
+            .await
+            .expect("tag lookup")
+            .expect("unicode tag exists")
+            .name,
+        "Straße"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_tag_renames_to_one_unused_case_folded_name_return_success_and_conflict() {
+    let (_tempdir, storage) = storage().await;
+
+    for iteration in 0..25 {
+        let alpha = match storage
+            .create_tag(new_tag(
+                "owner-a",
+                &format!("tag-alpha-{iteration}"),
+                &format!("Alpha {iteration}"),
+            ))
+            .await
+            .expect("create alpha tag")
+        {
+            CreateTagOutcome::Created(tag) => tag,
+            other => panic!("expected created tag, got {other:?}"),
+        };
+        let beta = match storage
+            .create_tag(new_tag(
+                "owner-a",
+                &format!("tag-beta-{iteration}"),
+                &format!("Beta {iteration}"),
+            ))
+            .await
+            .expect("create beta tag")
+        {
+            CreateTagOutcome::Created(tag) => tag,
+            other => panic!("expected created tag, got {other:?}"),
+        };
+
+        let barrier = Arc::new(Barrier::new(3));
+        let alpha_storage = storage.clone();
+        let alpha_barrier = Arc::clone(&barrier);
+        let alpha_id = alpha.id.clone();
+        let alpha_handle = tokio::spawn(async move {
+            alpha_barrier.wait().await;
+            alpha_storage
+                .rename_tag("owner-a", &alpha_id, &format!("Shared {iteration}"))
+                .await
+        });
+
+        let beta_storage = storage.clone();
+        let beta_barrier = Arc::clone(&barrier);
+        let beta_id = beta.id.clone();
+        let beta_handle = tokio::spawn(async move {
+            beta_barrier.wait().await;
+            beta_storage
+                .rename_tag("owner-a", &beta_id, &format!("SHARED {iteration}"))
+                .await
+        });
+
+        barrier.wait().await;
+        let outcomes = [
+            alpha_handle
+                .await
+                .expect("alpha rename task should not panic"),
+            beta_handle
+                .await
+                .expect("beta rename task should not panic"),
+        ];
+
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, Ok(RenameTagOutcome::Renamed(_))))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, Ok(RenameTagOutcome::Conflict)))
+                .count(),
+            1
+        );
+    }
 }
 
 #[tokio::test]

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use oracy_backend::storage::{
     AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewSegment, NewSession, NewTag,
-    NewTranscript, NewTranscriptVersion, NewTranscriptionJob, RenameTagOutcome, Storage,
-    StorageError, TranscriptMaterialization,
+    NewTranscript, NewTranscriptVersion, NewTranscriptionJob, RenameTagOutcome,
+    ReplaceTranscriptTagsOutcome, Storage, StorageError, TranscriptMaterialization,
 };
 use sqlx::Row;
 use tempfile::TempDir;
@@ -15,6 +15,8 @@ use tokio::time::{Duration, sleep};
 #[tokio::test]
 async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
     let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-a", "session-a").await;
+    insert_session_row(&storage, "owner-b", "session-b").await;
     let input = new_job("owner-a", "attempt-1", "hash-a");
 
     let created = match storage.accept_job(input.clone()).await.expect("accept job") {
@@ -29,10 +31,9 @@ async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
     };
     assert_eq!(replayed.id, created.id);
 
-    let different_owner = match storage
-        .accept_job(new_job("owner-b", "attempt-1", "hash-a"))
-        .await
-    {
+    let mut owner_b_input = new_job("owner-b", "attempt-1", "hash-a");
+    owner_b_input.session_id = Some("session-b".to_owned());
+    let different_owner = match storage.accept_job(owner_b_input).await {
         Ok(AcceptJobOutcome::Created(job)) => job,
         other => panic!("expected owner-isolated creation, got {other:?}"),
     };
@@ -58,8 +59,74 @@ async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
 }
 
 #[tokio::test]
+async fn new_jobs_reject_missing_session_at_acceptance() {
+    let (_tempdir, storage) = storage().await;
+
+    let outcome = storage
+        .accept_job(new_job("owner-a", "attempt-missing-session", "hash-a"))
+        .await
+        .expect("session validation outcome");
+
+    assert_eq!(outcome, AcceptJobOutcome::SessionNotFound);
+    assert_eq!(
+        job_count_by_key(&storage, "owner-a", "attempt-missing-session").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn new_jobs_reject_other_owner_session_at_acceptance() {
+    let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-b", "session-a").await;
+
+    let outcome = storage
+        .accept_job(new_job("owner-a", "attempt-other-owner-session", "hash-a"))
+        .await
+        .expect("session validation outcome");
+
+    assert_eq!(outcome, AcceptJobOutcome::SessionNotFound);
+    assert_eq!(
+        job_count_by_key(&storage, "owner-a", "attempt-other-owner-session").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn raw_job_rows_must_reference_owner_scoped_sessions() {
+    let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-b", "session-a").await;
+
+    let error = sqlx::query(
+        r#"
+        INSERT INTO transcription_jobs (
+            id, api_key_id, idempotency_key, audio_sha256_hex, recorded_at,
+            session_id, language, accepted_audio_path, status, created_at,
+            updated_at, retry_count, max_retries
+        )
+        VALUES (
+            'job-invalid-session', 'owner-a', 'attempt-invalid-session',
+            'hash-a', '2026-04-24T17:59:00.000000000Z', 'session-a', 'en',
+            '/var/lib/oracy/accepted-audio/job-invalid-session', 'queued',
+            '2026-04-24T18:00:00.000000000Z',
+            '2026-04-24T18:00:00.000000000Z', 0, 3
+        )
+        "#,
+    )
+    .execute(storage.pool())
+    .await
+    .expect_err("mismatched job session owner should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("job session must belong to same owner")
+    );
+}
+
+#[tokio::test]
 async fn racing_acceptance_resolves_unique_conflicts_as_replay_or_submission_conflict() {
     let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-a", "session-a").await;
     let input = new_job("owner-a", "attempt-1", "hash-a");
 
     let replayed = accept_while_uncommitted_row_exists(
@@ -97,6 +164,7 @@ async fn racing_acceptance_resolves_unique_conflicts_as_replay_or_submission_con
 #[tokio::test]
 async fn accepted_submission_tuple_is_immutable_in_storage() {
     let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-a", "session-a").await;
     let created = match storage
         .accept_job(new_job("owner-a", "attempt-1", "hash-a"))
         .await
@@ -329,6 +397,7 @@ async fn retry_waiting_jobs_are_not_eligible_for_transcript_completion() {
 #[tokio::test]
 async fn persisted_timestamps_order_and_filter_chronologically_under_sql_text_comparisons() {
     let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-a", "session-a").await;
     let cases = [
         ("after-fraction", timestamp("2026-04-24T18:00:00.1Z")),
         ("whole-second", timestamp("2026-04-24T18:00:00Z")),
@@ -568,23 +637,26 @@ async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcript
     };
     assert_ne!(other_owner.id, meeting.id);
 
-    assert!(
+    assert_eq!(
         storage
             .replace_transcript_tags("owner-a", "transcript-a", &[meeting.id.clone()])
             .await
-            .expect("tag transcript")
+            .expect("tag transcript"),
+        ReplaceTranscriptTagsOutcome::Replaced
     );
-    assert!(
+    assert_eq!(
         storage
             .replace_transcript_tags("owner-a", "transcript-b", &[meeting.id.clone()])
             .await
-            .expect("tag second transcript")
+            .expect("tag second transcript"),
+        ReplaceTranscriptTagsOutcome::Replaced
     );
-    assert!(
-        !storage
+    assert_eq!(
+        storage
             .replace_transcript_tags("owner-b", "transcript-c", &[meeting.id.clone()])
             .await
-            .expect("wrong-owner tag is rejected")
+            .expect("wrong-owner tag is rejected"),
+        ReplaceTranscriptTagsOutcome::NotFound
     );
 
     assert_eq!(
@@ -610,6 +682,82 @@ async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcript
     );
     assert_eq!(row_count(&storage, "transcripts", "transcript-a").await, 1);
     assert_eq!(row_count(&storage, "transcripts", "transcript-b").await, 1);
+}
+
+#[tokio::test]
+async fn duplicate_transcript_tag_ids_are_rejected_without_mutating_prior_tags() {
+    let (_tempdir, storage) = storage().await;
+    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    let meeting = match storage
+        .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
+        .await
+        .expect("create meeting tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+    let notes = match storage
+        .create_tag(new_tag("owner-a", "tag-notes", "Notes"))
+        .await
+        .expect("create notes tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+    assert_eq!(
+        storage
+            .replace_transcript_tags("owner-a", "transcript-a", &[notes.id.clone()])
+            .await
+            .expect("set prior tag"),
+        ReplaceTranscriptTagsOutcome::Replaced
+    );
+
+    let outcome = storage
+        .replace_transcript_tags(
+            "owner-a",
+            "transcript-a",
+            &[meeting.id.clone(), meeting.id.clone()],
+        )
+        .await
+        .expect("duplicate-input outcome");
+
+    assert_eq!(outcome, ReplaceTranscriptTagsOutcome::DuplicateTagIds);
+    assert_eq!(
+        storage
+            .list_transcript_tags("owner-a", "transcript-a")
+            .await
+            .expect("list transcript tags"),
+        vec![notes]
+    );
+}
+
+#[tokio::test]
+async fn transcript_tag_replacement_collapses_missing_transcript_and_tag_to_not_found() {
+    let (_tempdir, storage) = storage().await;
+    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    let meeting = match storage
+        .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
+        .await
+        .expect("create meeting tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+
+    assert_eq!(
+        storage
+            .replace_transcript_tags("owner-a", "transcript-missing", &[meeting.id])
+            .await
+            .expect("missing transcript outcome"),
+        ReplaceTranscriptTagsOutcome::NotFound
+    );
+    assert_eq!(
+        storage
+            .replace_transcript_tags("owner-a", "transcript-a", &["tag-missing".to_owned()])
+            .await
+            .expect("missing tag outcome"),
+        ReplaceTranscriptTagsOutcome::NotFound
+    );
 }
 
 #[tokio::test]
@@ -741,6 +889,46 @@ async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collis
             .name,
         "Notes"
     );
+}
+
+#[tokio::test]
+async fn missing_tag_rename_returns_not_found_before_name_conflict() {
+    let (_tempdir, storage) = storage().await;
+    storage
+        .create_tag(new_tag("owner-a", "tag-notes", "Notes"))
+        .await
+        .expect("create notes tag");
+
+    let outcome = storage
+        .rename_tag("owner-a", "tag-missing", "notes")
+        .await
+        .expect("rename missing tag");
+
+    assert_eq!(outcome, RenameTagOutcome::NotFound);
+}
+
+#[tokio::test]
+async fn other_owner_tag_rename_returns_not_found_before_name_conflict() {
+    let (_tempdir, storage) = storage().await;
+    storage
+        .create_tag(new_tag("owner-a", "tag-notes", "Notes"))
+        .await
+        .expect("create notes tag");
+    let other_owner = match storage
+        .create_tag(new_tag("owner-b", "tag-other-owner", "Other"))
+        .await
+        .expect("create other-owner tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+
+    let outcome = storage
+        .rename_tag("owner-a", &other_owner.id, "notes")
+        .await
+        .expect("rename other-owner tag");
+
+    assert_eq!(outcome, RenameTagOutcome::NotFound);
 }
 
 async fn storage() -> (TempDir, Storage) {

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use oracy_backend::storage::{
-    AcceptJobOutcome, NewEmbedding, NewSegment, NewTranscript, NewTranscriptVersion,
-    NewTranscriptionJob, Storage, StorageError, TranscriptMaterialization,
+    AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewSegment, NewSession, NewTag,
+    NewTranscript, NewTranscriptVersion, NewTranscriptionJob, RenameTagOutcome, Storage,
+    StorageError, TranscriptMaterialization,
 };
 use sqlx::Row;
 use tempfile::TempDir;
@@ -531,6 +532,217 @@ async fn completed_job_transcript_link_must_match_the_job_owner() {
     .expect_err("mismatched job transcript owner should fail");
 }
 
+#[tokio::test]
+async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcripts() {
+    let (_tempdir, storage) = storage().await;
+    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_transcript_only(&storage, "owner-a", "transcript-b").await;
+    insert_transcript_only(&storage, "owner-b", "transcript-c").await;
+
+    let meeting = match storage
+        .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
+        .await
+        .expect("create tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+    let replayed = match storage
+        .create_tag(new_tag("owner-a", "tag-meeting-lower", "meeting"))
+        .await
+        .expect("reuse case-insensitive tag")
+    {
+        CreateTagOutcome::Existing(tag) => tag,
+        other => panic!("expected existing tag, got {other:?}"),
+    };
+    assert_eq!(replayed.id, meeting.id);
+    assert_eq!(replayed.name, "Meeting");
+
+    let other_owner = match storage
+        .create_tag(new_tag("owner-b", "tag-meeting-owner-b", "meeting"))
+        .await
+        .expect("create owner-isolated tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected owner-isolated tag, got {other:?}"),
+    };
+    assert_ne!(other_owner.id, meeting.id);
+
+    assert!(
+        storage
+            .replace_transcript_tags("owner-a", "transcript-a", &[meeting.id.clone()])
+            .await
+            .expect("tag transcript")
+    );
+    assert!(
+        storage
+            .replace_transcript_tags("owner-a", "transcript-b", &[meeting.id.clone()])
+            .await
+            .expect("tag second transcript")
+    );
+    assert!(
+        !storage
+            .replace_transcript_tags("owner-b", "transcript-c", &[meeting.id.clone()])
+            .await
+            .expect("wrong-owner tag is rejected")
+    );
+
+    assert_eq!(
+        storage
+            .list_transcript_tags("owner-a", "transcript-a")
+            .await
+            .expect("list transcript tags"),
+        vec![meeting.clone()]
+    );
+
+    assert!(
+        storage
+            .delete_tag("owner-a", &meeting.id)
+            .await
+            .expect("delete tag")
+    );
+    assert!(
+        storage
+            .list_transcript_tags("owner-a", "transcript-a")
+            .await
+            .expect("tag associations removed")
+            .is_empty()
+    );
+    assert_eq!(row_count(&storage, "transcripts", "transcript-a").await, 1);
+    assert_eq!(row_count(&storage, "transcripts", "transcript-b").await, 1);
+}
+
+#[tokio::test]
+async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_tuples() {
+    let (_tempdir, storage) = storage().await;
+    let session = storage
+        .create_session(new_session("owner-a", "session-a", "Planning"))
+        .await
+        .expect("create session");
+    let same_name = storage
+        .create_session(new_session("owner-a", "session-b", "Planning"))
+        .await
+        .expect("create same-name session");
+    assert_ne!(same_name.id, session.id);
+    assert_eq!(same_name.name, session.name);
+
+    let input = new_job("owner-a", "attempt-session", "hash-session");
+    let job = match storage.accept_job(input.clone()).await.expect("accept job") {
+        AcceptJobOutcome::Created(job) => job,
+        other => panic!("expected created job, got {other:?}"),
+    };
+    mark_job_processing(&storage, &job.id).await;
+    storage
+        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-session"))
+        .await
+        .expect("materialize transcript");
+
+    assert_eq!(
+        storage
+            .get_transcript("owner-a", "transcript-session")
+            .await
+            .expect("transcript lookup")
+            .expect("transcript exists")
+            .session_id
+            .as_deref(),
+        Some("session-a")
+    );
+
+    assert!(
+        storage
+            .delete_session("owner-a", "session-a")
+            .await
+            .expect("delete session")
+    );
+    assert_eq!(
+        storage
+            .get_transcript("owner-a", "transcript-session")
+            .await
+            .expect("transcript lookup")
+            .expect("transcript exists")
+            .session_id,
+        None
+    );
+
+    let job_after_delete = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(job_after_delete.session_id.as_deref(), Some("session-a"));
+
+    let replayed = match storage.accept_job(input).await.expect("replay job") {
+        AcceptJobOutcome::Replayed(job) => job,
+        other => panic!("expected replayed job, got {other:?}"),
+    };
+    assert_eq!(replayed.id, job.id);
+    assert_eq!(replayed.session_id.as_deref(), Some("session-a"));
+}
+
+#[tokio::test]
+async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collisions() {
+    let (_tempdir, storage) = storage().await;
+    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    let meeting = match storage
+        .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
+        .await
+        .expect("create meeting tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+    let notes = match storage
+        .create_tag(new_tag("owner-a", "tag-notes", "Notes"))
+        .await
+        .expect("create notes tag")
+    {
+        CreateTagOutcome::Created(tag) => tag,
+        other => panic!("expected created tag, got {other:?}"),
+    };
+    storage
+        .replace_transcript_tags("owner-a", "transcript-a", &[meeting.id.clone()])
+        .await
+        .expect("tag transcript");
+
+    let renamed = match storage
+        .rename_tag("owner-a", &meeting.id, "MEETING")
+        .await
+        .expect("rename tag")
+    {
+        RenameTagOutcome::Renamed(tag) => tag,
+        other => panic!("expected renamed tag, got {other:?}"),
+    };
+    assert_eq!(renamed.id, meeting.id);
+    assert_eq!(renamed.name, "MEETING");
+    assert_eq!(
+        storage
+            .list_transcript_tags("owner-a", "transcript-a")
+            .await
+            .expect("list transcript tags")
+            .first()
+            .expect("tag exists")
+            .name,
+        "MEETING"
+    );
+
+    assert_eq!(
+        storage
+            .rename_tag("owner-a", &meeting.id, "notes")
+            .await
+            .expect("conflicting rename"),
+        RenameTagOutcome::Conflict
+    );
+    assert_eq!(
+        storage
+            .get_tag("owner-a", &notes.id)
+            .await
+            .expect("tag lookup")
+            .expect("notes tag exists")
+            .name,
+        "Notes"
+    );
+}
+
 async fn storage() -> (TempDir, Storage) {
     let tempdir = TempDir::new().expect("tempdir");
     let database_path = tempdir.path().join("oracy.sqlite");
@@ -545,6 +757,7 @@ async fn created_job(
     owner: &str,
     idempotency_key: &str,
 ) -> oracy_backend::storage::TranscriptionJobRecord {
+    insert_session_row(storage, owner, "session-a").await;
     match storage
         .accept_job(new_job(owner, idempotency_key, "hash-a"))
         .await
@@ -606,7 +819,7 @@ async fn insert_transcript_only(storage: &Storage, owner: &str, transcript_id: &
             ?, ?, 12.5, 'wav', 401280, 'en', 'general-transcription-v1', 1843, 1,
             '2026-04-24T18:00:30.000000000Z',
             '2026-04-24T17:59:00.000000000Z',
-            'session-a'
+            NULL
         )
         "#,
     )
@@ -615,6 +828,20 @@ async fn insert_transcript_only(storage: &Storage, owner: &str, transcript_id: &
     .execute(storage.pool())
     .await
     .expect("insert transcript");
+}
+
+async fn insert_session_row(storage: &Storage, owner: &str, session_id: &str) {
+    sqlx::query(
+        r#"
+        INSERT OR IGNORE INTO sessions (id, api_key_id, name, created_at)
+        VALUES (?, ?, 'Session A', '2026-04-24T17:58:00.000000000Z')
+        "#,
+    )
+    .bind(session_id)
+    .bind(owner)
+    .execute(storage.pool())
+    .await
+    .expect("insert session");
 }
 
 async fn mark_job_processing(storage: &Storage, job_id: &str) {
@@ -695,6 +922,24 @@ fn new_job(owner: &str, idempotency_key: &str, hash: &str) -> NewTranscriptionJo
         accepted_audio_path: PathBuf::from("/var/lib/oracy/accepted-audio/job-a"),
         max_retries: 3,
         now: datetime!(2026-04-24 18:00:00 UTC),
+    }
+}
+
+fn new_tag(owner: &str, id: &str, name: &str) -> NewTag {
+    NewTag {
+        id: id.to_owned(),
+        api_key_id: owner.to_owned(),
+        name: name.to_owned(),
+        created_at: datetime!(2026-04-24 18:00:45 UTC),
+    }
+}
+
+fn new_session(owner: &str, id: &str, name: &str) -> NewSession {
+    NewSession {
+        id: id.to_owned(),
+        api_key_id: owner.to_owned(),
+        name: name.to_owned(),
+        created_at: datetime!(2026-04-24 18:00:40 UTC),
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds durable SQLite storage for owner-scoped tags, sessions, and transcript-to-tag associations.
- Enforces metadata invariants in storage: case-insensitive tag identity, preserved tag spelling, session ID identity, and owner-matched transcript session links.
- Preserves idempotent replay tuples when sessions are deleted while nulling live transcript session membership.

## Changes

- Adds a metadata substrate migration for `sessions`, `tags`, `transcript_tags`, owner-scoped indexes, transcript session ownership triggers, and session deletion cleanup.
- Extends the storage API with tag create/reuse, tag rename conflict reporting, tag deletion, transcript tag replacement/listing, and session create/delete.
- Adds persistence tests for many-to-many tag associations, tag deletion cleanup, session deletion nulling, replay tuple preservation, and case-insensitive tag rename conflicts.
- Records the metadata substrate addition in the changelog.

## GitHub Issue(s)

Closes #15

## Test plan

- `cargo test` from `backend/`
- `git diff --check`
