### PR TITLE
spec(api-contract): surface failure_code enum on TranscriptionJob schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Document the `TranscriptionJob.failure_code` wire enum in the API
+  contract while keeping per-code failure semantics in backend
+  requirements.
 - Fix the foreground upload queue so pending recordings wait for a configured
   API key and resume after one is saved.
 - Add the durable backend SQLite substrate for accepted transcription jobs,

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -782,7 +782,12 @@ Fields:
 - `max_retries`: maximum backend retry attempts for this job
 - `next_attempt_at`: returned when `status=retry_waiting`, otherwise
   omitted or `null`
-- `failure_code`: present when a failure classification exists
+- `failure_code`: nullable closed-enum string present when a failure
+  classification exists. Supported values are `audio_invalid`,
+  `engine_timeout`, `engine_rate_limited`, `engine_error`,
+  `storage_error`, `internal_error`, and `submission_abandoned`.
+  `spec/backend-requirements.md` Failure Semantics defines what each
+  code means.
 - `failure_message`: human-readable explanation aligned with
   `failure_code`
 - `retryable_by_client`: whether a terminal failed job should be

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -334,6 +334,10 @@ Constraints on transitions:
 
 #### Failure Semantics
 
+This section defines the backend behavior represented by each failure
+code. `spec/api-contract.md` `TranscriptionJob` defines the wire enum
+values exposed to clients.
+
 Terminal failure codes:
 
 - `audio_invalid`


### PR DESCRIPTION
## Summary

- Surface the closed `TranscriptionJob.failure_code` wire enum in the API contract.
- Keep per-code failure behavior in backend requirements and add mutual cross-references.
- Record the API contract documentation change in the changelog.

## Changes

- `spec/api-contract.md` now lists all seven supported failure code strings beside the `TranscriptionJob` schema.
- `spec/backend-requirements.md` clarifies that Failure Semantics owns backend behavior and points readers back to the schema for wire values.
- `CHANGELOG.md` includes an Unreleased entry for the contract documentation update.

## GitHub Issue(s)

Closes #31

## Test plan

- `codes='audio_invalid engine_timeout engine_rate_limited engine_error storage_error internal_error submission_abandoned'; for file in spec/api-contract.md spec/backend-requirements.md; do for code in $codes; do rg -q "\\b${code}\\b" "$file" || exit 1; done; done`
- `rg -n "cannot be transcribed|retryable classes|not finalized within|partial submission|record again|retry exhaustion|client retry of the same audio" spec/api-contract.md` returns no matches.
- `git diff --check`
