### PR TITLE
docs(spec): encode v0.1.0 architecture in spec documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,8 @@
 - Clarify that `cost_cents` is always present on transcript resources but may be
   `null` when the backend cannot derive a stable estimate from fixed-rate
   pricing inputs.
+- Rewrite the v0.1.0 spec around the durable voice-note artifact: rename the
+  `Transcript` family to `VoiceNote`, replace single-multipart audio upload with
+  the chunked open/push/finalize protocol (with `accepting_chunks` as a
+  contract-visible job status), and add the per-API-key `transcription_model`
+  settings surface enumerating the OpenAI transcription engine identifiers.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -2,13 +2,29 @@
 
 Target release: `v0.1.0`
 
-This document captures the public HTTP contract required by the coordinated
-Flutter client and Rust backend. Polling cadence guidance, rate limits, and
-long-poll versus short-poll behavior are deferred to a later revision.
+## Exigence
+
+A person speaks. The words matter, but the speaking is fleeting. Oracy
+is the system that catches voice and keeps what was said: the user
+records audio, and the system produces a **voice note** — a durable
+text artifact derived from that audio that the user can search, edit,
+organize, and return to later. The voice note is what survives. Audio
+is the input that produces it; once a voice note exists and its
+embedding is stored, the audio's job on the server is done.
+
+This contract is the wire surface between the Oracy client and the
+Oracy backend. It encodes how voice notes are created (chunked audio
+upload composed into a transcription job), how they are read and
+mutated, how they are organized (free-text tags and optional
+sessions), how they are searched (keyword, semantic, hybrid against
+the current voice-note text and its current embedding), and how the
+user configures the transcription engine that produces them. Polling
+cadence guidance, rate limits, and long-poll versus short-poll
+behavior are deferred to a later revision.
 
 ## Authentication
 
-- All endpoints below require `Authorization: Bearer <api_key>`.
+- All endpoints require `Authorization: Bearer <api_key>`.
 - The `Bearer` auth scheme is matched case-insensitively.
 - API keys are provisioned out-of-band by the operator.
 - Idempotency is scoped per authenticated API key.
@@ -54,77 +70,173 @@ Fields:
 - `message`: human-readable summary
 - `details`: optional structured context for validation or conflict errors
 
-## Endpoint Inventory
+## Voice Note Submission
 
-### POST `/api/v1/transcriptions`
+A voice note is created through a three-step submission protocol: open
+a transcription job, push audio chunks against it, finalize. Audio is
+chunked client-side so each chunk fits the per-call ceiling of the
+configured transcription engine; the server composes the chunks into
+the job's input. The user-facing artifact is one voice note resulting
+from one recording regardless of how many chunks the client sent.
 
-Submit audio for asynchronous transcription.
+The supported audio formats for `v0.1.0` are `m4a`, `mp3`, `wav`, and
+`webm`. The per-chunk size ceiling is the per-call ceiling of the
+configured transcription engine; `v0.1.0` documents this as
+`25 MiB` per chunk. The `language` parameter, when supplied, is an
+ISO 639-1 hint that constrains transcription to the supplied language
+and disables engine-side auto-detection for the affected job.
+
+### POST `/api/v1/transcription-jobs`
+
+Open a submission attempt. No audio bytes cross this endpoint.
+
+Request:
+
+- Content type: `application/json`
+- Headers:
+  - `Idempotency-Key` required
+- Body:
+
+```json
+{
+  "recorded_at": "2026-04-21T18:29:55Z",
+  "chunk_count": 3,
+  "audio_format": "m4a",
+  "session_id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
+  "language": "en"
+}
+```
+
+Fields:
+
+- `recorded_at` required: RFC 3339 UTC timestamp describing when the
+  audio was recorded
+- `chunk_count` required: number of chunks the client will push;
+  integer in `1..256`
+- `audio_format` required: one of the supported audio formats
+- `session_id` optional: existing session identifier owned by the
+  authenticated API key
+- `language` optional: ISO 639-1 language hint
+
+Validation:
+
+- `chunk_count` must be a positive integer not exceeding `256`.
+- `session_id`, when present, must identify an existing session owned
+  by the authenticated API key.
+
+Responses:
+
+- `201 Created`: new submission attempt opened, or replay of an
+  already-open attempt under the same `(API key, Idempotency-Key)`
+  with a matching open-call body
+- `200 OK`: replay of an already-finalized attempt under the same
+  `(API key, Idempotency-Key)`
+- `400 Bad Request`: invalid idempotency header or invalid body fields
+- `401 Unauthorized`: missing or invalid API key
+- `404 Not Found`: supplied `session_id` does not exist for the
+  authenticated API key
+- `409 Conflict`: same `(API key, Idempotency-Key)` with a mismatch on
+  any open-call dimension (`recorded_at`, `chunk_count`,
+  `audio_format`, `session_id`, `language`) relative to the prior
+  attempt
+- `415 Unsupported Media Type`: unsupported `audio_format`
+
+Response body is a `TranscriptionJob` resource. New attempts are in
+status `accepting_chunks`.
+
+### POST `/api/v1/transcription-jobs/{job_id}/chunks`
+
+Push one chunk of audio against an open submission attempt.
 
 Request:
 
 - Content type: `multipart/form-data`
 - Fields:
-  - `file` required: uploaded audio file
-  - `recorded_at` required: RFC 3339 UTC timestamp describing when the audio
-    was recorded
-  - `session_id` optional: existing session identifier owned by the
-    authenticated API key
-  - `language` optional: ISO 639-1 language hint
-- Headers:
-  - `Idempotency-Key` required
+  - `chunk_index` required: zero-based chunk position, integer in
+    `0..chunk_count-1`
+  - `chunk_sha256` required: lowercase hex SHA-256 of the chunk bytes
+  - `file` required: the chunk's audio bytes
 
 Validation:
 
-- Accepted file formats are `m4a`, `mp3`, `wav`, and `webm`.
-- Maximum upload size is `25 MiB`.
-- `session_id`, when present on a new submission attempt, must identify an
-  existing session owned by the authenticated API key.
-- `language`, when present, constrains transcription to the supplied language.
-  The backend does not auto-detect language for that submission.
+- The job must exist and be in status `accepting_chunks`.
+- `chunk_index` must fall within `0..chunk_count-1`.
+- The chunk bytes must not exceed the per-chunk size ceiling.
+- The supplied `chunk_sha256` must match the SHA-256 of the received
+  chunk bytes.
+
+Idempotency at chunk granularity: re-submitting the same
+`(chunk_index, chunk_sha256)` pair against the same job is a no-op
+that returns `204 No Content`. A chunk push for a `chunk_index` that
+already has a different accepted hash returns `409 Conflict` and
+leaves the previously accepted chunk in place.
 
 Responses:
 
-- `202 Accepted`: new durable job accepted, or replay of an existing
-  nonterminal job
-- `200 OK`: replay of an existing terminal job
-- `400 Bad Request`: invalid idempotency header or invalid request fields
-- `401 Unauthorized`: missing or invalid API key
-- `404 Not Found`: on a new submission attempt, supplied `session_id` does not
-  exist for the authenticated API key
-- `413 Payload Too Large`: file exceeds allowed size
-- `415 Unsupported Media Type`: unsupported audio format
-- `409 Conflict`: same API key and `Idempotency-Key`, but a mismatch on audio
-  content, `recorded_at`, `session_id`, or `language` relative to the accepted
-  submission
-- `5xx`: synchronous failure before durable acceptance
+- `204 No Content`: chunk accepted, or idempotent replay of an
+  already-accepted chunk
+- `400 Bad Request`: malformed multipart, missing fields, or
+  `chunk_sha256` does not match the chunk bytes
+- `401 Unauthorized`
+- `404 Not Found`: no such job for the authenticated API key
+- `409 Conflict`: job is not in `accepting_chunks`, or the
+  `chunk_index` already has a different accepted hash
+- `413 Payload Too Large`: chunk bytes exceed the per-chunk ceiling
 
-Response body for `200` and `202` is a `TranscriptionJob` resource.
+### POST `/api/v1/transcription-jobs/{job_id}/finalize`
 
-### GET `/api/v1/transcriptions/{job_id}`
+Seal a submission attempt and commit it to durable acceptance.
+
+Request body is empty.
+
+The backend composes the accepted chunks (in `chunk_index` order) into
+a single accepted audio content hash and persists the composed audio
+artifact. Durable acceptance commits at this moment, not on the
+per-chunk pushes. The job transitions `accepting_chunks → queued`.
+
+Responses:
+
+- `202 Accepted`: new finalization, durable acceptance committed
+- `200 OK`: replay of an already-finalized job
+- `400 Bad Request`: declared/observed chunk set is internally
+  inconsistent
+- `401 Unauthorized`
+- `404 Not Found`
+- `409 Conflict`: job is not in `accepting_chunks`, or one or more
+  declared chunk indexes have not been accepted
+
+Response body is a `TranscriptionJob` resource.
+
+### GET `/api/v1/transcription-jobs/{job_id}`
 
 Fetch the current state of a transcription job.
 
 Responses:
 
 - `200 OK`: job found and owned by the authenticated API key
-- `401 Unauthorized`: missing or invalid API key
-- `404 Not Found`: no such job for the authenticated API key
+- `401 Unauthorized`
+- `404 Not Found`
 
 Response body is a `TranscriptionJob` resource.
 
-### GET `/api/v1/transcripts`
+## Voice Notes
 
-List completed transcripts for the authenticated API key.
+### GET `/api/v1/voice-notes`
+
+List voice notes for the authenticated API key. This endpoint is the
+unified collection for both history and search. `v0.1.0` does not
+duplicate the collection surface: history with no `q` and search with
+`q` share the same shape, filters, and ordering rules.
 
 Query parameters:
 
 - `cursor` optional
 - `limit` optional
 - `q` optional: search query text
-- `search_mode` optional when `q` is present: one of `keyword`, `semantic`,
-  `hybrid`; defaults to `hybrid` when omitted
-- `tag_id` optional and repeatable; repeated values combine by intersection
-  (`AND`)
+- `search_mode` optional when `q` is present: one of `keyword`,
+  `semantic`, `hybrid`; defaults to `hybrid` when omitted
+- `tag_id` optional and repeatable; repeated values combine by
+  intersection (`AND`)
 - `session_id` optional
 - `recorded_after` optional: exclusive lower bound on `recorded_at`
 - `recorded_before` optional: inclusive upper bound on `recorded_at`
@@ -134,41 +246,39 @@ Query parameters:
 Responses:
 
 - `200 OK`
-- `400 Bad Request`: invalid query parameter values, or `search_mode` supplied
-  without `q`
+- `400 Bad Request`: invalid query parameter values, or `search_mode`
+  supplied without `q`
 - `401 Unauthorized`
 
 Notes:
 
-- This endpoint is the unified transcript collection for both history and
-  search.
-- Without `q`, the endpoint returns transcript history ordered newest-first by
-  transcript `created_at`, with descending `id` as the deterministic
-  tiebreaker for cursor pagination.
-- With `q`, the endpoint returns transcript search results using the same
-  `Transcript` resource shape, filters, and collection envelope. This is an
-  explicit `v0.1.0` governance decision to avoid duplicating transcript
-  collection surface with no semantic gain.
-- If `q` is present and `search_mode` is omitted, the backend uses `hybrid`.
-- Search results are always transcript resources.
-- Keyword search may match current transcript text and historical
-  `TranscriptVersion` text, but the returned item is always the parent
-  `Transcript`.
-- Semantic and hybrid search use the current embedding. After a transcript
-  text edit, semantic freshness is eventual rather than immediate.
-- Search results are ordered by backend relevance score descending, then by
-  transcript `created_at` descending, then by descending `id` as the final
-  deterministic tiebreaker for cursor pagination.
-- Repeated `tag_id` filters combine by intersection: a transcript matches only
-  if it is associated with all supplied tags.
-- Failed jobs and in-flight jobs are not listed.
+- Without `q`, the endpoint returns voice-note history ordered
+  newest-first by voice-note `created_at`, with descending `id` as
+  the deterministic tiebreaker for cursor pagination.
+- With `q`, the endpoint returns voice-note search results using the
+  same `VoiceNote` resource shape, filters, and collection envelope.
+- If `q` is present and `search_mode` is omitted, the backend uses
+  `hybrid`.
+- Search results are always voice-note resources.
+- Keyword search may match current voice-note text and historical
+  `VoiceNoteVersion` text, but the returned item is always the parent
+  `VoiceNote`.
+- Semantic and hybrid search use the current embedding. After a
+  voice-note text edit, semantic freshness is eventual rather than
+  immediate.
+- Search results are ordered by backend relevance score descending,
+  then by voice-note `created_at` descending, then by descending `id`
+  as the final deterministic tiebreaker for cursor pagination.
+- Repeated `tag_id` filters combine by intersection: a voice note
+  matches only if it is associated with all supplied tags.
+- Failed and in-flight transcription jobs are not listed here.
 
