### PR TITLE
feat(backend): pin audio content hash composition

### DIFF
--- a/backend/migrations/20260429000000_pin_audio_content_hash_algorithm.sql
+++ b/backend/migrations/20260429000000_pin_audio_content_hash_algorithm.sql
@@ -1,0 +1,12 @@
+ALTER TABLE transcription_jobs
+    ADD COLUMN audio_content_hash_algorithm TEXT NOT NULL
+    DEFAULT 'sha256:chunk-sha256-raw-concat:v1';
+
+DROP TRIGGER transcription_jobs_accepted_tuple_immutable;
+
+CREATE TRIGGER transcription_jobs_accepted_tuple_immutable
+BEFORE UPDATE OF api_key_id, idempotency_key, audio_sha256_hex, audio_content_hash_algorithm, recorded_at, session_id, language
+ON transcription_jobs
+BEGIN
+    SELECT RAISE(ABORT, 'accepted submission tuple is immutable');
+END;

--- a/backend/src/audio_hash.rs
+++ b/backend/src/audio_hash.rs
@@ -1,0 +1,62 @@
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+pub const AUDIO_CONTENT_HASH_ALGORITHM_ID: &str = "sha256:chunk-sha256-raw-concat:v1";
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AudioContentHashError {
+    #[error("chunk digest at index {index} is not lowercase SHA-256 hex")]
+    InvalidChunkDigest { index: usize },
+}
+
+pub fn compose_audio_content_hash_hex<I, S>(
+    chunk_sha256_hexes: I,
+) -> Result<String, AudioContentHashError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut hasher = Sha256::new();
+    for (index, chunk_sha256_hex) in chunk_sha256_hexes.into_iter().enumerate() {
+        let digest = decode_lowercase_sha256_hex(chunk_sha256_hex.as_ref(), index)?;
+        hasher.update(digest);
+    }
+
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+fn decode_lowercase_sha256_hex(
+    value: &str,
+    index: usize,
+) -> Result<[u8; 32], AudioContentHashError> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 64 {
+        return Err(AudioContentHashError::InvalidChunkDigest { index });
+    }
+
+    let mut decoded = [0_u8; 32];
+    for (target, pair) in decoded.iter_mut().zip(bytes.chunks_exact(2)) {
+        let high = decode_hex_nibble(pair[0], index)?;
+        let low = decode_hex_nibble(pair[1], index)?;
+        *target = (high << 4) | low;
+    }
+    Ok(decoded)
+}
+
+fn decode_hex_nibble(value: u8, index: usize) -> Result<u8, AudioContentHashError> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        _ => Err(AudioContentHashError::InvalidChunkDigest { index }),
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(unix)]
 
+pub mod audio_hash;
 pub mod auth;
 pub mod bootstrap;
 pub mod config;

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -12,6 +12,8 @@ use time::macros::format_description;
 use ulid::Ulid;
 use unicode_normalization::UnicodeNormalization;
 
+use crate::audio_hash::AUDIO_CONTENT_HASH_ALGORITHM_ID;
+
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
 
 #[derive(Clone, Debug)]
