### PR TITLE
fix(backend): validate OPENAI_API_KEY at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Require a non-empty `OPENAI_API_KEY` during backend startup so the service does
+  not advertise transcription capability without its operator-provisioned engine
+  credential.
 - Document the `TranscriptionJob.failure_code` wire enum in the API
   contract while keeping per-code failure semantics in backend
   requirements.

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,11 +19,9 @@ key = "operator-issued-secret"
 Startup fails unless `api_keys` contains at least one valid operator-provisioned
 key, `accepted_audio_dir` already exists as a writable directory, and
 `database_path` points to a SQLite database file whose parent directory exists
-and is writable. Relative storage paths resolve from the real configuration
-file directory.
-
-Transcription requires `OPENAI_API_KEY` to be set in the environment; without
-it, transcription jobs cannot succeed.
+and is writable. `OPENAI_API_KEY` must also be set to a non-empty environment
+value. Relative storage paths resolve from the real configuration file
+directory.
 
 Every API route requires `Authorization: Bearer <api_key>`. The bearer scheme is
 case-insensitive, and missing or invalid keys return the shared JSON

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -12,11 +12,16 @@ use crate::state::AppState;
 use crate::storage::{Storage, StorageError};
 
 pub const CONFIG_ENV_VAR: &str = "ORACY_CONFIG";
+pub const OPENAI_API_KEY_ENV_VAR: &str = "OPENAI_API_KEY";
 
 #[derive(Debug, Error)]
 pub enum BootstrapError {
     #[error("{CONFIG_ENV_VAR} is not set")]
     MissingConfigEnv,
+    #[error("{OPENAI_API_KEY_ENV_VAR} is not set")]
+    MissingOpenAiApiKeyEnv,
+    #[error("{OPENAI_API_KEY_ENV_VAR} must not be empty")]
+    EmptyOpenAiApiKeyEnv,
     #[error("failed to read config file {path}: {source}")]
     ReadConfig {
         path: PathBuf,
@@ -47,6 +52,12 @@ pub enum BootstrapError {
 
 pub async fn load_runtime_from_env() -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
     let config_path = std::env::var_os(CONFIG_ENV_VAR).ok_or(BootstrapError::MissingConfigEnv)?;
+    let openai_api_key =
+        std::env::var_os(OPENAI_API_KEY_ENV_VAR).ok_or(BootstrapError::MissingOpenAiApiKeyEnv)?;
+    if openai_api_key.is_empty() {
+        return Err(BootstrapError::EmptyOpenAiApiKeyEnv);
+    }
+
     load_runtime_from_path(Path::new(&config_path)).await
 }
 

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -23,6 +23,114 @@ async fn startup_rejects_missing_oracy_config_env_helper() {
 }
 
 #[tokio::test]
+async fn startup_rejects_missing_openai_api_key_env() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display()
+        ),
+    );
+
+    support::assert_ignored_test_passes_with_env(
+        "startup_rejects_missing_openai_api_key_env_helper",
+        &[("ORACY_CONFIG", config_path.as_os_str())],
+        &["OPENAI_API_KEY"],
+    );
+}
+
+#[tokio::test]
+#[ignore = "helper subprocess only"]
+async fn startup_rejects_missing_openai_api_key_env_helper() {
+    let error = load_runtime_from_env()
+        .await
+        .expect_err("missing OpenAI API key should fail");
+    assert!(error.to_string().contains("OPENAI_API_KEY is not set"));
+}
+
+#[tokio::test]
+async fn startup_rejects_empty_openai_api_key_env() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display()
+        ),
+    );
+
+    support::assert_ignored_test_passes_with_env(
+        "startup_rejects_empty_openai_api_key_env_helper",
+        &[
+            ("ORACY_CONFIG", config_path.as_os_str()),
+            ("OPENAI_API_KEY", std::ffi::OsStr::new("")),
+        ],
+        &[],
+    );
+}
+
+#[tokio::test]
+#[ignore = "helper subprocess only"]
+async fn startup_rejects_empty_openai_api_key_env_helper() {
+    let error = load_runtime_from_env()
+        .await
+        .expect_err("empty OpenAI API key should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("OPENAI_API_KEY must not be empty")
+    );
+}
+
+#[tokio::test]
+async fn startup_accepts_non_empty_openai_api_key_env() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display()
+        ),
+    );
+
+    support::assert_ignored_test_passes_with_env(
+        "startup_accepts_non_empty_openai_api_key_env_helper",
+        &[
+            ("ORACY_CONFIG", config_path.as_os_str()),
+            ("OPENAI_API_KEY", std::ffi::OsStr::new("test-openai-key")),
+        ],
+        &[],
+    );
+}
+
+#[tokio::test]
+#[ignore = "helper subprocess only"]
+async fn startup_accepts_non_empty_openai_api_key_env_helper() {
+    load_runtime_from_env()
+        .await
+        .expect("non-empty OpenAI API key should allow startup");
+}
+
+#[tokio::test]
 async fn startup_rejects_when_no_api_keys_are_configured() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(

--- a/backend/tests/support/mod.rs
+++ b/backend/tests/support/mod.rs
@@ -3,16 +3,27 @@ use std::process::Command;
 #[cfg(unix)]
 const CAP_DAC_OVERRIDE_MASK: u64 = 1 << 1;
 
-pub fn assert_ignored_test_passes_with_env_missing(test_name: &str, env_name: &str) {
-    let output = Command::new(std::env::current_exe().expect("resolve current test binary"))
+pub fn assert_ignored_test_passes_with_env(
+    test_name: &str,
+    envs: &[(&str, &std::ffi::OsStr)],
+    missing_envs: &[&str],
+) {
+    let mut command = Command::new(std::env::current_exe().expect("resolve current test binary"));
+    command
         .arg("--ignored")
         .arg("--exact")
         .arg(test_name)
-        .arg("--nocapture")
-        .env(env_name, "/tmp/oracy-config-should-have-been-removed")
-        .env_remove(env_name)
-        .output()
-        .expect("spawn helper test");
+        .arg("--nocapture");
+    for (name, value) in envs {
+        command.env(name, value);
+    }
+    for name in missing_envs {
+        command
+            .env(name, "/tmp/oracy-config-should-have-been-removed")
+            .env_remove(name);
+    }
+
+    let output = command.output().expect("spawn helper test");
 
     assert!(
         output.status.success(),
@@ -20,6 +31,10 @@ pub fn assert_ignored_test_passes_with_env_missing(test_name: &str, env_name: &s
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+pub fn assert_ignored_test_passes_with_env_missing(test_name: &str, env_name: &str) {
+    assert_ignored_test_passes_with_env(test_name, &[], &[env_name]);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Refuses backend startup when `OPENAI_API_KEY` is unset or empty.
- Aligns startup behavior with the backend requirements so transcription capability is not advertised without the engine credential.
- Updates operator-facing startup documentation and the changelog.

## Changes

- Adds explicit `OPENAI_API_KEY` validation to the environment bootstrap path.
- Covers missing, empty, and non-empty credential cases with subprocess-based startup tests.
- Documents the new startup precondition in `backend/README.md` and `CHANGELOG.md`.

## GitHub Issue(s)

Closes #33

## Test plan

- `cargo fmt --check`
- `cargo test`
- `git diff --check`