-Response body is a transcript collection envelope whose `items` are
-`Transcript` resources.
+Response body is a voice-note collection envelope whose `items` are
+`VoiceNote` resources.
 
-### GET `/api/v1/transcripts/{transcript_id}`
+### GET `/api/v1/voice-notes/{voice_note_id}`
 
-Fetch one completed transcript for the authenticated API key.
+Fetch one voice note for the authenticated API key.
 
 Responses:
 
@@ -178,20 +288,20 @@ Responses:
 
 Notes:
 
-- Only completed transcripts are addressable here.
-- A job ID is never valid on this endpoint.
+- Only completed voice notes are addressable here. A
+  `TranscriptionJob` ID is never valid on this endpoint.
 
-Response body is a `Transcript` resource.
+Response body is a `VoiceNote` resource.
 
-### PATCH `/api/v1/transcripts/{transcript_id}`
+### PATCH `/api/v1/voice-notes/{voice_note_id}`
 
-Replace the current transcript text.
+Replace the current voice-note text.
 
 Request body:
 
 ```json
 {
-  "transcript": "Updated transcript text."
+  "text": "Updated voice note text."
 }
 ```
 
@@ -204,20 +314,22 @@ Responses:
 
 Notes:
 
-- The request changes transcript text only.
-- A successful edit creates one new `TranscriptVersion` and moves
-  `Transcript.current_version_id` to the new version.
+- The request changes voice-note text only.
+- Editing is the only adjustment path for an existing voice note. The
+  backend does not re-transcribe audio against an existing voice note.
+- A successful edit creates one new `VoiceNoteVersion` and moves
+  `VoiceNote.current_version_id` to the new version.
 - Prior versions remain available through the version-history endpoint.
 - Segment timing remains unchanged by text edits.
-- Embedding regeneration is asynchronous. Full-text reads return the edited
-  text immediately; semantic and hybrid search may lag until regeneration
-  completes.
+- Embedding regeneration is asynchronous. Full-text reads return the
+  edited text immediately; semantic and hybrid search may lag until
+  regeneration completes.
 
-Response body is the updated `Transcript` resource.
+Response body is the updated `VoiceNote` resource.
 
-### DELETE `/api/v1/transcripts/{transcript_id}`
+### DELETE `/api/v1/voice-notes/{voice_note_id}`
 
-Hard-delete a transcript.
+Hard-delete a voice note.
 
 Responses:
 
@@ -227,15 +339,15 @@ Responses:
 
 Notes:
 
-- Deletion cascades to transcript versions, segments, the current embedding,
-  and tag associations.
-- The originating succeeded `TranscriptionJob` survives as the durable replay
-  record for the accepted submission attempt, and its `transcript_id` becomes
-  `null`.
+- Deletion cascades to voice-note versions, segments, the current
+  embedding, and tag associations.
+- The originating succeeded `TranscriptionJob` survives as the durable
+  replay record for the accepted submission attempt, and its
+  `voice_note_id` becomes `null`.
 
-### GET `/api/v1/transcripts/{transcript_id}/versions`
+### GET `/api/v1/voice-notes/{voice_note_id}/versions`
 
-List transcript versions for one transcript.
+List voice-note versions for one voice note.
 
 Query parameters:
 
@@ -251,16 +363,16 @@ Responses:
 
 Notes:
 
-- Versions are returned newest-first by `created_at`, with descending `id` as
-  the deterministic tiebreaker for cursor pagination.
+- Versions are returned newest-first by `created_at`, with descending
+  `id` as the deterministic tiebreaker for cursor pagination.
 - Version history is linear and append-only.
 
 Response body is a collection envelope whose `items` are
-`TranscriptVersion` resources.
+`VoiceNoteVersion` resources.
 
-### GET `/api/v1/transcripts/{transcript_id}/segments`
+### GET `/api/v1/voice-notes/{voice_note_id}/segments`
 
-List timing segments for one transcript.
+List timing segments for one voice note.
 
 Query parameters:
 
@@ -277,13 +389,14 @@ Responses:
 Notes:
 
 - Segments are returned in ascending `position` order.
-- Segment content is stable across transcript text edits.
+- Segment content is stable across voice-note text edits.
 
-Response body is a collection envelope whose `items` are `Segment` resources.
+Response body is a collection envelope whose `items` are `Segment`
+resources.
 
-### PUT `/api/v1/transcripts/{transcript_id}/tags`
+### PUT `/api/v1/voice-notes/{voice_note_id}/tags`
 
-Replace the transcript's entire tag set.
+Replace the voice note's entire tag set.
 
 Request body:
 
@@ -298,17 +411,19 @@ Responses:
 - `200 OK`
 - `400 Bad Request`
 - `401 Unauthorized`
-- `404 Not Found`: transcript or one or more referenced tags not found for the
-  authenticated API key
+- `404 Not Found`: voice note or one or more referenced tags not found
+  for the authenticated API key
 
 Notes:
 
-- `PUT` replaces the transcript's entire tag set. The request body is the full
-  desired set.
+- `PUT` replaces the voice note's entire tag set. The request body is
+  the full desired set.
 - Duplicate `tag_ids` are invalid.
-- Replacing tags does not create a new `TranscriptVersion`.
+- Replacing tags does not create a new `VoiceNoteVersion`.
 
-Response body is the updated `Transcript` resource.
+Response body is the updated `VoiceNote` resource.
+
+## Tags
 
 ### GET `/api/v1/tags`
 
@@ -327,14 +442,16 @@ Responses:
 
 Notes:
 
-- Tags are returned newest-first by `created_at`, with descending `id` as the
-  deterministic tiebreaker for cursor pagination.
+- Tags are returned newest-first by `created_at`, with descending `id`
+  as the deterministic tiebreaker for cursor pagination.
 
-Response body is a collection envelope whose `items` are `Tag` resources.
+Response body is a collection envelope whose `items` are `Tag`
+resources.
 
 ### POST `/api/v1/tags`
 
-Create a tag, or return the existing tag with the same case-insensitive name.
+Create a tag, or return the existing tag with the same case-insensitive
+name.
 
 Request body:
 
@@ -347,8 +464,8 @@ Request body:
 Responses:
 
 - `201 Created`: new tag created
-- `200 OK`: a tag with the same case-insensitive name already exists for the
-  authenticated API key
+- `200 OK`: a tag with the same case-insensitive name already exists
+  for the authenticated API key
 - `400 Bad Request`
 - `401 Unauthorized`
 
@@ -389,12 +506,12 @@ Responses:
 - `400 Bad Request`
 - `401 Unauthorized`
 - `404 Not Found`
-- `409 Conflict`: another tag with the same case-insensitive name already
-  exists for the authenticated API key
+- `409 Conflict`: another tag with the same case-insensitive name
+  already exists for the authenticated API key
 
 Notes:
 
-- A successful rename updates the visible tag name on every transcript
+- A successful rename updates the visible tag name on every voice note
   associated with that tag.
 
 Response body is the updated `Tag` resource.
@@ -411,8 +528,10 @@ Responses:
 
 Notes:
 
-- Deleting a tag removes its transcript associations but does not delete any
-  transcript.
+- Deleting a tag removes its voice-note associations but does not
+  delete any voice note.
+
+## Sessions
 
 ### GET `/api/v1/sessions`
 
@@ -431,10 +550,11 @@ Responses:
 
 Notes:
 
-- Sessions are returned newest-first by `created_at`, with descending `id` as
-  the deterministic tiebreaker for cursor pagination.
+- Sessions are returned newest-first by `created_at`, with descending
+  `id` as the deterministic tiebreaker for cursor pagination.
 
-Response body is a collection envelope whose `items` are `Session` resources.
+Response body is a collection envelope whose `items` are `Session`
+resources.
 
 ### POST `/api/v1/sessions`
 
@@ -501,24 +621,24 @@ Responses:
 
 Notes:
 
-- Deleting a session preserves contained transcripts and sets their
+- Deleting a session preserves contained voice notes and sets their
   `session_id` to `null`.
-- Deleting a session does not invalidate previously accepted replay records
-  whose stored submission tuple referenced that session.
+- Deleting a session does not invalidate previously accepted replay
+  records whose stored submission tuple referenced that session.
 
-### GET `/api/v1/sessions/{session_id}/transcripts`
+### GET `/api/v1/sessions/{session_id}/voice-notes`
 
-List completed transcripts that belong to one session.
+List voice notes that belong to one session.
 
 Query parameters:
 
 - `cursor` optional
 - `limit` optional
 - `q` optional
-- `search_mode` optional when `q` is present: one of `keyword`, `semantic`,
-  `hybrid`; defaults to `hybrid` when omitted
-- `tag_id` optional and repeatable; repeated values combine by intersection
-  (`AND`)
+- `search_mode` optional when `q` is present: one of `keyword`,
+  `semantic`, `hybrid`; defaults to `hybrid` when omitted
+- `tag_id` optional and repeatable; repeated values combine by
+  intersection (`AND`)
 - `recorded_after` optional
 - `recorded_before` optional
 - `created_after` optional
@@ -533,15 +653,83 @@ Responses:
 
 Notes:
 
-- This endpoint applies the same collection semantics as `GET /api/v1/transcripts`
-  but with the session scope fixed by the path, including the same ordering
-  and time-bound semantics.
-- If `q` is present and `search_mode` is omitted, the backend uses `hybrid`.
-- Repeated `tag_id` filters combine by intersection: a transcript matches only
-  if it is associated with all supplied tags.
+- This endpoint applies the same collection semantics as
+  `GET /api/v1/voice-notes` but with the session scope fixed by the
+  path, including the same ordering and time-bound semantics.
+- If `q` is present and `search_mode` is omitted, the backend uses
+  `hybrid`.
+- Repeated `tag_id` filters combine by intersection.
 
-Response body is a transcript collection envelope whose `items` are
-`Transcript` resources.
+Response body is a voice-note collection envelope whose `items` are
+`VoiceNote` resources.
+
+## Settings
+
+The settings resource carries user-level configuration scoped to the
+authenticated API key. `v0.1.0` exposes one setting:
+`transcription_model`.
+
+### GET `/api/v1/settings`
+
+Fetch the authenticated API key's settings.
+
+Responses:
+
+- `200 OK`
+- `401 Unauthorized`
+
+Response body is a `Settings` resource. On first read for an API key
+that has never updated settings, the response carries the documented
+defaults.
+
+### PATCH `/api/v1/settings`
+
+Partial update of settings. Omitted fields are left unchanged.
+
+Request body:
+
+```json
+{
+  "transcription_model": "gpt-4o-transcribe"
+}
+```
+
+Validation:
+
+- `transcription_model`, when present, must be one of the supported
+  transcription model identifiers documented under the engine surface.
+
+Responses:
+
+- `200 OK`
+- `400 Bad Request`: unknown field or unsupported model identifier
+- `401 Unauthorized`
+
+Notes:
+
+- The selected `transcription_model` applies to every transcription job
+  that reaches `queued` after the update. Jobs already past `queued`
+  are unaffected.
+
+Response body is the updated `Settings` resource.
+
+### Engine Surface
+
+The `v0.1.x` engine family is OpenAI's transcription models. `v0.1.0`
+ships two model identifiers:
+
+- `gpt-4o-mini-transcribe` — default. Fast, low-cost, accuracy
+  suitable for typical voice notes.
+- `gpt-4o-transcribe` — quality upgrade. Higher accuracy at higher
+  cost, suitable for difficult audio (accents, noise, technical
+  vocabulary).
+
+The default `transcription_model` for an API key that has never
+updated settings is `gpt-4o-mini-transcribe`.
+
+Engine identifiers in the contract are opaque strings. Adding or
+removing engines in future releases does not alter the shape of any
+endpoint or resource.
 
 ## Resource Schemas
 
