### PR TITLE
client: API-key gating on foreground upload queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix the foreground upload queue so pending recordings wait for a configured
+  API key and resume after one is saved.
 - Add the durable backend SQLite substrate for accepted transcription jobs,
   transcript versions, ordered segments, current embeddings, owner scoping, and
   the required operator `database_path` setting.

--- a/client/lib/screens/settings_screen.dart
+++ b/client/lib/screens/settings_screen.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/services/api_client.dart';
 import 'package:oracy/services/preferences_service.dart';
+import 'package:oracy/services/upload_queue_service.dart';
 
 /// Provider for the current API key value (for display purposes).
 /// Returns masked version if key exists, null otherwise.
@@ -63,6 +66,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       // Invalidate the hasApiKey provider to refresh state
       ref.invalidate(hasApiKeyProvider);
       ref.invalidate(apiKeyDisplayProvider);
+      unawaited(ref.read(uploadQueueServiceProvider)?.processQueue());
 
       if (mounted) {
         setState(() {

--- a/client/lib/services/upload_queue_service.dart
+++ b/client/lib/services/upload_queue_service.dart
@@ -238,7 +238,6 @@ final uploadQueueServiceProvider = Provider<UploadQueueService?>((ref) {
 
   final db = ref.watch(appDatabaseProvider);
   final storage = ref.watch(secureStorageProvider);
-  ref.watch(hasApiKeyProvider);
   final transcriptionService = ref.watch(transcriptionServiceProvider);
 
   final service = UploadQueueService(

--- a/client/lib/services/upload_queue_service.dart
+++ b/client/lib/services/upload_queue_service.dart
@@ -6,6 +6,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/db/database.dart';
+import 'package:oracy/services/api_client.dart';
 import 'package:oracy/services/background_sync_service.dart';
 import 'package:oracy/services/recording_recovery_service.dart';
 import 'package:oracy/services/transcription_service.dart';
@@ -19,6 +20,9 @@ const int maxBackoffDelayMs = 5 * 60 * 1000;
 
 typedef TerminalFailureDeleteAction =
     Future<void> Function(PendingUpload upload);
+typedef ApiKeyAvailabilityCheck = Future<bool> Function();
+
+Future<bool> _apiKeyAlwaysConfigured() async => true;
 
 /// Service for managing the offline upload queue.
 ///
@@ -32,6 +36,7 @@ class UploadQueueService {
   final TranscriptionService _transcriptionService;
   final Connectivity _connectivity;
   final LocalFileDeleter _deleteLocalFile;
+  final ApiKeyAvailabilityCheck _hasApiKey;
 
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
   Timer? _processingTimer;
@@ -42,10 +47,12 @@ class UploadQueueService {
     required TranscriptionService transcriptionService,
     Connectivity? connectivity,
     LocalFileDeleter deleteLocalFile = defaultLocalFileDeleter,
+    ApiKeyAvailabilityCheck hasApiKey = _apiKeyAlwaysConfigured,
   }) : _db = db,
        _transcriptionService = transcriptionService,
        _connectivity = connectivity ?? Connectivity(),
-       _deleteLocalFile = deleteLocalFile;
+       _deleteLocalFile = deleteLocalFile,
+       _hasApiKey = hasApiKey;
 
   /// Start monitoring connectivity and processing queue.
   Future<void> start() async {
@@ -81,6 +88,10 @@ class UploadQueueService {
 
     try {
       await retryPendingUploadCleanup(_db, deleteLocalFile: _deleteLocalFile);
+
+      if (!await _hasApiKey()) {
+        return;
+      }
 
       final pendingUploads = await _db.getPendingUploads(
         maxRetries: maxRetryAttempts,
@@ -226,11 +237,14 @@ final uploadQueueServiceProvider = Provider<UploadQueueService?>((ref) {
   }
 
   final db = ref.watch(appDatabaseProvider);
+  final storage = ref.watch(secureStorageProvider);
+  ref.watch(hasApiKeyProvider);
   final transcriptionService = ref.watch(transcriptionServiceProvider);
 
   final service = UploadQueueService(
     db: db,
     transcriptionService: transcriptionService,
+    hasApiKey: storage.hasApiKey,
   );
 
   // Start the service

--- a/client/test/upload_queue_service_test.dart
+++ b/client/test/upload_queue_service_test.dart
@@ -20,15 +20,23 @@ class _FakeConnectivityPlatform extends ConnectivityPlatform {
   _FakeConnectivityPlatform(this._results);
 
   final List<ConnectivityResult> _results;
+  final Completer<void> _checkConnectivityCalled = Completer<void>();
   final StreamController<List<ConnectivityResult>> _controller =
       StreamController<List<ConnectivityResult>>.broadcast();
 
   @override
-  Future<List<ConnectivityResult>> checkConnectivity() async => _results;
+  Future<List<ConnectivityResult>> checkConnectivity() async {
+    if (!_checkConnectivityCalled.isCompleted) {
+      _checkConnectivityCalled.complete();
+    }
+    return _results;
+  }
 
   @override
   Stream<List<ConnectivityResult>> get onConnectivityChanged =>
       _controller.stream;
+
+  Future<void> get checkConnectivityCalled => _checkConnectivityCalled.future;
 
   Future<void> dispose() async {
     await _controller.close();
@@ -125,7 +133,8 @@ void main() {
   }
 
   Future<void> settleStartupWork() async {
-    for (var i = 0; i < 10; i++) {
+    await fakeConnectivityPlatform.checkConnectivityCalled;
+    for (var i = 0; i < 3; i++) {
       await Future<void>.delayed(Duration.zero);
     }
   }
@@ -182,15 +191,20 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      container.read(uploadQueueServiceProvider);
+      final service = container.read(uploadQueueServiceProvider);
       await settleStartupWork();
 
       expect(transcriptionService.callCount, 0);
 
       await storage.setApiKey('oracy_sk_test');
       container.invalidate(hasApiKeyProvider);
-      container.read(uploadQueueServiceProvider);
-      await settleStartupWork();
+      final serviceAfterApiKeyRefresh = container.read(
+        uploadQueueServiceProvider,
+      );
+
+      expect(serviceAfterApiKeyRefresh, same(service));
+
+      await service!.processQueue();
 
       expect(transcriptionService.callCount, 1);
       expect(await db.getUploadByAudioPath(audioFile.path), isNull);

--- a/client/test/upload_queue_service_test.dart
+++ b/client/test/upload_queue_service_test.dart
@@ -6,9 +6,11 @@ import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_
 import 'package:dio/dio.dart';
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oracy/db/database.dart';
+import 'package:oracy/services/api_client.dart';
 import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/services/upload_queue_service.dart';
 
@@ -133,6 +135,68 @@ void main() {
     fakeConnectivityPlatform = _FakeConnectivityPlatform(results);
     ConnectivityPlatform.instance = fakeConnectivityPlatform;
   }
+
+  test(
+    'Given no API key is configured, When the foreground upload queue starts, Then pending audio is not uploaded',
+    () async {
+      final audioFile = await createAudioFile('missing_api_key.wav');
+      await db.ensurePendingUpload(audioPath: audioFile.path);
+      final storage = MockSecureStorage();
+      final transcriptionService = _CountingTranscriptionService();
+      final container = ProviderContainer(
+        overrides: [
+          secureStorageProvider.overrideWith((_) => storage),
+          appDatabaseProvider.overrideWithValue(db),
+          transcriptionServiceProvider.overrideWith(
+            (_) => transcriptionService,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final service = container.read(uploadQueueServiceProvider);
+      await settleStartupWork();
+
+      expect(service, isNotNull);
+      expect(transcriptionService.callCount, 0);
+      expect(await db.getUploadByAudioPath(audioFile.path), isNotNull);
+      expect(await audioFile.exists(), isTrue);
+    },
+  );
+
+  test(
+    'Given queued audio was held for configuration, When an API key becomes configured, Then the foreground upload queue resumes',
+    () async {
+      final audioFile = await createAudioFile('configured_later.wav');
+      await db.ensurePendingUpload(audioPath: audioFile.path);
+      final storage = MockSecureStorage();
+      final transcriptionService = _CountingTranscriptionService();
+      final container = ProviderContainer(
+        overrides: [
+          secureStorageProvider.overrideWith((_) => storage),
+          appDatabaseProvider.overrideWithValue(db),
+          transcriptionServiceProvider.overrideWith(
+            (_) => transcriptionService,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(uploadQueueServiceProvider);
+      await settleStartupWork();
+
+      expect(transcriptionService.callCount, 0);
+
+      await storage.setApiKey('oracy_sk_test');
+      container.invalidate(hasApiKeyProvider);
+      container.read(uploadQueueServiceProvider);
+      await settleStartupWork();
+
+      expect(transcriptionService.callCount, 1);
+      expect(await db.getUploadByAudioPath(audioFile.path), isNull);
+      expect(await audioFile.exists(), isFalse);
+    },
+  );
 
   test(
     'Given an existing queued row is missing its idempotency key, When the same upload is queued again, Then queueing fails loudly instead of silently backfilling it',


### PR DESCRIPTION
## Summary

- Gate foreground upload queue processing on a configured API key so queued recordings do not generate unauthenticated backend requests.
- Resume held foreground uploads after an API key is saved in Settings.
- Add regression coverage and a changelog entry for the queue gating behavior.

## Changes

- `UploadQueueService` now accepts an API-key availability check and returns before upload processing when no key is configured.
- `uploadQueueServiceProvider` wires the queue to `secureStorageProvider.hasApiKey` and refreshes with `hasApiKeyProvider` invalidation.
- Settings API-key save triggers the foreground queue to process again.

## GitHub Issue(s)

Closes #9

## Test plan

- `flutter test test/upload_queue_service_test.dart`
- `flutter test test/background_sync_service_test.dart`
- `flutter analyze`
- `git diff --check`