@@ -46,6 +48,13 @@ pub enum StorageError {
         path: PathBuf,
         #[source]
         source: sqlx::migrate::MigrateError,
+    },
+    #[error(
+        "unsupported audio content hash algorithm in database: expected {expected}, found {found}"
+    )]
+    UnsupportedAudioContentHashAlgorithm {
+        expected: &'static str,
+        found: String,
     },
     #[error("storage query failed: {0}")]
     Query(#[from] sqlx::Error),
@@ -95,6 +104,7 @@ pub struct NewTranscriptionJob {
     pub api_key_id: String,
     pub idempotency_key: String,
     pub audio_sha256_hex: String,
+    pub audio_content_hash_algorithm: String,
     pub recorded_at: OffsetDateTime,
     pub session_id: Option<String>,
     pub language: Option<String>,
@@ -125,6 +135,7 @@ pub struct TranscriptionJobRecord {
     pub api_key_id: String,
     pub idempotency_key: String,
     pub audio_sha256_hex: String,
+    pub audio_content_hash_algorithm: String,
     pub recorded_at: OffsetDateTime,
     pub session_id: Option<String>,
     pub language: Option<String>,
@@ -263,6 +274,7 @@ impl Storage {
                 path: database_path.to_path_buf(),
                 source,
             })?;
+        ensure_supported_audio_content_hash_algorithm(&pool).await?;
 
         Ok(Self { pool })
     }
@@ -284,11 +296,12 @@ impl Storage {
         let result = sqlx::query(
             r#"
             INSERT INTO transcription_jobs (
-                id, api_key_id, idempotency_key, audio_sha256_hex, recorded_at,
-                session_id, language, accepted_audio_path, status, created_at,
-                updated_at, retry_count, max_retries
+                id, api_key_id, idempotency_key, audio_sha256_hex,
+                audio_content_hash_algorithm, recorded_at, session_id, language,
+                accepted_audio_path, status, created_at, updated_at, retry_count,
+                max_retries
             )
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?
             WHERE ? IS NULL
                 OR EXISTS (
                     SELECT 1 FROM sessions
@@ -301,6 +314,7 @@ impl Storage {
         .bind(&input.api_key_id)
         .bind(&input.idempotency_key)
         .bind(&input.audio_sha256_hex)
+        .bind(&input.audio_content_hash_algorithm)
         .bind(recorded_at)
         .bind(&input.session_id)
         .bind(&input.language)
@@ -981,6 +995,7 @@ impl Storage {
 impl TranscriptionJobRecord {
     fn matches_submission(&self, input: &NewTranscriptionJob) -> bool {
         self.audio_sha256_hex == input.audio_sha256_hex
+            && self.audio_content_hash_algorithm == input.audio_content_hash_algorithm
             && self.recorded_at == input.recorded_at
             && self.session_id == input.session_id
             && self.language == input.language
@@ -1030,6 +1045,31 @@ fn new_id() -> String {
     Ulid::new().to_string()
 }
 
+async fn ensure_supported_audio_content_hash_algorithm(
+    pool: &SqlitePool,
+) -> Result<(), StorageError> {
+    let unsupported = sqlx::query(
+        r#"
+        SELECT audio_content_hash_algorithm
+        FROM transcription_jobs
+        WHERE audio_content_hash_algorithm != ?
+        LIMIT 1
+        "#,
+    )
+    .bind(AUDIO_CONTENT_HASH_ALGORITHM_ID)
+    .fetch_optional(pool)
+    .await?;
+
+    if let Some(row) = unsupported {
+        return Err(StorageError::UnsupportedAudioContentHashAlgorithm {
+            expected: AUDIO_CONTENT_HASH_ALGORITHM_ID,
+            found: row.try_get("audio_content_hash_algorithm")?,
+        });
+    }
+
+    Ok(())
+}
+
 fn fold_tag_name(value: &str) -> String {
     value.chars().nfd().default_case_fold().nfd().collect()
 }
@@ -1056,6 +1096,7 @@ fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, 
         api_key_id: row.try_get("api_key_id")?,
         idempotency_key: row.try_get("idempotency_key")?,
         audio_sha256_hex: row.try_get("audio_sha256_hex")?,
+        audio_content_hash_algorithm: row.try_get("audio_content_hash_algorithm")?,
         recorded_at: parse_timestamp(row.try_get("recorded_at")?)?,
         session_id: row.try_get("session_id")?,
         language: row.try_get("language")?,

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -104,7 +104,6 @@ pub struct NewTranscriptionJob {
     pub api_key_id: String,
     pub idempotency_key: String,
     pub audio_sha256_hex: String,
-    pub audio_content_hash_algorithm: String,
     pub recorded_at: OffsetDateTime,
     pub session_id: Option<String>,
     pub language: Option<String>,
@@ -314,7 +313,7 @@ impl Storage {
         .bind(&input.api_key_id)
         .bind(&input.idempotency_key)
         .bind(&input.audio_sha256_hex)
-        .bind(&input.audio_content_hash_algorithm)
+        .bind(AUDIO_CONTENT_HASH_ALGORITHM_ID)
         .bind(recorded_at)
         .bind(&input.session_id)
         .bind(&input.language)
@@ -995,7 +994,6 @@ impl Storage {
 impl TranscriptionJobRecord {
     fn matches_submission(&self, input: &NewTranscriptionJob) -> bool {
         self.audio_sha256_hex == input.audio_sha256_hex
-            && self.audio_content_hash_algorithm == input.audio_content_hash_algorithm
             && self.recorded_at == input.recorded_at
             && self.session_id == input.session_id
             && self.language == input.language

--- a/backend/tests/audio_hash.rs
+++ b/backend/tests/audio_hash.rs
@@ -1,0 +1,31 @@
+use oracy_backend::audio_hash::compose_audio_content_hash_hex;
+
+#[test]
+fn composed_audio_content_hash_uses_raw_chunk_digest_bytes_in_order() {
+    let chunk_hashes = [
+        "b18efa847f7a3fa48fe0aafd4a6250aa5129740e05126859377af20cedafdeee",
+        "2725aea2d2dea736fbe38e41ecb518f6098cb68ac77362c5e34faafb356567c5",
+        "b6f3c15844fe12f966ad90db59da8332a9a6d9dfd198ac83949be2045ec6dc1e",
+    ];
+
+    let composed = compose_audio_content_hash_hex(chunk_hashes).expect("compose hash");
+
+    assert_eq!(
+        composed,
+        "5bdae50ac99ab32dd48fbc23bf45c6415fd318e770a9b846c86b7cb7c1087a93"
+    );
+}
+
+#[test]
+fn composed_audio_content_hash_rejects_invalid_chunk_digest_shapes() {
+    for invalid in [
+        "b18efa847f7a3fa48fe0aafd4a6250aa5129740e05126859377af20cedafdee",
+        "b18efa847f7a3fa48fe0aafd4a6250aa5129740e05126859377af20cedafdeeg",
+        "B18EFA847F7A3FA48FE0AAFD4A6250AA5129740E05126859377AF20CEDAFDEEE",
+    ] {
+        assert!(
+            compose_audio_content_hash_hex([invalid]).is_err(),
+            "invalid digest should be rejected: {invalid}"
+        );
+    }
+}

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use oracy_backend::audio_hash::{AUDIO_CONTENT_HASH_ALGORITHM_ID, compose_audio_content_hash_hex};
 use oracy_backend::storage::{
     AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewSegment, NewSession, NewTag,
     NewTranscript, NewTranscriptVersion, NewTranscriptionJob, RenameTagOutcome,
@@ -57,6 +58,100 @@ async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
         AcceptJobOutcome::Conflict(oracy_backend::storage::SubmissionConflict {
             job_id: created.id
         })
+    );
+}
+
+#[tokio::test]
+async fn accepted_audio_hash_algorithm_survives_restart_with_rederived_hash() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let database_path = tempdir.path().join("oracy.sqlite");
+    let chunk_hashes = [
+        "b18efa847f7a3fa48fe0aafd4a6250aa5129740e05126859377af20cedafdeee",
+        "2725aea2d2dea736fbe38e41ecb518f6098cb68ac77362c5e34faafb356567c5",
+        "b6f3c15844fe12f966ad90db59da8332a9a6d9dfd198ac83949be2045ec6dc1e",
+    ];
+    let composed_hash =
+        compose_audio_content_hash_hex(chunk_hashes).expect("compose accepted audio hash");
+    let accepted_job_id = {
+        let storage = Storage::connect(&database_path)
+            .await
+            .expect("connect storage");
+        insert_session_row(&storage, "owner-a", "session-a").await;
+        let job = match storage
+            .accept_job(new_job("owner-a", "attempt-1", &composed_hash))
+            .await
+            .expect("accept job")
+        {
+            AcceptJobOutcome::Created(job) => job,
+            other => panic!("expected created job, got {other:?}"),
+        };
+
+        assert_eq!(
+            job.audio_content_hash_algorithm,
+            AUDIO_CONTENT_HASH_ALGORITHM_ID
+        );
+        job.id
+    };
+
+    let restarted = Storage::connect(&database_path)
+        .await
+        .expect("reconnect storage");
+    let stored = restarted
+        .get_job("owner-a", &accepted_job_id)
+        .await
+        .expect("read job")
+        .expect("job survives restart");
+
+    assert_eq!(stored.audio_sha256_hex, composed_hash);
+    assert_eq!(
+        stored.audio_content_hash_algorithm,
+        AUDIO_CONTENT_HASH_ALGORITHM_ID
+    );
+    assert_eq!(
+        compose_audio_content_hash_hex(chunk_hashes).expect("rederive accepted audio hash"),
+        stored.audio_sha256_hex
+    );
+}
+
+#[tokio::test]
+async fn storage_rejects_restart_when_stored_audio_hash_algorithm_drifted() {
+    let (tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-a", "session-a").await;
+    match storage
+        .accept_job(new_job("owner-a", "attempt-1", "hash-a"))
+        .await
+        .expect("accept job")
+    {
+        AcceptJobOutcome::Created(_) => {}
+        other => panic!("expected created job, got {other:?}"),
+    };
+
+    sqlx::query("DROP TRIGGER transcription_jobs_accepted_tuple_immutable")
+        .execute(storage.pool())
+        .await
+        .expect("drop immutability trigger for drift fixture");
+    sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET audio_content_hash_algorithm = 'sha256:chunk-sha256-raw-concat:v2'
+        WHERE api_key_id = 'owner-a' AND idempotency_key = 'attempt-1'
+        "#,
+    )
+    .execute(storage.pool())
+    .await
+    .expect("write drifted algorithm fixture");
+    drop(storage);
+
+    let error = Storage::connect(&tempdir.path().join("oracy.sqlite"))
+        .await
+        .expect_err("algorithm drift should reject startup");
+
+    assert!(error.to_string().contains("audio content hash algorithm"));
+    assert!(error.to_string().contains(AUDIO_CONTENT_HASH_ALGORITHM_ID));
+    assert!(
+        error
+            .to_string()
+            .contains("sha256:chunk-sha256-raw-concat:v2")
     );
 }
 
@@ -179,7 +274,7 @@ async fn accepted_submission_tuple_is_immutable_in_storage() {
     let error = sqlx::query(
         r#"
         UPDATE transcription_jobs
-        SET recorded_at = '2026-04-25T00:00:00Z'
+        SET audio_content_hash_algorithm = 'sha256:chunk-sha256-raw-concat:v2'
         WHERE id = ?
         "#,
     )
@@ -198,7 +293,10 @@ async fn accepted_submission_tuple_is_immutable_in_storage() {
         .await
         .expect("lookup")
         .expect("job exists");
-    assert_eq!(unchanged.recorded_at, created.recorded_at);
+    assert_eq!(
+        unchanged.audio_content_hash_algorithm,
+        created.audio_content_hash_algorithm
+    );
 }
 
 #[tokio::test]
@@ -1301,6 +1399,7 @@ fn new_job(owner: &str, idempotency_key: &str, hash: &str) -> NewTranscriptionJo
         api_key_id: owner.to_owned(),
         idempotency_key: idempotency_key.to_owned(),
         audio_sha256_hex: hash.to_owned(),
+        audio_content_hash_algorithm: AUDIO_CONTENT_HASH_ALGORITHM_ID.to_owned(),
         recorded_at: datetime!(2026-04-24 17:59:00 UTC),
         session_id: Some("session-a".to_owned()),
         language: Some("en".to_owned()),

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -114,6 +114,26 @@ async fn accepted_audio_hash_algorithm_survives_restart_with_rederived_hash() {
 }
 
 #[tokio::test]
+async fn storage_owns_the_accepted_audio_hash_algorithm_pin() {
+    let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-a", "session-a").await;
+
+    let created = match storage
+        .accept_job(new_job("owner-a", "attempt-1", "hash-a"))
+        .await
+        .expect("accept job")
+    {
+        AcceptJobOutcome::Created(job) => job,
+        other => panic!("expected created job, got {other:?}"),
+    };
+
+    assert_eq!(
+        created.audio_content_hash_algorithm,
+        AUDIO_CONTENT_HASH_ALGORITHM_ID
+    );
+}
+
+#[tokio::test]
 async fn storage_rejects_restart_when_stored_audio_hash_algorithm_drifted() {
     let (tempdir, storage) = storage().await;
     insert_session_row(&storage, "owner-a", "session-a").await;
@@ -1399,7 +1419,6 @@ fn new_job(owner: &str, idempotency_key: &str, hash: &str) -> NewTranscriptionJo
         api_key_id: owner.to_owned(),
         idempotency_key: idempotency_key.to_owned(),
         audio_sha256_hex: hash.to_owned(),
-        audio_content_hash_algorithm: AUDIO_CONTENT_HASH_ALGORITHM_ID.to_owned(),
         recorded_at: datetime!(2026-04-24 17:59:00 UTC),
         session_id: Some("session-a".to_owned()),
         language: Some("en".to_owned()),


### PR DESCRIPTION
## Summary

- Adds the internal `sha256:chunk-sha256-raw-concat:v1` accepted audio content hash composition function.
- Persists the algorithm ID with accepted transcription jobs by deriving it at the storage write boundary, and rejects startup when stored rows use a different algorithm.
- Covers the golden vector, invalid chunk digest shapes, restart re-derivation, drift rejection, storage-owned pinning, and accepted tuple immutability.

## Changes

- Introduces `backend/src/audio_hash.rs` for raw digest byte concatenation and lowercase SHA-256 output.
- Adds a migration for `transcription_jobs.audio_content_hash_algorithm` and includes it in the accepted tuple immutability trigger.
- Narrows `NewTranscriptionJob` so callers supply only accepted tuple values storage cannot derive; `accept_job` writes the current algorithm pin directly and replay matching compares the caller-meaningful tuple values.

## GitHub Issue(s)

Closes #39
Refs #40

## Test plan

- `cargo test`