@@ -550,44 +738,150 @@ Response body is a transcript collection envelope whose `items` are
 ```json
 {
   "id": "01JS8D2PR4W8VW6TQZ0N8M1T0K",
-  "status": "retry_waiting",
+  "status": "accepting_chunks",
   "created_at": "2026-04-21T18:30:00Z",
-  "updated_at": "2026-04-21T18:31:12Z",
-  "retry_count": 1,
+  "updated_at": "2026-04-21T18:30:14Z",
+  "chunk_count": 3,
+  "chunks_received": 1,
+  "retry_count": 0,
   "max_retries": 3,
-  "next_attempt_at": "2026-04-21T18:32:12Z",
-  "failure_code": "engine_timeout",
-  "failure_message": "The transcription attempt timed out while processing audio.",
-  "retryable_by_client": true,
-  "transcript_id": null
+  "next_attempt_at": null,
+  "failure_code": null,
+  "failure_message": null,
+  "retryable_by_client": null,
+  "voice_note_id": null
 }
 ```
 
 Fields:
 
 - `id`: job identifier
-- `status`: one of `queued`, `processing`, `retry_waiting`, `succeeded`,
-  `failed`
-- `created_at`: acceptance timestamp
-- `updated_at`: last state-transition timestamp
-- `retry_count`: number of backend retry attempts already consumed; always
-  returned
+- `status`: one of `accepting_chunks`, `queued`, `processing`,
+  `retry_waiting`, `succeeded`, `failed`
+- `created_at`: open-call timestamp
+- `updated_at`: last state-transition or chunk-acceptance timestamp
+- `chunk_count`: declared chunk count from the open call
+- `chunks_received`: number of distinct accepted chunks; reaches
+  `chunk_count` before finalize succeeds
+- `retry_count`: number of backend retry attempts already consumed;
+  always returned
 - `max_retries`: maximum backend retry attempts for this job
-- `next_attempt_at`: returned when `status=retry_waiting`, otherwise omitted or
-  `null`
+- `next_attempt_at`: returned when `status=retry_waiting`, otherwise
+  omitted or `null`
 - `failure_code`: present when a failure classification exists
-- `failure_message`: human-readable explanation aligned with `failure_code`
-- `retryable_by_client`: whether a terminal failed job should be retried by
-  creating a fresh submission with a new `Idempotency-Key`
-- `transcript_id`: present when `status=succeeded` and the transcript is still
-  addressable; `null` for non-succeeded jobs and for succeeded jobs whose
-  transcript has been deleted
+- `failure_message`: human-readable explanation aligned with
+  `failure_code`
+- `retryable_by_client`: whether a terminal failed job should be
+  retried by creating a fresh submission with a new `Idempotency-Key`
+- `voice_note_id`: present when `status=succeeded` and the voice note
+  is still addressable; `null` for non-succeeded jobs and for
+  succeeded jobs whose voice note has been deleted
 
 Semantics:
 
-- `retry_count` and `next_attempt_at` are part of the job resource because the
-  client uses them for UX and polling suppression.
-- The same `TranscriptionJob` resource is returned for idempotent replays.
+- `chunk_count` and `chunks_received` are part of the job resource so
+  the client can render upload progress and decide when to call
+  `finalize`.
+- `retry_count` and `next_attempt_at` are part of the job resource
+  because the client uses them for UX and polling suppression.
+- The same `TranscriptionJob` resource is returned for idempotent
+  replays.
+
+### `VoiceNote`
+
+```json
+{
+  "id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
+  "current_version_id": "01JS9P1D6CK9M0N1P2Q3R4S5T6",
+  "text": "Hello, this is a voice note.",
+  "audio_duration_seconds": 12.5,
+  "audio_format": "m4a",
+  "audio_size_bytes": 401280,
+  "language": "en",
+  "model": "gpt-4o-mini-transcribe",
+  "processing_time_ms": 1843,
+  "cost_cents": 1,
+  "created_at": "2026-04-21T18:31:19Z",
+  "recorded_at": "2026-04-21T18:29:55Z",
+  "session_id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
+  "tags": [
+    {
+      "id": "01JS9P0Q0THR2X3E4A5B6C7D8E",
+      "name": "Meeting",
+      "created_at": "2026-04-21T18:31:30Z"
+    }
+  ]
+}
+```
+
+Fields:
+
+- `id`: voice-note identifier
+- `current_version_id`: identifier of the current voice-note version
+- `text`: current voice-note text
+- `audio_duration_seconds`: composed audio duration
+- `audio_format`: accepted audio format
+- `audio_size_bytes`: composed audio size in bytes
+- `language`: the language hint or detected language for the
+  transcription
+- `model`: transcription engine identifier in use when the voice note
+  was produced
+- `processing_time_ms`: total server-side processing time
+- `cost_cents`: backend cost estimate in cents; always present and
+  nullable
+- `created_at`: voice-note creation timestamp
+- `recorded_at`: client-supplied audio capture timestamp
+- `session_id`: associated session identifier, or `null`
+- `tags`: associated `Tag` resources
+
+Semantics:
+
+- `audio_duration_seconds`, `audio_format`, and `audio_size_bytes` are
+  durable provenance properties of the voice note. The composed audio
+  bytes are released from the server once the originating job reaches
+  a terminal state; these fields persist regardless.
+
+### `VoiceNoteVersion`
+
+```json
+{
+  "id": "01JS9P1D6CK9M0N1P2Q3R4S5T6",
+  "voice_note_id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
+  "text": "Hello, this is a voice note.",
+  "created_at": "2026-04-21T18:31:19Z"
+}
+```
+
+Fields:
+
+- `id`: voice-note-version identifier
+- `voice_note_id`: parent voice-note identifier
+- `text`: voice-note text captured in this version
+- `created_at`: version creation timestamp
+
+### `Segment`
+
+```json
+{
+  "id": "01JS9P1K2AQ3B4C5D6E7F8G9H0",
+  "voice_note_id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
+  "position": 0,
+  "start_ms": 0,
+  "end_ms": 1480,
+  "text": "Hello, this is a voice note."
+}
+```
+
+Fields:
+
+- `id`: segment identifier
+- `voice_note_id`: parent voice-note identifier
+- `position`: zero-based segment order
+- `start_ms`: segment start offset in milliseconds, measured from the
+  start of the composed audio
+- `end_ms`: segment end offset in milliseconds, measured from the
+  start of the composed audio
+- `text`: segment text captured from the transcription result
 
 ### `Tag`
 
@@ -621,121 +915,64 @@ Fields:
 - `name`: session display name
 - `created_at`: session creation timestamp
 
-### `Transcript`
+### `Settings`
 
 ```json
 {
-  "id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
-  "current_version_id": "01JS9P1D6CK9M0N1P2Q3R4S5T6",
-  "transcript": "Hello, this is a test recording.",
-  "audio_duration_seconds": 12.5,
-  "audio_format": "wav",
-  "audio_size_bytes": 401280,
-  "transcript_language": "en",
-  "model": "general-transcription-v1",
-  "processing_time_ms": 1843,
-  "cost_cents": 1,
-  "created_at": "2026-04-21T18:31:19Z",
-  "recorded_at": "2026-04-21T18:29:55Z",
-  "session_id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
-  "tags": [
-    {
-      "id": "01JS9P0Q0THR2X3E4A5B6C7D8E",
-      "name": "Meeting",
-      "created_at": "2026-04-21T18:31:30Z"
-    }
-  ]
+  "transcription_model": "gpt-4o-mini-transcribe"
 }
 ```
 
 Fields:
 
-- `id`: transcript identifier
-- `current_version_id`: identifier of the current transcript version
-- `transcript`: current transcript text
-- `audio_duration_seconds`: source audio duration
-- `audio_format`: accepted audio format
-- `audio_size_bytes`: original uploaded size
-- `transcript_language`: detected or hinted language
-- `model`: transcription engine identifier
-- `processing_time_ms`: total server-side processing time
-- `cost_cents`: backend cost estimate in cents; always present and nullable
-- `created_at`: transcript creation timestamp
-- `recorded_at`: client-supplied audio capture timestamp
-- `session_id`: associated session identifier, or `null`
-- `tags`: associated `Tag` resources
-
-### `TranscriptVersion`
-
-```json
-{
-  "id": "01JS9P1D6CK9M0N1P2Q3R4S5T6",
-  "transcript_id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
-  "transcript": "Hello, this is a test recording.",
-  "created_at": "2026-04-21T18:31:19Z"
-}
-```
-
-Fields:
-
-- `id`: transcript-version identifier
-- `transcript_id`: parent transcript identifier
-- `transcript`: transcript text captured in this version
-- `created_at`: version creation timestamp
-
-### `Segment`
-
-```json
-{
-  "id": "01JS9P1K2AQ3B4C5D6E7F8G9H0",
-  "transcript_id": "01JS8D6E2S3T1J7H9J2Q2N4P5R",
-  "position": 0,
-  "start_ms": 0,
-  "end_ms": 1480,
-  "text": "Hello, this is a test recording."
-}
-```
-
-Fields:
-
-- `id`: segment identifier
-- `transcript_id`: parent transcript identifier
-- `position`: zero-based segment order
-- `start_ms`: segment start offset in milliseconds
-- `end_ms`: segment end offset in milliseconds
-- `text`: segment text captured from the transcription result
+- `transcription_model`: the engine identifier used for every
+  transcription job that reaches `queued` after the most recent update
 
 ## Idempotency Rules
 
-- The backend matches a replay by `API key + Idempotency-Key + accepted audio
-content hash + recorded_at + session_id + language`.
-- The accepted submission tuple is an immutable acceptance-time record, not a
-  live reference to current resource state.
-- For `recorded_at`, replay matching compares the parsed instant normalized to
-  UTC, not the raw wire-format string. Any RFC 3339 UTC representation of the
-  same instant is a match.
-- Omitted optional `session_id` and `language` values participate as `null`.
-- Same API key + same `Idempotency-Key` + same accepted submission tuple
-  returns the same `TranscriptionJob`.
-- Same API key + same `Idempotency-Key` + a mismatch on any accepted
-  submission dimension returns `409 Conflict`.
-- If the session referenced by an accepted `session_id` is later deleted,
-  idempotent replays still return the original `TranscriptionJob` matched by
-  the stored accepted tuple.
-- If the transcript created by a succeeded job is later deleted, idempotent
-  replays still return the original succeeded `TranscriptionJob` with
-  `transcript_id=null`.
+- A submission attempt is identified by
+  `API key + Idempotency-Key + accepted audio content hash +
+  recorded_at + session_id + language`.
+- The `Idempotency-Key` is supplied on the open call
+  (`POST /api/v1/transcription-jobs`) and governs replay matching for
+  the entire submission attempt.
+- The accepted audio content hash is computed at finalize time as a
+  hash composed deterministically from the accepted chunk hashes in
+  `chunk_index` order.
+- The accepted submission tuple is an immutable acceptance-time
+  record, not a live reference to current resource state.
+- For `recorded_at`, replay matching compares the parsed instant
+  normalized to UTC, not the raw wire-format string. Any RFC 3339 UTC
+  representation of the same instant is a match.
+- Omitted optional `session_id` and `language` values participate as
+  `null`.
+- Same API key + same `Idempotency-Key` + same accepted submission
+  tuple returns the same `TranscriptionJob`.
+- Same API key + same `Idempotency-Key` + a mismatch on any open-call
+  dimension (before finalize) or any accepted submission dimension
+  (after finalize) returns `409 Conflict`.
+- Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
+- If the session referenced by an accepted `session_id` is later
+  deleted, idempotent replays still return the original
+  `TranscriptionJob` matched by the stored accepted tuple.
+- If the voice note created by a succeeded job is later deleted,
+  idempotent replays still return the original succeeded
+  `TranscriptionJob` with `voice_note_id=null`.
 - A new submission attempt after terminal failure must use a new
   `Idempotency-Key`.
 
 ## Contract Notes
 
-- This contract intentionally omits a synchronous transcript-returning upload
-  endpoint.
+- This contract intentionally omits a synchronous voice-note-returning
+  upload endpoint.
 - This contract intentionally omits `prompt` from `v0.1.0`.
-- This contract intentionally omits public API-key management endpoints.
-- Speaker diarization, branching edit history, transcript-to-session
-  reassignment after submission, and embedding export are deferred beyond
-  `v0.1.0`.
-- Polling cadence, rate limits, and backoff advice are deferred to a later API
-  contract revision.
+- This contract intentionally omits public API-key management
+  endpoints.
+- This contract intentionally omits a runtime engine-discovery
+  endpoint; the supported transcription model identifiers are
+  enumerated in this document.
+- This contract intentionally omits embedding-vector export.
+- Speaker diarization, branching edit history, and voice-note-to-
+  session reassignment after submission are deferred beyond `v0.1.0`.
+- Polling cadence, rate limits, and backoff advice are deferred to a
+  later API contract revision.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -129,8 +129,9 @@ Responses:
 - `201 Created`: new submission attempt opened, or replay of an
   already-open attempt under the same `(API key, Idempotency-Key)`
   with a matching open-call body
