### PR TITLE
docs: align v0.1.0 documentation surfaces with the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-Oracy is the voice transcription product: `client/` contains the Flutter
-application, `spec/` defines the public API contract, and `backend/` contains
-the Rust backend service.
+Oracy catches voice and keeps it. The user records audio; Oracy produces a
+**voice note** — a durable text artifact derived from that audio, kept on
+the server so it can be searched, edited, organized with tags and sessions,
+and returned to.
+
+`v0.1.0` delivers the voice-note substrate: chunked-audio submission,
+OpenAI-backed transcription, durable storage, edit history, timing
+segments, server-side embeddings, free-text tags, optional sessions, and
+unified history/search. The backend is Linux-only (POSIX); the client
+ships on Android and web.
+
+The contract of record is [`spec/api-contract.md`](spec/api-contract.md);
+backend obligations are in
+[`spec/backend-requirements.md`](spec/backend-requirements.md). When other
+documentation drifts, the spec wins.
+
+## Repository Layout
+
+- [`backend/`](backend/) — Rust service.
+- [`client/`](client/) — Flutter application.
+- [`spec/`](spec/) — API contract and backend requirements.
 
 ## Quality Gates
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,6 +2,9 @@
 name = "oracy-backend"
 version = "0.1.0"
 edition = "2024"
+description = "Oracy backend: the Rust service that catches voice and keeps it as durable voice notes."
+license = "MIT"
+repository = "https://github.com/pentaxis93/oracy"
 
 [dependencies]
 axum = "0.8.9"

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,8 @@
 `backend/` contains the Rust service for Oracy's `v0.1.0` backend. The
 backend targets Linux deployment and assumes POSIX filesystem semantics.
 
-Run the service with `ORACY_CONFIG` set to a TOML configuration file:
+Run the service with `ORACY_CONFIG` set to a TOML configuration file and
+`OPENAI_API_KEY` set to a valid OpenAI credential:
 
 ```toml
 listen_addr = "127.0.0.1:8080"
@@ -20,6 +21,9 @@ key, `accepted_audio_dir` already exists as a writable directory, and
 `database_path` points to a SQLite database file whose parent directory exists
 and is writable. Relative storage paths resolve from the real configuration
 file directory.
+
+Transcription requires `OPENAI_API_KEY` to be set in the environment; without
+it, transcription jobs cannot succeed.
 
 Every API route requires `Authorization: Bearer <api_key>`. The bearer scheme is
 case-insensitive, and missing or invalid keys return the shared JSON

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -641,21 +641,21 @@ async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcript
 
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", &[meeting.id.clone()])
+            .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&meeting.id))
             .await
             .expect("tag transcript"),
         ReplaceTranscriptTagsOutcome::Replaced
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-b", &[meeting.id.clone()])
+            .replace_transcript_tags("owner-a", "transcript-b", std::slice::from_ref(&meeting.id))
             .await
             .expect("tag second transcript"),
         ReplaceTranscriptTagsOutcome::Replaced
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-b", "transcript-c", &[meeting.id.clone()])
+            .replace_transcript_tags("owner-b", "transcript-c", std::slice::from_ref(&meeting.id))
             .await
             .expect("wrong-owner tag is rejected"),
         ReplaceTranscriptTagsOutcome::NotFound
@@ -739,7 +739,7 @@ async fn duplicate_transcript_tag_ids_are_rejected_without_mutating_prior_tags()
     };
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", &[notes.id.clone()])
+            .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&notes.id))
             .await
             .expect("set prior tag"),
         ReplaceTranscriptTagsOutcome::Replaced
@@ -929,7 +929,7 @@ async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collis
         other => panic!("expected created tag, got {other:?}"),
     };
     storage
-        .replace_transcript_tags("owner-a", "transcript-a", &[meeting.id.clone()])
+        .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&meeting.id))
         .await
         .expect("tag transcript");
 

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: oracy
-description: "A new Flutter project."
+description: "Oracy's Flutter client: capturing voice and returning to it as durable voice notes."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev


### PR DESCRIPTION
## Summary

- Reframe the doc surfaces a context-free reader sees first so they cohere with `spec/api-contract.md` and `spec/backend-requirements.md`.
- Replace drifted phrasing ("voice transcription product", "A new Flutter project."), document `OPENAI_API_KEY` as a required operator prerequisite per spec, and add manifest hygiene fields to `backend/Cargo.toml`.
- Fold in a clippy fix surfaced during verification (separate atomic commit).

## Changes

`README.md` — orientation paragraph rewritten around the voice-note framing the spec defines as load-bearing; v0.1.0 scope and platform scope named; `spec/api-contract.md` declared as the contract of record. Quality Gates section preserved verbatim.

`backend/README.md` — `OPENAI_API_KEY` env var documented as required-for-operation per `spec/backend-requirements.md` §"Operator Prerequisites". Framed as required-for-operation rather than startup-validated because the implementation does not yet enforce it at startup; that gap is filed as #33.

`client/pubspec.yaml` — Flutter scaffold default description replaced.

`backend/Cargo.toml` — `description`, `license`, `repository` added so a developer surfacing the manifest via tooling gets honest orientation.

`backend/tests/storage.rs` — five `&[<expr>.id.clone()]` call sites replaced with `std::slice::from_ref(&<expr>.id)` to satisfy the Rust 1.95 `cloned_ref_to_slice_refs` clippy lint. Mechanical, behavior-equivalent.

GitHub repo metadata (set out-of-band via `gh repo edit`, not in this commit): topics added — voice-notes, transcription, rust, flutter, axum, sqlite. Description and homepageUrl unchanged.

## Issues

Refs #33 — OPENAI_API_KEY startup validation gap, filed during this work.
Refs #34 — server/database/init/ disposition, filed during this work.

Neither rides along in this PR; both are filed for separate work per the fix-or-file discipline (Oracy Principle 5).

## Test plan

- [ ] `cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` is green.
- [ ] `cd client && flutter pub get` resolves.
- [ ] Reading from the GitHub repo page (description + topics) into the root README and onward to `spec/api-contract.md` produces a coherent voice-note framing; no surface contradicts another.
- [ ] Drifted phrasing is gone: `grep -i "voice transcription product" README.md` and `grep -i "A new Flutter project" client/pubspec.yaml` both return nothing.