-- `200 OK`: replay of an already-finalized attempt under the same
-  `(API key, Idempotency-Key)`
+- `200 OK`: replay against an already-terminated attempt (succeeded
+  or failed) under the same `(API key, Idempotency-Key)` with a
+  matching open-call body
 - `400 Bad Request`: invalid idempotency header or invalid body fields
 - `401 Unauthorized`: missing or invalid API key
 - `404 Not Found`: supplied `session_id` does not exist for the
@@ -726,9 +727,10 @@ ships two model identifiers:
 The default `transcription_model` for an API key that has never
 updated settings is `gpt-4o-mini-transcribe`.
 
-Engine identifiers in the contract are opaque strings. Adding or
-removing engines in future releases does not alter the shape of any
-endpoint or resource.
+Engine identifiers in the contract are closed-enum strings whose
+internal structure carries no contract meaning. Adding or removing
+engines in future releases extends or contracts the enum but does
+not alter the shape of any endpoint or resource.
 
 ## Resource Schemas
 
@@ -950,14 +952,15 @@ Fields:
 - Same API key + same `Idempotency-Key` + a mismatch on any open-call
   dimension (before finalize) or any accepted submission dimension
   (after finalize) returns `409 Conflict`.
-- For a new open call against an already-finalized attempt under the
-  same `(API key, Idempotency-Key)`, replay matching compares the new
-  open-call body's `recorded_at`, `chunk_count`, `audio_format`,
-  `session_id`, and `language` against the original open-call values.
-  All match returns the original finalized `TranscriptionJob` with
-  `200 OK`. Any mismatch returns `409 Conflict`. The accepted audio
-  content hash does not participate in this comparison because a
-  fresh open call carries no audio bytes.
+- For a new open call against an already-terminated attempt
+  (succeeded or failed) under the same `(API key, Idempotency-Key)`,
+  replay matching compares the new open-call body's `recorded_at`,
+  `chunk_count`, `audio_format`, `session_id`, and `language` against
+  the original open-call values. All match returns the original
+  terminated `TranscriptionJob` with `200 OK`. Any mismatch returns
+  `409 Conflict`. The accepted audio content hash does not
+  participate in this comparison because a fresh open call carries no
+  audio bytes.
 - Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
 - If the session referenced by an accepted `session_id` is later
   deleted, idempotent replays still return the original
@@ -965,8 +968,9 @@ Fields:
 - If the voice note created by a succeeded job is later deleted,
   idempotent replays still return the original succeeded
   `TranscriptionJob` with `voice_note_id=null`.
-- A new submission attempt after terminal failure must use a new
-  `Idempotency-Key`.
+- An intentional fresh submission attempt after terminal failure
+  must use a new `Idempotency-Key`. Reusing the original key returns
+  the same terminated job rather than starting a new attempt.
 
 ## Contract Notes
 

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -139,7 +139,6 @@ Responses:
   any open-call dimension (`recorded_at`, `chunk_count`,
   `audio_format`, `session_id`, `language`) relative to the prior
   attempt
-- `415 Unsupported Media Type`: unsupported `audio_format`
 
 Response body is a `TranscriptionJob` resource. New attempts are in
 status `accepting_chunks`.
@@ -951,6 +950,14 @@ Fields:
 - Same API key + same `Idempotency-Key` + a mismatch on any open-call
   dimension (before finalize) or any accepted submission dimension
   (after finalize) returns `409 Conflict`.
+- For a new open call against an already-finalized attempt under the
+  same `(API key, Idempotency-Key)`, replay matching compares the new
+  open-call body's `recorded_at`, `chunk_count`, `audio_format`,
+  `session_id`, and `language` against the original open-call values.
+  All match returns the original finalized `TranscriptionJob` with
+  `200 OK`. Any mismatch returns `409 Conflict`. The accepted audio
+  content hash does not participate in this comparison because a
+  fresh open call carries no audio bytes.
 - Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
 - If the session referenced by an accepted `session_id` is later
   deleted, idempotent replays still return the original

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -74,18 +74,24 @@ Fields:
 
 A voice note is created through a three-step submission protocol: open
 a transcription job, push audio chunks against it, finalize. Audio is
-chunked client-side so each chunk fits the per-call ceiling of the
-configured transcription engine; the server composes the chunks into
-the job's input. The user-facing artifact is one voice note resulting
-from one recording regardless of how many chunks the client sent.
+chunked client-side so each chunk fits within the per-chunk size
+ceiling defined below; the server composes the chunks into the job's
+input. The user-facing artifact is one voice note resulting from one
+recording regardless of how many chunks the client sent.
+
+The `Idempotency-Key` is supplied on the open call only. Subsequent
+chunk and finalize calls scope idempotency through the `{job_id}` in
+the path; they do not carry their own `Idempotency-Key` headers.
 
 The supported audio formats for `v0.1.0` are `m4a`, `mp3`, `wav`, and
-`webm`. The per-chunk size ceiling is the per-call ceiling of the
-configured transcription engine; `v0.1.0` documents this as
-`25 MiB` per chunk (`26,214,400` bytes — the actual server-enforced
-limit, which OpenAI's documentation describes loosely as "25 MB").
-The `language` parameter, when supplied, is an ISO 639-1 hint that
-constrains transcription to the supplied language and disables
+`webm`. The per-chunk size ceiling is `25 MiB` (`26,214,400` bytes —
+the actual server-enforced limit, which OpenAI's documentation
+describes loosely as "25 MB"). Both `v0.1.0` engines share this
+per-call ceiling, so the per-chunk ceiling is fixed for `v0.1.0` and
+does not vary by configured `transcription_model`. A future engine
+with a different per-call ceiling would require an explicit contract
+change. The `language` parameter, when supplied, is an ISO 639-1 hint
+that constrains transcription to the supplied language and disables
 engine-side auto-detection for the affected job.
 
 ### POST `/api/v1/transcription-jobs`
@@ -206,6 +212,8 @@ Responses:
 - `404 Not Found`
 - `409 Conflict`: job is not in `accepting_chunks`, or one or more
   declared chunk indexes have not been accepted
+- `5xx`: synchronous persistence failure during finalize; the job
+  remains in `accepting_chunks` and may be retried
 
 Response body is a `TranscriptionJob` resource.
 
@@ -947,6 +955,10 @@ Fields:
   `chunk_index` order.
 - The accepted submission tuple is an immutable acceptance-time
   record, not a live reference to current resource state.
+- The original open-call body's `chunk_count` and `audio_format` are
+  durably stored alongside the accepted submission tuple for the
+  lifetime of the replay record so that terminal-replay matching
+  against a fresh open call survives backend restart.
 - For `recorded_at`, replay matching compares the parsed instant
   normalized to UTC, not the raw wire-format string. Any RFC 3339 UTC
   representation of the same instant is a match.
@@ -967,6 +979,11 @@ Fields:
   participate in this comparison because a fresh open call carries no
   audio bytes.
 - Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
+- Idempotency replay takes precedence over session-existence
+  validation on the open call. When a replay match exists under the
+  same `(API key, Idempotency-Key)`, the backend returns the original
+  `TranscriptionJob` even if the supplied `session_id` no longer
+  identifies an existing session for the authenticated API key.
 - If the session referenced by an accepted `session_id` is later
   deleted, idempotent replays still return the original
   `TranscriptionJob` matched by the stored accepted tuple.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -82,9 +82,11 @@ from one recording regardless of how many chunks the client sent.
 The supported audio formats for `v0.1.0` are `m4a`, `mp3`, `wav`, and
 `webm`. The per-chunk size ceiling is the per-call ceiling of the
 configured transcription engine; `v0.1.0` documents this as
-`25 MiB` per chunk. The `language` parameter, when supplied, is an
-ISO 639-1 hint that constrains transcription to the supplied language
-and disables engine-side auto-detection for the affected job.
+`25 MiB` per chunk (`26,214,400` bytes — the actual server-enforced
+limit, which OpenAI's documentation describes loosely as "25 MB").
+The `language` parameter, when supplied, is an ISO 639-1 hint that
+constrains transcription to the supplied language and disables
+engine-side auto-detection for the affected job.
 
 ### POST `/api/v1/transcription-jobs`
 
@@ -698,6 +700,9 @@ Validation:
 
 - `transcription_model`, when present, must be one of the supported
   transcription model identifiers documented under the engine surface.
+- Field values must be of the documented type. Explicit `null` is not
+  a valid value for any setting field; to leave a setting unchanged,
+  omit the field.
 
 Responses:
 

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -100,8 +100,10 @@ required, not optional.
     cost, suitable for difficult audio.
 - The backend records the engine identifier in use on each `VoiceNote`
   via the `model` field, carrying the OpenAI model identifier.
-- Engine identifiers in the contract are opaque strings. Adding or
-  removing models in future releases does not alter contract shape.
+- Engine identifiers in the contract are closed-enum strings whose
+  internal structure carries no contract meaning. Adding or removing
+  engines in future releases extends or contracts the enum but does
+  not alter the shape of any endpoint or resource.
 - Per-call audio size is an engine-imposed ceiling. The backend
   enforces the same per-chunk ceiling on each accepted chunk;
   `v0.1.0` documents this as `25 MiB` per chunk.
@@ -224,20 +226,21 @@ chunks into the job's input.
   dimension (after finalize) is a client conflict and must return
   `409 Conflict`.
 - When a new open call arrives under the same
-  `(API key, Idempotency-Key)` as an already-finalized attempt, replay
-  matching compares the new open-call body's `recorded_at`,
-  `chunk_count`, `audio_format`, `session_id`, and `language` against
-  the original open-call values. All match returns the original
-  finalized job. Any mismatch is a client conflict and must return
-  `409 Conflict`. The accepted audio content hash does not participate
-  in this comparison because a fresh open call carries no audio bytes.
+  `(API key, Idempotency-Key)` as an already-terminated attempt
+  (succeeded or failed), replay matching compares the new open-call
+  body's `recorded_at`, `chunk_count`, `audio_format`, `session_id`,
+  and `language` against the original open-call values. All match
+  returns the original terminated job. Any mismatch is a client
+  conflict and must return `409 Conflict`. The accepted audio content
+  hash does not participate in this comparison because a fresh open
+  call carries no audio bytes.
 - Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
 - Deletion of a session referenced by an accepted `session_id` does
   not mutate the stored tuple or invalidate replay of that accepted
   submission attempt.
-- One `Idempotency-Key` names one attempt forever. Reusing it after
-  terminal failure returns the same failed job. An intentional fresh
-  attempt requires a new key.
+- One `Idempotency-Key` names one attempt forever. An intentional
+  fresh attempt after terminal failure requires a new key; reusing
+  the original key returns the same terminated job.
 
 #### Job State Machine
 
@@ -311,6 +314,7 @@ Terminal failure codes:
 - `engine_error`
 - `storage_error`
 - `internal_error`
+- `submission_abandoned`
 
 Semantics:
 
@@ -320,9 +324,14 @@ Semantics:
   `storage_error`, and `internal_error` are retryable classes during
   backend-owned retry, but may still become terminal after retry
   exhaustion.
+- `submission_abandoned` means the submission attempt was opened but
+  was not finalized within the backend's abandonment window; the
+  partial submission has been released and the job is terminal.
 - `retryable_by_client=false` only for `audio_invalid`.
-- `retryable_by_client=true` for the other terminal classes after
-  backend retries have been exhausted.
+- `retryable_by_client=true` for the other terminal classes
+  (including `submission_abandoned`) after backend retries have been
+  exhausted; for `submission_abandoned`, the user's path forward is
+  to record again with a new `Idempotency-Key`.
 
 #### Ordering and Visibility
 

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -2,133 +2,258 @@
 
 Target release: `v0.1.0`
 
+## Exigence
+
+A person speaks. The words matter, but the speaking is fleeting. Oracy
+is the system that catches voice and keeps what was said: the user
+records audio, and the system produces a **voice note** — a durable
+text artifact derived from that audio that the user can search, edit,
+organize, and return to later.
+
+The voice note is the load-bearing artifact. Its data integrity is the
+backend's central commitment: voice notes survive long-term on the
+server, the user searches across them, the user edits them, the user
+organizes them with tags and sessions. Audio is transient input that
+produces a voice note; once the voice note and its embedding exist on
+the server, the audio's job server-side is done. The architecture is
+layered by canonicality: audio is canonical for the voice note's text
+during the transcription pipeline; voice-note text is canonical for
+the embedding derived from it.
+
+This document defines what the backend must do to honor that
+commitment.
+
 ## Capability
 
-The backend accepts authenticated audio submissions, creates durable
-transcription jobs, drives those jobs to a terminal state without requiring
-client resubmission, and materializes successful jobs as long-lived transcript
-records. Completed transcripts carry the data substrate required for `v0.1.0`:
+The backend accepts authenticated chunked audio submissions, composes
+each submission's chunks into one transcription job's input, drives
+the job to a terminal state without requiring client resubmission, and
+materializes successful jobs as long-lived voice-note records.
+Completed voice notes carry the data substrate `v0.1.0` requires:
 current text, linear edit history, timestamped segments, server-side
-embeddings, free-text tags, optional sessions, and transcript search.
+embeddings, free-text tags, optional sessions, and voice-note search.
+The backend exposes a per-API-key settings surface that controls which
+transcription engine model is used for subsequent jobs.
+
+## Operator Prerequisites
+
+The backend depends on two operator-provided resources. Both are
+required, not optional.
+
+### Persistent Storage Location
+
+- A persistent filesystem location for accepted audio chunks, composed
+  audio artifacts, and other job-associated durable artifacts.
+- This location is a required backend dependency, not an optional
+  deployment optimization.
+- The backend must not advertise durable acceptance semantics when
+  this location is unavailable or not writable.
+- `spec/deployment.md` must later define the operator's persistent-
+  storage responsibilities, including path provisioning, persistence
+  across restart, and capacity implications.
+
+### `OPENAI_API_KEY`
+
+- The credential that the OpenAI transcription engine authenticates
+  with.
+- Provided to the backend through the `OPENAI_API_KEY` environment
+  variable.
+- The backend must not advertise transcription capability when
+  `OPENAI_API_KEY` is unset or empty.
+- `spec/deployment.md` must later define the operator's responsibility
+  for provisioning, rotating, and protecting this credential.
 
 ## Constraints
 
 ### Authentication and Ownership
 
-- `v0.1.0` is a single-user testbed authenticated by operator-provisioned API
-  keys.
+- `v0.1.0` is a single-user testbed authenticated by operator-
+  provisioned API keys.
 - No public endpoint creates, rotates, revokes, or deletes API keys in
   `v0.1.0`.
-- Every public resource is scoped to the authenticated API key. A key can only
-  read or mutate its own jobs, transcripts, tags, and sessions.
-- Idempotency isolation is per API key. Different API keys may reuse the same
-  `Idempotency-Key` without colliding.
-- Tag name identity is case-insensitive within one API-key scope. Session
-  identity is by session ID, not by session name.
+- Every public resource is scoped to the authenticated API key. A key
+  can only read or mutate its own jobs, voice notes, tags, sessions,
+  and settings.
+- Idempotency isolation is per API key. Different API keys may reuse
+  the same `Idempotency-Key` without colliding.
+- Tag name identity is case-insensitive within one API-key scope.
+  Session identity is by session ID, not by session name.
+
+### User Settings
+
+- The backend exposes one per-API-key setting in `v0.1.0`:
+  `transcription_model`.
+- The default `transcription_model` for an API key that has never
+  updated settings is `gpt-4o-mini-transcribe`.
+- The selected `transcription_model` applies to every transcription
+  job that reaches `queued` after the update. Jobs already past
+  `queued` are unaffected.
+- The backend persists settings durably and survives restart.
+
+### Engine Surface
+
+- The `v0.1.x` engine family is OpenAI's transcription models.
+- `v0.1.0` ships two model identifiers:
+  - `gpt-4o-mini-transcribe` — default. Fast, low-cost, accuracy
+    suitable for typical voice notes.
+  - `gpt-4o-transcribe` — quality upgrade. Higher accuracy at higher
+    cost, suitable for difficult audio.
+- The backend records the engine identifier in use on each `VoiceNote`
+  via the `model` field, carrying the OpenAI model identifier.
+- Engine identifiers in the contract are opaque strings. Adding or
+  removing models in future releases does not alter contract shape.
+- Per-call audio size is an engine-imposed ceiling. The backend
+  enforces the same per-chunk ceiling on each accepted chunk;
+  `v0.1.0` documents this as `25 MiB` per chunk.
 
 ### Transcription Pipeline
 
 #### Resource Model
 
-- A submission creates a `TranscriptionJob`, not a transcript placeholder.
-- A successful job creates exactly one `Transcript`.
-- Failed and in-flight jobs do not appear in transcript history, transcript
-  detail, session transcript listings, or search results.
-- Transcript resources are long-lived user artifacts. Job resources are
-  workflow artifacts that may point to a transcript once complete.
+- A submission attempt creates a `TranscriptionJob`, not a voice-note
+  placeholder.
+- A successful job creates exactly one `VoiceNote`.
+- Failed and in-flight jobs do not appear in voice-note collections,
+  voice-note detail, session voice-note listings, or search results.
+- Voice-note resources are long-lived user artifacts. Job resources
+  are workflow artifacts that may point to a voice note once complete.
 
 #### Cost Attribution
 
-- The `Transcript` resource includes a `cost_cents` field recording the
-  backend's estimated cost to produce the transcript. The field is present on
-  every transcript resource; its value is nullable.
-- When the backend can compute cost from engine-provided data using fixed-rate
-  pricing, `cost_cents` carries a numeric estimate.
-- `cost_cents` is `null` when the cost cannot be determined without dynamic
-  pricing infrastructure.
+- The `VoiceNote` resource includes a `cost_cents` field recording
+  the backend's estimated cost to produce the voice note. The field
+  is present on every voice-note resource; its value is nullable.
+- When the backend can compute cost from engine-provided data using
+  fixed-rate pricing, `cost_cents` carries a numeric estimate.
+- `cost_cents` is `null` when the cost cannot be determined without
+  dynamic pricing infrastructure.
 
-#### Durable Acceptance
+#### Submission Contract (Chunked)
 
-- `202 Accepted` is a durability commitment, not an admission of best effort.
-- A request may return `202` only after the backend has durably persisted the
-  job record, the accepted audio payload, the accepted audio content hash, and
-  the accepted `recorded_at`, `session_id`, and `language` values used for
-  idempotency matching.
-- If any persistence step fails, the request fails synchronously and no
-  accepted job exists.
-- Accepted jobs must survive backend restart and continue progressing toward a
-  terminal state. The semantic layer requires eventual recovery, but it does
-  not commit a numeric recovery-time bound.
+A submission attempt has three phases: open, push chunks, finalize.
+Audio is chunked client-side so each chunk fits the per-call ceiling
+of the configured transcription engine; the server composes the
+chunks into the job's input.
 
-#### Operator Dependency
-
-- Durable acceptance depends on an operator-provided persistent storage
-  location for accepted audio and other job-associated durable artifacts.
-- This storage location is a required backend dependency, not an optional
-  deployment optimization.
-- The backend must not advertise durable acceptance semantics when that storage
-  location is unavailable or not writable.
-- `spec/deployment.md` must later define the operator's persistent-storage
-  responsibilities, including path provisioning, persistence across restart,
-  and capacity implications.
-
-#### Submission Contract
+**Open**
 
 - Every submission requires authentication by API key.
-- Every submission requires an `Idempotency-Key`, including web submissions.
-- The request body contains the uploaded audio file, required `recorded_at`,
-  optional `session_id`, and optional `language`.
-- `recorded_at` is client-supplied and records when the audio was captured.
-- `language`, when present, is an ISO 639-1 language hint. It constrains the
-  transcription request to that language and disables engine-side
-  auto-detection for that submission.
-- `session_id`, when present, must identify an existing session owned by the
-  authenticated API key.
-- Supported upload formats are `m4a`, `mp3`, `wav`, and `webm`.
-- The maximum accepted upload size is `25 MiB`.
+- Every submission requires an `Idempotency-Key` on the open call,
+  including web submissions.
+- The open-call body declares `recorded_at`, `chunk_count`,
+  `audio_format`, optional `session_id`, and optional `language`.
+- `recorded_at` is client-supplied and records when the audio was
+  captured.
+- `chunk_count` is the number of chunks the client commits to
+  pushing; it is bounded by the contract.
+- `audio_format` must be one of `m4a`, `mp3`, `wav`, `webm`.
+- `session_id`, when present, must identify an existing session owned
+  by the authenticated API key.
+- `language`, when present, is an ISO 639-1 language hint. It
+  constrains the transcription request to that language and disables
+  engine-side auto-detection for that submission.
 - `prompt` is out of scope for `v0.1.0`.
-- Validation that can be performed before acceptance must remain synchronous:
-  authentication, filename presence, supported format, file-size limit,
-  `recorded_at` syntax, session ownership, language syntax, and
-  idempotency-header validity.
+- Pre-acceptance validation that can be performed at open time must
+  remain synchronous: authentication, body fields, format, chunk-count
+  bounds, language syntax, session ownership, idempotency-header
+  validity.
+- The open call returns a `TranscriptionJob` in status
+  `accepting_chunks`. No audio bytes have been transferred yet.
+
+**Push chunks**
+
+- Each chunk push carries `chunk_index`, `chunk_sha256`, and the
+  chunk audio bytes.
+- The backend rejects chunks whose `chunk_index` is out of range,
+  whose bytes exceed the per-chunk ceiling, or whose declared
+  `chunk_sha256` does not match the received bytes.
+- The backend persists each accepted chunk durably as it is received.
+- Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
+  Re-submitting the same pair against the same job is a no-op. A push
+  for a `chunk_index` that already has a different accepted hash is a
+  conflict and returns `409 Conflict`, leaving the previously
+  accepted chunk in place.
+
+**Finalize**
+
+- Finalize seals the submission attempt.
+- The backend requires every declared chunk index to have an accepted
+  chunk before finalize can succeed.
+- The backend composes the accepted chunk hashes into the accepted
+  audio content hash that participates in the idempotency tuple.
+- The backend persists the composed audio artifact.
+- `202 Accepted` is the durability commitment moment, not the
+  per-chunk commitment.
+- A request may return `202` only after the backend has durably
+  persisted the job record's finalized state, the composed audio
+  artifact, the accepted audio content hash, and the accepted
+  `recorded_at`, `session_id`, and `language` values used for
+  idempotency matching.
+- If any persistence step at finalize fails, the request fails
+  synchronously and the job remains in `accepting_chunks` for retry.
+- Accepted (post-finalize) jobs must survive backend restart and
+  continue progressing toward a terminal state. The semantic layer
+  requires eventual recovery; it does not commit a numeric recovery-
+  time bound.
 
 #### Idempotency
 
-- One submission attempt is identified by `API key + Idempotency-Key +
-accepted audio content hash + recorded_at + session_id + language`.
-- The backend computes and stores the accepted audio content hash and the
-  accepted `recorded_at`, `session_id`, and `language` values at acceptance
-  time.
-- The accepted submission tuple is an immutable acceptance-time record, not a
-  live reference to current resource state.
-- For `recorded_at`, replay matching compares the parsed instant normalized to
-  UTC, not the raw wire-format string. Any RFC 3339 UTC representation of the
-  same instant is a match.
+- A submission attempt is identified by
+  `API key + Idempotency-Key + accepted audio content hash +
+  recorded_at + session_id + language`.
+- The `Idempotency-Key` is supplied on the open call and governs
+  replay matching for the entire submission attempt.
+- The backend computes the accepted audio content hash at finalize
+  time as a deterministic composition of the accepted chunk hashes
+  in `chunk_index` order. The backend stores this composed hash and
+  the accepted `recorded_at`, `session_id`, and `language` values at
+  finalize time.
+- The accepted submission tuple is an immutable acceptance-time
+  record, not a live reference to current resource state.
+- For `recorded_at`, replay matching compares the parsed instant
+  normalized to UTC, not the raw wire-format string. Any RFC 3339 UTC
+  representation of the same instant is a match.
 - Omitted optional `session_id` and `language` values participate in
   idempotency as `null`.
-- Reusing the same API key and `Idempotency-Key` with the same accepted
-  submission tuple returns the original job instead of creating duplicate work.
-- Reusing the same API key and `Idempotency-Key` with a mismatch on any
-  accepted submission dimension is a client conflict and must return
+- Reusing the same API key and `Idempotency-Key` with the same open-
+  call body returns the original open job. Reusing them with the same
+  accepted submission tuple after finalize returns the original
+  finalized job.
+- Reusing the same API key and `Idempotency-Key` with a mismatch on
+  any open-call dimension (before finalize) or any accepted submission
+  dimension (after finalize) is a client conflict and must return
   `409 Conflict`.
-- Deletion of a session referenced by an accepted `session_id` does not mutate
-  the stored tuple or invalidate replay of that accepted submission attempt.
-- One `Idempotency-Key` names one attempt forever. Reusing it after terminal
-  failure returns the same failed job. An intentional fresh attempt requires a
-  new key.
+- Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
+- Deletion of a session referenced by an accepted `session_id` does
+  not mutate the stored tuple or invalidate replay of that accepted
+  submission attempt.
+- One `Idempotency-Key` names one attempt forever. Reusing it after
+  terminal failure returns the same failed job. An intentional fresh
+  attempt requires a new key.
 
 #### Job State Machine
 
 Permitted states:
 
-- `queued`: accepted, durable, not currently being processed
+- `accepting_chunks`: open call accepted, awaiting chunk pushes and
+  finalize
+- `queued`: durably accepted at finalize, not currently being
+  processed
 - `processing`: actively claimed by a worker
 - `retry_waiting`: waiting for the backend's scheduled retry window
-- `succeeded`: terminal success, transcript persisted
+- `succeeded`: terminal success, voice note persisted
 - `failed`: terminal failure, no further backend retry
+
+`accepting_chunks` is a contract-visible status. The client
+legitimately needs to know whether the server is ready for finalize,
+and forcing the client to track an invariant the server already knows
+is unnecessary asymmetry.
 
 Permitted transitions:
 
+- `accepting_chunks -> queued` (finalize success)
+- `accepting_chunks -> failed` (terminal pre-finalize failure such as
+  abandonment timeout)
 - `queued -> processing`
 - `processing -> succeeded`
 - `processing -> retry_waiting`
@@ -137,21 +262,28 @@ Permitted transitions:
 
 Constraints on transitions:
 
-- A job enters `succeeded` only after its transcript record, current
-  transcript version, segments, and current embedding have been durably stored.
-- A job enters `failed` only for a terminal classification or after exhausting
-  backend-managed retries.
-- `processing` is leased work, not a terminal assumption. A crashed worker or
-  backend restart must allow the job to be reclaimed and resumed.
+- A job enters `succeeded` only after its voice-note record, current
+  voice-note version, segments, and current embedding have been
+  durably stored.
+- A job enters `failed` only for a terminal classification, after
+  exhausting backend-managed retries, or — from `accepting_chunks` —
+  for a terminal pre-finalize failure.
+- `processing` is leased work, not a terminal assumption. A crashed
+  worker or backend restart must allow the job to be reclaimed and
+  resumed.
 
 #### Retry Ownership
 
-- Once a job is accepted, the backend owns transient retries.
+- Once a job has been accepted (post-finalize), the backend owns
+  transient retries.
 - The client does not resubmit while the job is nonterminal.
 - The job resource must expose `retry_count` on every read.
 - The job resource must expose `next_attempt_at` when the job is in
-  `retry_waiting` so the client can suppress wasteful polling during a known
-  backoff window.
+  `retry_waiting` so the client can suppress wasteful polling during
+  a known backoff window.
+- The job resource must expose `chunks_received` while the job is in
+  `accepting_chunks` so the client can render upload progress and
+  decide when to call `finalize`.
 
 #### Failure Semantics
 
@@ -166,215 +298,288 @@ Terminal failure codes:
 
 Semantics:
 
-- `audio_invalid` means the accepted payload cannot be transcribed and further
-  client retry of the same audio is not meaningful.
-- `engine_timeout`, `engine_rate_limited`, `engine_error`, `storage_error`,
-  and `internal_error` are retryable classes during backend-owned retry, but
-  may still become terminal after retry exhaustion.
+- `audio_invalid` means the accepted payload cannot be transcribed
+  and further client retry of the same audio is not meaningful.
+- `engine_timeout`, `engine_rate_limited`, `engine_error`,
+  `storage_error`, and `internal_error` are retryable classes during
+  backend-owned retry, but may still become terminal after retry
+  exhaustion.
 - `retryable_by_client=false` only for `audio_invalid`.
-- `retryable_by_client=true` for the other terminal classes after backend
-  retries have been exhausted.
+- `retryable_by_client=true` for the other terminal classes after
+  backend retries have been exhausted.
 
 #### Ordering and Visibility
 
-- Job claim order is FIFO by readiness: first by retry eligibility, then by
-  acceptance time.
+- Job claim order is FIFO by readiness: first by retry eligibility,
+  then by acceptance (finalize) time.
 - Completion order is not guaranteed and is not exposed as a contract.
-- Transcript history is ordered newest-first by transcript `created_at`, with
-  descending `id` as the deterministic tiebreaker.
+- Voice-note history is ordered newest-first by voice-note
+  `created_at`, with descending `id` as the deterministic tiebreaker.
 
 ### Data Substrate
 
-#### Transcript
+#### VoiceNote
 
-- The `Transcript` resource includes `id`, `current_version_id`, `transcript`,
-  `audio_duration_seconds`, `audio_format`, `audio_size_bytes`,
-  `transcript_language`, `model`, `processing_time_ms`, `cost_cents`,
-  `created_at`, `recorded_at`, `session_id`, and `tags`.
-- `transcript` is always the current transcript version's text.
-- `current_version_id` points to the latest `TranscriptVersion`.
-- `created_at` records when the transcript was first materialized from a
-  successful job.
+- The `VoiceNote` resource includes `id`, `current_version_id`,
+  `text`, `audio_duration_seconds`, `audio_format`,
+  `audio_size_bytes`, `language`, `model`, `processing_time_ms`,
+  `cost_cents`, `created_at`, `recorded_at`, `session_id`, and
+  `tags`.
+- `text` is always the current voice-note version's text.
+- `current_version_id` points to the latest `VoiceNoteVersion`.
+- `created_at` records when the voice note was first materialized
+  from a successful job.
 - `recorded_at` records when the client says the audio was captured.
+- `audio_duration_seconds`, `audio_format`, and `audio_size_bytes`
+  are durable provenance properties of the voice note. They survive
+  even after the composed audio bytes have been released from the
+  server at the originating job's terminal state.
+- `language` is the language hint used for the transcription, or the
+  detected language when no hint was supplied.
+- `model` carries the OpenAI engine identifier in use when the voice
+  note was produced.
 - `session_id` is nullable.
-- `tags` is an array of `Tag` resources owned by the authenticated API key.
+- `tags` is an array of `Tag` resources owned by the authenticated
+  API key.
 
-#### TranscriptVersion
+#### VoiceNoteVersion
 
-- The `TranscriptVersion` resource includes `id`, `transcript_id`,
-  `transcript`, and `created_at`.
-- Version history is linear and append-only. No branching or merging exists in
-  `v0.1.0`.
-- The initial transcription result becomes the first transcript version.
-- Each text edit creates one new `TranscriptVersion` and moves
-  `Transcript.current_version_id` to that new version.
-- Historical versions remain readable through the version-history endpoint.
+- The `VoiceNoteVersion` resource includes `id`, `voice_note_id`,
+  `text`, and `created_at`.
+- Version history is linear and append-only. No branching or merging
+  exists in `v0.1.0`.
+- The initial transcription result becomes the first voice-note
+  version.
+- Each text edit creates one new `VoiceNoteVersion` and moves
+  `VoiceNote.current_version_id` to that new version.
+- Historical versions remain readable through the version-history
+  endpoint.
 
 #### Segment
 
-- The `Segment` resource includes `id`, `transcript_id`, `position`,
+- The `Segment` resource includes `id`, `voice_note_id`, `position`,
   `start_ms`, `end_ms`, and `text`.
-- Segments are stored as first-class rows joined to the transcript, not as a
-  blob embedded in transcript text.
+- Segments are stored as first-class rows joined to the voice note,
+  not as a blob embedded in voice-note text.
 - Segment ordering is ascending by `position`.
-- Segments represent engine-ground-truth timing. They are not user-editable in
-  `v0.1.0`.
-- Segments remain anchored to the transcript across transcript text edits.
-- Speaker diarization is out of scope. No `speaker_label` field exists in
-  `v0.1.0`.
+- `start_ms` and `end_ms` are measured from the start of the composed
+  audio and represent engine-ground-truth timing. Segments are not
+  user-editable in `v0.1.0`.
+- Segments remain anchored to the voice note across voice-note text
+  edits.
+- Speaker diarization is out of scope. No `speaker_label` field
+  exists in `v0.1.0`.
 
 #### Tag
 
 - The `Tag` resource includes `id`, `name`, and `created_at`.
-- Tags are free-text and many-to-many with transcripts.
+- Tags are free-text and many-to-many with voice notes.
 - Tag identity is case-insensitive within one API-key scope.
-- The stored `name` preserves the spelling of the latest create or rename
-  request that established the current tag value.
-- Creating a tag with a case-insensitive name that already exists for the
-  authenticated API key returns the existing `Tag` instead of creating a
-  duplicate.
-- Renaming a tag updates the visible name on every associated transcript
-  immediately because associations are by `tag_id`, not copied text.
+- The stored `name` preserves the spelling of the latest create or
+  rename request that established the current tag value.
+- Creating a tag with a case-insensitive name that already exists for
+  the authenticated API key returns the existing `Tag` instead of
+  creating a duplicate.
+- Renaming a tag updates the visible name on every associated voice
+  note immediately because associations are by `tag_id`, not copied
+  text.
 
 #### Session
 
 - The `Session` resource includes `id`, `name`, and `created_at`.
-- Sessions are optional groupings for related recordings.
-- A transcript may belong to at most one session in `v0.1.0`.
-- `session_id=null` is valid and means the transcript is ungrouped.
-- Session identity is by ID. Session names are not required to be unique.
+- Sessions are optional groupings for related voice notes.
+- A voice note may belong to at most one session in `v0.1.0`.
+- `session_id=null` is valid and means the voice note is ungrouped.
+- Session identity is by ID. Session names are not required to be
+  unique.
 
 #### Embeddings
 
-- The backend stores one current embedding per transcript.
-- The first embedding is generated when a successful transcription job creates
-  the transcript.
-- A text edit triggers asynchronous regeneration of the transcript's current
-  embedding.
-- Full-text reads reflect the new transcript text immediately after the edit is
-  committed.
+- The backend stores one current embedding per voice note.
+- The first embedding is generated when a successful transcription
+  job creates the voice note.
+- A text edit triggers asynchronous regeneration of the voice note's
+  current embedding.
+- Full-text reads reflect the new voice-note text immediately after
+  the edit is committed.
 - Semantic and hybrid search may return stale matches until embedding
   regeneration completes.
-- Embeddings are not exposed on the default transcript resource and no public
-  endpoint returns embedding vectors in `v0.1.0`.
+- Embeddings are not exposed on the default voice-note resource and
+  no public endpoint returns embedding vectors in `v0.1.0`.
+
+#### Editing Scope
+
+- Editing is the only adjustment path for an existing voice note.
+- The backend does not re-transcribe audio against an existing voice
+  note. Once a voice note exists, it is final from the transcription
+  pipeline's perspective; subsequent quality concerns are addressed
+  through editing.
+- If a transcription job fails terminally before a voice note is
+  produced, the user's path forward is to record again or re-upload
+  from local storage. The backend treats the new submission as a
+  fresh transcription attempt, producing a new voice-note identity if
+  successful.
+
+#### Settings
+
+- The `Settings` resource includes `transcription_model`.
+- The `transcription_model` value is one of the documented engine
+  identifiers (`gpt-4o-mini-transcribe`, `gpt-4o-transcribe`).
+- The default at first read for an API key that has never updated
+  settings is `gpt-4o-mini-transcribe`.
 
 ### Search and Retrieval
 
-- Transcript history and transcript search share one collection contract:
-  `GET /api/v1/transcripts`.
-- Without `q`, the collection is transcript history with optional filters.
-- With `q`, the collection is transcript search with the same result shape,
-  filters, and pagination. This is an explicit `v0.1.0` governance decision to
-  avoid duplicating transcript-collection surface with no semantic gain.
-- Search results are always `Transcript` resources. Jobs, sessions, tags,
-  versions, and segments are not returned as search hits.
-- Keyword search supports full-text matching over current transcript text and
-  may additionally match historical transcript-version text, but results always
-  resolve to the parent `Transcript`.
-- Semantic search uses the current transcript embedding.
-- Hybrid search combines keyword and semantic ranking over the same transcript
-  result set.
-- When `q` is present and `search_mode` is omitted, the backend defaults to
-  `hybrid`.
+- Voice-note history and voice-note search share one collection
+  contract: `GET /api/v1/voice-notes`.
+- Without `q`, the collection is voice-note history with optional
+  filters.
+- With `q`, the collection is voice-note search with the same result
+  shape, filters, and pagination. This is an explicit `v0.1.0`
+  governance decision to avoid duplicating voice-note collection
+  surface with no semantic gain.
+- Search results are always `VoiceNote` resources. Jobs, sessions,
+  tags, versions, and segments are not returned as search hits.
+- Keyword search supports full-text matching over current voice-note
+  text and may additionally match historical voice-note-version text,
+  but results always resolve to the parent `VoiceNote`.
+- Semantic search uses the current voice-note embedding.
+- Hybrid search combines keyword and semantic ranking over the same
+  voice-note result set.
+- When `q` is present and `search_mode` is omitted, the backend
+  defaults to `hybrid`.
 - Search filters support tag, session, `recorded_at` time range, and
-  `created_at` time range. `*_after` bounds are exclusive; `*_before` bounds
-  are inclusive.
-- Repeated `tag_id` filters combine by intersection: a transcript matches only
-  if it is associated with all supplied tags.
-- Transcript history is ordered newest-first by transcript `created_at`, with
+  `created_at` time range. `*_after` bounds are exclusive;
+  `*_before` bounds are inclusive.
+- Repeated `tag_id` filters combine by intersection: a voice note
+  matches only if it is associated with all supplied tags.
+- Voice-note history is ordered newest-first by voice-note
+  `created_at`, with descending `id` as the deterministic tiebreaker.
+- Version-history listings are ordered newest-first by `created_at`,
+  with descending `id` as the deterministic tiebreaker.
+- Tag listings are ordered newest-first by `created_at`, with
   descending `id` as the deterministic tiebreaker.
-- Version-history listings are ordered newest-first by `created_at`, with
+- Session listings are ordered newest-first by `created_at`, with
   descending `id` as the deterministic tiebreaker.
-- Tag listings are ordered newest-first by `created_at`, with descending `id`
-  as the deterministic tiebreaker.
-- Session listings are ordered newest-first by `created_at`, with descending
-  `id` as the deterministic tiebreaker.
-- Search results are ordered by backend relevance score descending, then by
-  transcript `created_at` descending, then by descending `id` as the final
-  deterministic tiebreaker.
-- Transcript collection pagination is cursor-based. The default page size is
-  `50`; the maximum page size is `100`.
-- Transcript, session, tag, version-history, and segment listings use the same
-  collection envelope: `items` plus nullable `next_cursor`.
+- Search results are ordered by backend relevance score descending,
+  then by voice-note `created_at` descending, then by descending `id`
+  as the final deterministic tiebreaker.
+- Voice-note collection pagination is cursor-based. The default page
+  size is `50`; the maximum page size is `100`.
+- Voice-note, session, tag, version-history, and segment listings use
+  the same collection envelope: `items` plus nullable `next_cursor`.
 
 ### Mutation Semantics
 
-- `PATCH /api/v1/transcripts/{transcript_id}` changes transcript text only.
-- A transcript edit creates a new `TranscriptVersion`; it does not rewrite or
-  delete prior versions.
-- `PUT /api/v1/transcripts/{transcript_id}/tags` replaces the transcript's
-  entire tag set with the supplied `tag_ids`.
-- Replacing tags does not create a new `TranscriptVersion`.
-- Session membership is assigned only at transcription submission time in
-  `v0.1.0`. No later transcript-to-session reassignment endpoint exists.
+- `PATCH /api/v1/voice-notes/{voice_note_id}` changes voice-note text
+  only.
+- A voice-note edit creates a new `VoiceNoteVersion`; it does not
+  rewrite or delete prior versions.
+- `PUT /api/v1/voice-notes/{voice_note_id}/tags` replaces the voice
+  note's entire tag set with the supplied `tag_ids`.
+- Replacing tags does not create a new `VoiceNoteVersion`.
+- Session membership is assigned only at transcription submission
+  time in `v0.1.0`. No later voice-note-to-session reassignment
+  endpoint exists.
+- `PATCH /api/v1/settings` is a partial update; omitted fields are
+  left unchanged.
 
 ### Deletion and Retention
 
-- Transcript retention is indefinite until explicit transcript deletion.
-- Transcript deletion is a hard delete with no grace period.
-- Deleting a transcript cascades to its versions, segments, current embedding,
-  and tag associations.
-- The originating `TranscriptionJob` survives transcript deletion as the durable
-  replay record for the accepted submission attempt.
-- If a deleted transcript came from a succeeded job, that job remains
-  `succeeded` and its `transcript_id` becomes `null`.
-- Deleting a session sets `session_id` to `null` on contained transcripts. The
-  transcripts remain otherwise unchanged.
-- Deleting a session does not invalidate replay records for submissions that
-  were accepted with that `session_id`.
-- Deleting a tag removes its transcript associations. The transcripts remain
-  otherwise unchanged.
-- The backend retains accepted audio only while a job is `queued`,
-  `processing`, or `retry_waiting`.
-- Once a job reaches `succeeded` or `failed`, the backend must promptly delete
-  the retained audio.
-- Failure to delete retained audio does not create a new public job state. The
-  job remains terminal while cleanup is retried internally and surfaced to
-  operators through logs and metrics.
+- Voice-note retention is indefinite until explicit voice-note
+  deletion.
+- Voice-note deletion is a hard delete with no grace period.
+- Deleting a voice note cascades to its versions, segments, current
+  embedding, and tag associations.
+- The originating `TranscriptionJob` survives voice-note deletion as
+  the durable replay record for the accepted submission attempt.
+- If a deleted voice note came from a succeeded job, that job remains
+  `succeeded` and its `voice_note_id` becomes `null`.
+- Deleting a session sets `session_id` to `null` on contained voice
+  notes. The voice notes remain otherwise unchanged.
+- Deleting a session does not invalidate replay records for
+  submissions that were accepted with that `session_id`.
+- Deleting a tag removes its voice-note associations. The voice notes
+  remain otherwise unchanged.
+- The backend retains accepted audio chunks and composed audio only
+  while a job is in `accepting_chunks`, `queued`, `processing`, or
+  `retry_waiting`.
+- Once a job reaches `succeeded` or `failed`, the backend must
+  promptly delete the retained audio chunks and composed audio.
+- Failure to delete retained audio does not create a new public job
+  state. The job remains terminal while cleanup is retried internally
+  and surfaced to operators through logs and metrics.
 
 ### Error Contract
 
-- Every `4xx` and `5xx` response body is JSON with at least `error_code` and
-  `message`.
-- `details` is optional and carries structured validation or conflict context
-  when useful.
-- Validation errors use `details` to identify request fields that failed
-  validation.
-- Error response structure is shared across job, transcript, tag, and session
-  endpoints.
+- Every `4xx` and `5xx` response body is JSON with at least
+  `error_code` and `message`.
+- `details` is optional and carries structured validation or conflict
+  context when useful.
+- Validation errors use `details` to identify request fields that
+  failed validation.
+- Error response structure is shared across job, voice-note, tag,
+  session, and settings endpoints.
 
 ## Acceptance
 
-The backend requirements are acceptable for `v0.1.0` when the following are
-true:
+The backend requirements are acceptable for `v0.1.0` when the
+following are true:
 
-- Valid submission returns a durable job resource instead of a blocking
-  transcript response.
-- Replaying a submission with the same API key, `Idempotency-Key`, and
-  accepted submission tuple returns the same job in every state.
-- Reusing an accepted `Idempotency-Key` with a mismatch on any accepted
-  submission dimension returns `409 Conflict` and leaves the original job
-  unchanged.
-- Accepted jobs survive backend restart and still reach a terminal state.
-- Backend-managed retries move transient failures through `retry_waiting`
-  instead of forcing client resubmission.
-- `retry_count` is always visible on the job resource, and `next_attempt_at`
-  is visible during `retry_waiting`.
-- Successful jobs create one transcript each and only completed transcripts
-  appear in transcript history, detail, session transcript listings, and
-  search.
-- Deleting a transcript does not delete its originating job, and replay of the
-  same accepted submission tuple still returns that original job.
-- The transcript substrate is concrete: transcripts carry current text,
-  sessions, tags, and current version identity; versions are append-only;
-  segments are first-class timing rows; embeddings are stored server-side and
-  regenerated asynchronously after text edits.
-- Search behavior is explicit: history and search share one transcript
-  collection contract, omitted `search_mode` with `q` defaults to `hybrid`,
-  repeated `tag_id` filters intersect, results are transcript-only, and
-  semantic search is eventually consistent after edits.
-- Deletion semantics are explicit and match resource ownership expectations.
-- Supported audio formats, maximum upload size, language-hint semantics,
-  pagination shape, and error-envelope semantics are named concretely.
-- No vendor product names appear in contract shapes or response field names,
-  and no implementation substrate leaks into the backend requirements.
+- The operator's persistent storage location and `OPENAI_API_KEY` are
+  named as required prerequisites, and the backend refuses to
+  advertise the dependent capabilities when either is missing.
+- A valid open call returns a `TranscriptionJob` in
+  `accepting_chunks` with the declared `chunk_count`.
+- Each accepted chunk push moves `chunks_received` toward
+  `chunk_count`, and the chunk push is idempotent on
+  `(chunk_index, chunk_sha256)`.
+- A finalize call after every declared chunk has been accepted
+  returns `202 Accepted` and durably commits the job, the composed
+  audio, and the accepted submission tuple before returning.
+- Replaying a submission with the same API key, `Idempotency-Key`,
+  and accepted submission tuple returns the same job in every state.
+- Reusing an accepted `Idempotency-Key` with a mismatch on any
+  open-call or accepted submission dimension returns `409 Conflict`
+  and leaves the original job unchanged.
+- Accepted (post-finalize) jobs survive backend restart and still
+  reach a terminal state.
+- Backend-managed retries move transient failures through
+  `retry_waiting` instead of forcing client resubmission.
+- `retry_count` is always visible on the job resource;
+  `next_attempt_at` is visible during `retry_waiting`;
+  `chunks_received` is visible during `accepting_chunks`.
+- Successful jobs create one voice note each, and only completed
+  voice notes appear in voice-note collections, detail, session
+  voice-note listings, and search.
+- Each `VoiceNote.model` carries the OpenAI engine identifier in use
+  when the voice note was produced.
+- The settings resource exposes `transcription_model` per API key
+  with the documented default; updates apply to jobs that reach
+  `queued` after the update; settings persist across restart.
+- Deleting a voice note does not delete its originating job, and
+  replay of the same accepted submission tuple still returns that
+  original job.
+- The voice-note substrate is concrete: voice notes carry current
+  text, sessions, tags, and current version identity; versions are
+  append-only; segments are first-class timing rows; embeddings are
+  stored server-side and regenerated asynchronously after text edits.
+- Editing is the only adjustment path for an existing voice note;
+  the backend does not re-transcribe against an existing voice note.
+- Search behavior is explicit: history and search share one voice-
+  note collection contract, omitted `search_mode` with `q` defaults
+  to `hybrid`, repeated `tag_id` filters intersect, results are
+  voice-note-only, and semantic search is eventually consistent
+  after edits.
+- Deletion semantics are explicit and match resource ownership
+  expectations.
+- Audio retention semantics are explicit: chunks and composed audio
+  are released promptly once the originating job reaches `succeeded`
+  or `failed`.
+- Supported audio formats, per-chunk size ceiling, language-hint
+  semantics, pagination shape, and error-envelope semantics are
+  named concretely.
+- No vendor product names appear in contract shapes or response
+  field names outside the engine surface section and the
+  `VoiceNote.model` field, and no implementation substrate leaks
+  into the backend requirements.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -104,11 +104,14 @@ required, not optional.
   internal structure carries no contract meaning. Adding or removing
   engines in future releases extends or contracts the enum but does
   not alter the shape of any endpoint or resource.
-- Per-call audio size is an engine-imposed ceiling. The backend
-  enforces the same per-chunk ceiling on each accepted chunk;
-  `v0.1.0` documents this as `25 MiB` per chunk (`26,214,400` bytes
-  — the actual server-enforced limit, which OpenAI's documentation
-  describes loosely as "25 MB").
+- Per-call audio size is an engine-imposed ceiling. Both `v0.1.0`
+  engines share the same per-call ceiling of `25 MiB`
+  (`26,214,400` bytes — the actual server-enforced limit, which
+  OpenAI's documentation describes loosely as "25 MB"). The backend
+  enforces this ceiling on each accepted chunk. The per-chunk
+  ceiling is therefore fixed for `v0.1.0` and does not vary by
+  configured `transcription_model`. A future engine with a different
+  per-call ceiling would require an explicit contract change.
 
 ### Transcription Pipeline
 
@@ -221,6 +224,12 @@ chunks into the job's input.
   finalize time.
 - The accepted submission tuple is an immutable acceptance-time
   record, not a live reference to current resource state.
+- The backend stores the original open-call `chunk_count` and
+  `audio_format` durably alongside the accepted submission tuple for
+  the lifetime of the replay record. These fields participate in
+  pre-finalize replay matching and in terminal-replay matching for a
+  fresh open call under the same `(API key, Idempotency-Key)`, and
+  must survive backend restart.
 - For `recorded_at`, replay matching compares the parsed instant
   normalized to UTC, not the raw wire-format string. Any RFC 3339 UTC
   representation of the same instant is a match.
@@ -244,6 +253,11 @@ chunks into the job's input.
   hash does not participate in this comparison because a fresh open
   call carries no audio bytes.
 - Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
+- Idempotency replay takes precedence over session-existence
+  validation on the open call. When a replay match exists under the
+  same `(API key, Idempotency-Key)`, the backend returns the original
+  job even if the supplied `session_id` no longer identifies an
+  existing session for the authenticated API key.
 - Deletion of a session referenced by an accepted `session_id` does
   not mutate the stored tuple or invalidate replay of that accepted
   submission attempt.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -223,6 +223,14 @@ chunks into the job's input.
   any open-call dimension (before finalize) or any accepted submission
   dimension (after finalize) is a client conflict and must return
   `409 Conflict`.
+- When a new open call arrives under the same
+  `(API key, Idempotency-Key)` as an already-finalized attempt, replay
+  matching compares the new open-call body's `recorded_at`,
+  `chunk_count`, `audio_format`, `session_id`, and `language` against
+  the original open-call values. All match returns the original
+  finalized job. Any mismatch is a client conflict and must return
+  `409 Conflict`. The accepted audio content hash does not participate
+  in this comparison because a fresh open call carries no audio bytes.
 - Chunk pushes are idempotent on `(chunk_index, chunk_sha256)`.
 - Deletion of a session referenced by an accepted `session_id` does
   not mutate the stored tuple or invalidate replay of that accepted
@@ -268,6 +276,14 @@ Constraints on transitions:
 - A job enters `failed` only for a terminal classification, after
   exhausting backend-managed retries, or — from `accepting_chunks` —
   for a terminal pre-finalize failure.
+- The backend enforces a bounded abandonment window on jobs in
+  `accepting_chunks`. A job that has not been finalized within that
+  window transitions to terminal `failed` and is no longer eligible
+  to receive chunks or finalize. This bounds the lifetime of
+  unfinalized submission state. The specific window value and the
+  precise abandonment definition are implementation-tunable and not
+  contract-visible; clients observe only the eventual state
+  transition through the `TranscriptionJob` resource.
 - `processing` is leased work, not a terminal assumption. A crashed
   worker or backend restart must allow the job to be reclaimed and
   resumed.
@@ -537,6 +553,9 @@ following are true:
 - A finalize call after every declared chunk has been accepted
   returns `202 Accepted` and durably commits the job, the composed
   audio, and the accepted submission tuple before returning.
+- An `accepting_chunks` job that is not finalized within the
+  backend's abandonment window transitions to terminal `failed`
+  rather than persisting indefinitely.
 - Replaying a submission with the same API key, `Idempotency-Key`,
   and accepted submission tuple returns the same job in every state.
 - Reusing an accepted `Idempotency-Key` with a mismatch on any

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -106,7 +106,9 @@ required, not optional.
   not alter the shape of any endpoint or resource.
 - Per-call audio size is an engine-imposed ceiling. The backend
   enforces the same per-chunk ceiling on each accepted chunk;
-  `v0.1.0` documents this as `25 MiB` per chunk.
+  `v0.1.0` documents this as `25 MiB` per chunk (`26,214,400` bytes
+  — the actual server-enforced limit, which OpenAI's documentation
+  describes loosely as "25 MB").
 
 ### Transcription Pipeline
 
@@ -175,6 +177,10 @@ chunks into the job's input.
   for a `chunk_index` that already has a different accepted hash is a
   conflict and returns `409 Conflict`, leaving the previously
   accepted chunk in place.
+- The `audio_format` declared at open time applies uniformly to all
+  chunks. Per-chunk format integrity is not separately validated; the
+  engine validates the assembled audio and surfaces inconsistency as
+  `audio_invalid`.
 
 **Finalize**
 
@@ -197,6 +203,9 @@ chunks into the job's input.
   continue progressing toward a terminal state. The semantic layer
   requires eventual recovery; it does not commit a numeric recovery-
   time bound.
+- Session deletion between open and finalize does not block finalize.
+  The resulting voice note's `session_id` is `null`, consistent with
+  the standard session-deletion cascade.
 
 #### Idempotency
 
@@ -241,6 +250,11 @@ chunks into the job's input.
 - One `Idempotency-Key` names one attempt forever. An intentional
   fresh attempt after terminal failure requires a new key; reusing
   the original key returns the same terminated job.
+- The composition function used to derive the accepted audio content
+  hash from the accepted chunk hashes is durably pinned within a
+  backend deployment so replay matching survives restart. The exact
+  function is implementation-owned; the persistence property is
+  contract-relevant.
 
 #### Job State Machine
 


### PR DESCRIPTION
## Summary

- `Oracy_Architecture_v0_1_0.md` is now authoritative for v0.1.0; this rewrites both spec documents to encode it exactly while preserving spec-owned ground (auth, ownership, idempotency, tags, sessions, search, embeddings, retry, failure semantics).
- Three architectural shifts land here: the durable artifact rename (`Transcript` → `VoiceNote`), the chunked submission protocol (open / push chunks / finalize, with `accepting_chunks` as a contract-visible status), and the engine surface (OpenAI engine family with two ship-time models, per-API-key `transcription_model` setting, `OPENAI_API_KEY` operator prerequisite).
- Both files open with an exigence section that anchors every later commitment in what the system answers — voice note as durable artifact, audio as transient input, layered canonicality.
- Post-review commit closes three gaps surfaced during governance review: adds `submission_abandoned` to the terminal failure-code set so the `accepting_chunks → failed` (abandonment) transition has a contract-visible cause; generalizes the open-call replay rule across both spec files to cover both terminal states (succeeded and failed); replaces "opaque strings" wording in the engine-surface sections with closed-enum wording that no longer contradicts the enumerated identifiers.

## Changes

**`spec/api-contract.md`**

- Adds an exigence opening framing voice note as the durable artifact.
- Replaces `POST /api/v1/transcriptions` (single multipart, 25 MiB cap) with the chunked protocol:
  - `POST /api/v1/transcription-jobs` opens an attempt with `Idempotency-Key`, body declares `recorded_at`, `chunk_count`, `audio_format`, optional `session_id`/`language`. Returns a `TranscriptionJob` in `accepting_chunks`.
  - `POST /api/v1/transcription-jobs/{id}/chunks` pushes chunks. Idempotent on `(chunk_index, chunk_sha256)`.
  - `POST /api/v1/transcription-jobs/{id}/finalize` is the `202 Accepted` durability commitment. Composes the accepted chunk hashes into the audio content hash that participates in the idempotency tuple.
- Renames the resource family wholesale: `Transcript` → `VoiceNote`, `transcript_id` → `voice_note_id`, `transcript` field → `text`, `transcript_language` → `language`. Endpoints become `/api/v1/voice-notes`, `/api/v1/voice-notes/{id}/{versions,segments,tags}`, and `/api/v1/sessions/{id}/voice-notes`.
- Adds `GET`/`PATCH /api/v1/settings` with one v0.1.0 field, `transcription_model`. Engine surface section enumerates `gpt-4o-mini-transcribe` (default) and `gpt-4o-transcribe` as a closed enum.
- Updates idempotency rules for the chunked protocol; the open-call replay rule covers both terminal states (succeeded and failed) under the same `(API key, Idempotency-Key)`. Preserves auth, error envelope, pagination, ordering, search semantics, tags, sessions, version history, segments, and deletion semantics verbatim with `voice_note` re-references.
- Adds new non-goals: no embedding-vector export, no runtime engine-discovery endpoint.

**`spec/backend-requirements.md`**

- Mirrors the exigence opening with the data-integrity / load-bearing framing and the layered canonicality (`audio → text → embedding`).
- Adds `OPENAI_API_KEY` as a required operator prerequisite alongside the existing persistent storage requirement; backend must not advertise transcription capability when unset.
- Adds the User Settings constraint (`transcription_model`, default `gpt-4o-mini-transcribe`, applies to jobs reaching `queued` after update, persists across restart) and the Engine Surface constraint (OpenAI engine family, two model identifiers, closed-enum discipline, per-chunk ceiling = engine per-call ceiling).
- Replaces the single-file submission contract with the chunked Open / Push / Finalize contract; adds `accepting_chunks` to the job state machine with the new `accepting_chunks → queued` and `accepting_chunks → failed` transitions; the latter emits `submission_abandoned` on abandonment-window timeout.
- Updates idempotency to treat the post-finalize composed audio hash as the accepted-tuple audio hash; chunk pushes are idempotent on `(chunk_index, chunk_sha256)`. Open-call replay against an already-terminated attempt (succeeded or failed) returns the original terminated job; fresh attempts after terminal failure require a new key.
- Audio retention covers `accepting_chunks` alongside `queued`/`processing`/`retry_waiting`; release is prompt at `succeeded`/`failed`.
- Adds an Editing Scope subsection: editing is the only adjustment path for an existing voice note; the backend does not re-transcribe against an existing voice note.
- Acceptance criteria updated to cover the chunked protocol, settings surface, engine identifier on voice notes, and the operator credential prerequisite.

## Follow-ups filed

Per the project's fix-or-file discipline (Principle 5):

- **#32** — `feat(backend): align implementation with v0.1.0 spec rewrite`. Consolidated tracker for the implementation drift this PR introduces (rename, `accepting_chunks` substrate, settings resource, `OPENAI_API_KEY` wiring, per-`VoiceNote` engine identifier).
- **#31** — `spec(api-contract): surface failure_code enum on TranscriptionJob schema`. Pre-existing condition; the contract-visible `failure_code` enum lives only in `spec/backend-requirements.md` and should move next to its wire surface.
- **#30** — `spec(api-contract): surface pagination defaults (50/100) on collection endpoints`.
- **#29** — `spec(backend): reckon abandonment window value and definition for accepting_chunks jobs`.

All four carry the `spec` label and `v0.1.0` milestone.

## Test plan

Specs are documentation; verification is by reading.

- [ ] Read both files end-to-end without consulting `Oracy_Architecture_v0_1_0.md` — every concept is defined where it first appears, and the exigence anchors every later section.
- [ ] Walk every architectural commitment in `Oracy_Architecture_v0_1_0.md` against the spec and confirm an explicit landing site (voice note artifact, audio retention, layered canonicality, chunked upload, transcribe-with-configured-model, structure, search, lifecycle, engine surface, configuration surface).
- [ ] Confirm the preserved areas remain substantively present: auth, ownership, idempotency rules, tags, sessions, search semantics, embedding subsystem, retry policy, failure codes, error envelope, pagination, segments, deletion.
- [ ] Cross-document consistency: `TranscriptionJob` status enum, `VoiceNote` field set, audio-format list, per-chunk ceiling, pagination defaults, default model, terminal failure-code set (including `submission_abandoned`), open-call replay wording for terminated attempts, and `ErrorResponse` shape match across both files.
- [ ] No vendor leakage outside the engine surface section and the `VoiceNote.model` field — confirm with `grep -i 'openai\|gpt-4o' spec/`.
