### PR TITLE
feat(settings): per-key transcription_model setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add authenticated `GET /api/v1/settings` and `PATCH /api/v1/settings`
+  endpoints for durable per-API-key transcription model settings.
 - Require a non-empty `OPENAI_API_KEY` during backend startup so the service does
   not advertise transcription capability without its operator-provisioned engine
   credential.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Preserve the shared `ErrorResponse` envelope for framework-owned API
+  rejections, including unsupported methods and JSON body parse, content-type,
+  shape, and size failures.
 - Add authenticated `GET /api/v1/settings` and `PATCH /api/v1/settings`
   endpoints for durable per-API-key transcription model settings.
 - Require a non-empty `OPENAI_API_KEY` during backend startup so the service does

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/pentaxis93/oracy"
 axum = "0.8.9"
 caseless = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
 subtle = "2.6"
@@ -23,6 +24,5 @@ ulid = "1.2.1"
 unicode-normalization = "0.1.25"
 
 [dev-dependencies]
-serde_json = "1.0"
 tempfile = "3.23"
 tower = { version = "0.5", features = ["util"] }

--- a/backend/migrations/20260429010000_create_api_key_settings.sql
+++ b/backend/migrations/20260429010000_create_api_key_settings.sql
@@ -1,0 +1,10 @@
+CREATE TABLE api_key_settings (
+    api_key_id TEXT PRIMARY KEY,
+    transcription_model TEXT NOT NULL CHECK (
+        transcription_model IN (
+            'gpt-4o-mini-transcribe',
+            'gpt-4o-transcribe'
+        )
+    ),
+    updated_at TEXT NOT NULL
+);

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -1,4 +1,5 @@
 use axum::Json;
+use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
@@ -52,6 +53,22 @@ impl ApiError {
         }
     }
 
+    pub fn from_json_rejection(rejection: JsonRejection) -> Self {
+        match rejection {
+            JsonRejection::JsonSyntaxError(_) => Self::malformed_json(),
+            JsonRejection::MissingJsonContentType(_) => Self::unsupported_content_type(),
+            JsonRejection::JsonDataError(_) => Self::invalid_request_shape(),
+            JsonRejection::BytesRejection(rejection) => {
+                if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE {
+                    Self::payload_too_large()
+                } else {
+                    Self::request_body_error(rejection.status())
+                }
+            }
+            _ => Self::request_body_error(rejection.status()),
+        }
+    }
+
     pub fn conflict(message: impl Into<String>, details: Option<Vec<ErrorDetail>>) -> Self {
         Self {
             status: StatusCode::CONFLICT,
@@ -69,6 +86,72 @@ impl ApiError {
             body: ErrorResponse {
                 error_code: "not_found".to_owned(),
                 message: message.into(),
+                details: None,
+            },
+        }
+    }
+
+    fn malformed_json() -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            body: ErrorResponse {
+                error_code: "malformed_json".to_owned(),
+                message: "Request body must be valid JSON.".to_owned(),
+                details: None,
+            },
+        }
+    }
+
+    fn unsupported_content_type() -> Self {
+        Self {
+            status: StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            body: ErrorResponse {
+                error_code: "unsupported_content_type".to_owned(),
+                message: "Request content type must be application/json.".to_owned(),
+                details: None,
+            },
+        }
+    }
+
+    fn invalid_request_shape() -> Self {
+        Self {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            body: ErrorResponse {
+                error_code: "invalid_request_shape".to_owned(),
+                message: "Request JSON shape is invalid.".to_owned(),
+                details: None,
+            },
+        }
+    }
+
+    fn payload_too_large() -> Self {
+        Self {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            body: ErrorResponse {
+                error_code: "payload_too_large".to_owned(),
+                message: "Request body is too large.".to_owned(),
+                details: None,
+            },
+        }
+    }
+
+    fn request_body_error(status: StatusCode) -> Self {
+        Self {
+            status,
+            body: ErrorResponse {
+                error_code: "request_body_error".to_owned(),
+                message: "Failed to read request body.".to_owned(),
+                details: None,
+            },
+        }
+    }
+
+    pub fn method_not_allowed() -> Self {
+        Self {
+            status: StatusCode::METHOD_NOT_ALLOWED,
+            body: ErrorResponse {
+                error_code: "method_not_allowed".to_owned(),
+                message: "Method not allowed.".to_owned(),
                 details: None,
             },
         }

--- a/backend/src/json.rs
+++ b/backend/src/json.rs
@@ -1,0 +1,22 @@
+use axum::Json;
+use axum::extract::{FromRequest, Request};
+use serde::de::DeserializeOwned;
+
+use crate::errors::ApiError;
+
+pub struct JsonBody<T>(pub T);
+
+impl<S, T> FromRequest<S> for JsonBody<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        Json::<T>::from_request(req, state)
+            .await
+            .map(|Json(body)| Self(body))
+            .map_err(ApiError::from_json_rejection)
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod bootstrap;
 pub mod config;
 pub mod errors;
+pub mod json;
 pub mod router;
 pub mod settings;
 pub mod state;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -6,5 +6,6 @@ pub mod bootstrap;
 pub mod config;
 pub mod errors;
 pub mod router;
+pub mod settings;
 pub mod state;
 pub mod storage;

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -1,10 +1,13 @@
 use axum::Router;
+use axum::routing::get;
 
 use crate::errors::ApiError;
+use crate::settings::{get_settings, patch_settings};
 use crate::state::AppState;
 
 pub fn build_router(state: AppState) -> Router {
     Router::new()
+        .route("/api/v1/settings", get(get_settings).patch(patch_settings))
         .fallback(|| async { Err::<(), _>(ApiError::not_found("Resource not found.")) })
         .with_state(state)
 }

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -9,5 +9,6 @@ pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/api/v1/settings", get(get_settings).patch(patch_settings))
         .fallback(|| async { Err::<(), _>(ApiError::not_found("Resource not found.")) })
+        .method_not_allowed_fallback(|| async { Err::<(), _>(ApiError::method_not_allowed()) })
         .with_state(state)
 }

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -1,0 +1,104 @@
+use axum::Json;
+use axum::extract::State;
+use serde::Serialize;
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use crate::auth::AuthenticatedKey;
+use crate::errors::{ApiError, ErrorDetail};
+use crate::state::AppState;
+use crate::storage::{SettingsPatch, SettingsRecord};
+
+pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "gpt-4o-mini-transcribe";
+pub const SUPPORTED_TRANSCRIPTION_MODELS: [&str; 2] =
+    ["gpt-4o-mini-transcribe", "gpt-4o-transcribe"];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SettingsResource {
+    pub transcription_model: String,
+}
+
+pub async fn get_settings(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+) -> Result<Json<SettingsResource>, ApiError> {
+    let settings = state
+        .storage
+        .get_settings(authenticated_key.api_key_id.as_str())
+        .await
+        .map_err(|_| ApiError::internal("Failed to load settings."))?;
+
+    Ok(Json(SettingsResource::from(settings)))
+}
+
+pub async fn patch_settings(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Json(body): Json<Value>,
+) -> Result<Json<SettingsResource>, ApiError> {
+    let patch = parse_patch(body)?;
+    let settings = state
+        .storage
+        .update_settings(
+            authenticated_key.api_key_id.as_str(),
+            patch,
+            OffsetDateTime::now_utc(),
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to update settings."))?;
+
+    Ok(Json(SettingsResource::from(settings)))
+}
+
+impl From<SettingsRecord> for SettingsResource {
+    fn from(settings: SettingsRecord) -> Self {
+        Self {
+            transcription_model: settings.transcription_model,
+        }
+    }
+}
+
+fn parse_patch(body: Value) -> Result<SettingsPatch, ApiError> {
+    let Value::Object(fields) = body else {
+        return Err(validation_error("", "Request body must be a JSON object."));
+    };
+
+    let mut patch = SettingsPatch {
+        transcription_model: None,
+    };
+
+    for (field, value) in fields {
+        match field.as_str() {
+            "transcription_model" => {
+                let Some(model) = value.as_str() else {
+                    return Err(validation_error(
+                        "transcription_model",
+                        "Must be a supported transcription model identifier.",
+                    ));
+                };
+                if !SUPPORTED_TRANSCRIPTION_MODELS.contains(&model) {
+                    return Err(validation_error(
+                        "transcription_model",
+                        "Must be a supported transcription model identifier.",
+                    ));
+                }
+                patch.transcription_model = Some(model.to_owned());
+            }
+            _ => {
+                return Err(validation_error(&field, "Unknown settings field."));
+            }
+        }
+    }
+
+    Ok(patch)
+}
+
+fn validation_error(field: &str, message: &str) -> ApiError {
+    ApiError::validation(
+        "One or more request fields are invalid.",
+        Some(vec![ErrorDetail {
+            field: field.to_owned(),
+            message: message.to_owned(),
+        }]),
+    )
+}

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -6,6 +6,7 @@ use time::OffsetDateTime;
 
 use crate::auth::AuthenticatedKey;
 use crate::errors::{ApiError, ErrorDetail};
+use crate::json::JsonBody;
 use crate::state::AppState;
 use crate::storage::{SettingsPatch, SettingsRecord};
 
@@ -34,7 +35,7 @@ pub async fn get_settings(
 pub async fn patch_settings(
     authenticated_key: AuthenticatedKey,
     State(state): State<AppState>,
-    Json(body): Json<Value>,
+    JsonBody(body): JsonBody<Value>,
 ) -> Result<Json<SettingsResource>, ApiError> {
     let patch = parse_patch(body)?;
     let settings = state

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -13,6 +13,7 @@ use ulid::Ulid;
 use unicode_normalization::UnicodeNormalization;
 
 use crate::audio_hash::AUDIO_CONTENT_HASH_ALGORITHM_ID;
+use crate::settings::DEFAULT_TRANSCRIPTION_MODEL;
 
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
 
@@ -97,6 +98,16 @@ pub enum ReplaceTranscriptTagsOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmissionConflict {
     pub job_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsPatch {
+    pub transcription_model: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsRecord {
+    pub transcription_model: String,
 }
 
 #[derive(Debug, Clone)]
@@ -280,6 +291,55 @@ impl Storage {
 
     pub fn pool(&self) -> &SqlitePool {
         &self.pool
+    }
+
+    pub async fn get_settings(&self, api_key_id: &str) -> Result<SettingsRecord, StorageError> {
+        let row = sqlx::query(
+            r#"
+            SELECT transcription_model
+            FROM api_key_settings
+            WHERE api_key_id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some(row) => Ok(settings_from_row(row)?),
+            None => Ok(SettingsRecord {
+                transcription_model: DEFAULT_TRANSCRIPTION_MODEL.to_owned(),
+            }),
+        }
+    }
+
+    pub async fn update_settings(
+        &self,
+        api_key_id: &str,
+        patch: SettingsPatch,
+        now: OffsetDateTime,
+    ) -> Result<SettingsRecord, StorageError> {
+        let Some(transcription_model) = patch.transcription_model else {
+            return self.get_settings(api_key_id).await;
+        };
+
+        let updated_at = format_timestamp(now)?;
+        sqlx::query(
+            r#"
+            INSERT INTO api_key_settings (api_key_id, transcription_model, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(api_key_id) DO UPDATE SET
+                transcription_model = excluded.transcription_model,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcription_model)
+        .bind(updated_at)
+        .execute(&self.pool)
+        .await?;
+
+        self.get_settings(api_key_id).await
     }
 
     pub async fn accept_job(
@@ -1112,6 +1172,12 @@ fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, 
         failure_message: row.try_get("failure_message")?,
         retryable_by_client,
         transcript_id: row.try_get("transcript_id")?,
+    })
+}
+
+fn settings_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SettingsRecord, StorageError> {
+    Ok(SettingsRecord {
+        transcription_model: row.try_get("transcription_model")?,
     })
 }
 

--- a/backend/tests/responses.rs
+++ b/backend/tests/responses.rs
@@ -1,7 +1,12 @@
+use axum::body::Body;
+use axum::extract::DefaultBodyLimit;
 use axum::http::{Request, StatusCode};
+use axum::routing::post;
 use oracy_backend::bootstrap::load_runtime_from_path;
 use oracy_backend::errors::{CollectionEnvelope, ErrorDetail, ErrorResponse};
+use oracy_backend::json::JsonBody;
 use oracy_backend::router::build_router;
+use serde::Deserialize;
 use serde_json::json;
 use tempfile::TempDir;
 use tower::util::ServiceExt;
@@ -113,6 +118,82 @@ key = "alpha-secret"
         json!({
             "error_code": "not_found",
             "message": "Resource not found."
+        })
+    );
+}
+
+#[tokio::test]
+async fn typed_json_shape_rejection_returns_shared_error_envelope() {
+    #[derive(Deserialize)]
+    struct RequestBody {
+        name: String,
+    }
+
+    async fn handler(JsonBody(body): JsonBody<RequestBody>) -> String {
+        body.name
+    }
+
+    let app = axum::Router::new().route("/typed", post(handler));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/typed")
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "name": 1 }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&body).expect("json"),
+        json!({
+            "error_code": "invalid_request_shape",
+            "message": "Request JSON shape is invalid."
+        })
+    );
+}
+
+#[tokio::test]
+async fn oversized_json_body_returns_shared_error_envelope() {
+    #[derive(Deserialize)]
+    struct RequestBody {
+        name: String,
+    }
+
+    async fn handler(JsonBody(body): JsonBody<RequestBody>) -> String {
+        body.name
+    }
+
+    let app = axum::Router::new()
+        .route("/typed", post(handler))
+        .layer(DefaultBodyLimit::max(8));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/typed")
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "name": "too large" }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&body).expect("json"),
+        json!({
+            "error_code": "payload_too_large",
+            "message": "Request body is too large."
         })
     );
 }

--- a/backend/tests/settings.rs
+++ b/backend/tests/settings.rs
@@ -1,0 +1,300 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use oracy_backend::bootstrap::load_runtime_from_path;
+use oracy_backend::router::build_router;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+#[tokio::test]
+async fn first_read_returns_default_settings_for_authenticated_api_key() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/settings")
+                .header("Authorization", "Bearer alpha-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "transcription_model": "gpt-4o-mini-transcribe"
+        })
+    );
+}
+
+#[tokio::test]
+async fn patch_updates_transcription_model_to_each_supported_value() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    for model in ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/api/v1/settings")
+                    .header("Authorization", "Bearer alpha-secret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        json!({ "transcription_model": model }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            json_body(response).await,
+            json!({
+                "transcription_model": model
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn empty_patch_preserves_current_settings() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    patch_settings(
+        &app,
+        "alpha-secret",
+        json!({ "transcription_model": "gpt-4o-transcribe" }),
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/v1/settings")
+                .header("Authorization", "Bearer alpha-secret")
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "transcription_model": "gpt-4o-transcribe"
+        })
+    );
+}
+
+#[tokio::test]
+async fn patch_rejects_invalid_setting_values() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    for body in [
+        json!({ "transcription_model": "not-supported" }),
+        json!({ "transcription_model": null }),
+        json!({ "unknown": "value" }),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/api/v1/settings")
+                    .header("Authorization", "Bearer alpha-secret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(json_body(response).await["error_code"], "validation_error");
+    }
+}
+
+#[tokio::test]
+async fn settings_routes_require_valid_authentication() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    for request in [
+        Request::builder()
+            .uri("/api/v1/settings")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .uri("/api/v1/settings")
+            .header("Authorization", "Bearer unknown-secret")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .method("PATCH")
+            .uri("/api/v1/settings")
+            .header("Content-Type", "application/json")
+            .body(Body::from(json!({}).to_string()))
+            .unwrap(),
+    ] {
+        let response = app.clone().oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            json_body(response).await,
+            json!({
+                "error_code": "unauthorized",
+                "message": "Missing or invalid API key."
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn settings_persist_across_backend_restart() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+    patch_settings(
+        &app,
+        "alpha-secret",
+        json!({ "transcription_model": "gpt-4o-transcribe" }),
+    )
+    .await;
+    drop(app);
+
+    let restarted = fixture.app().await;
+    let response = restarted
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/settings")
+                .header("Authorization", "Bearer alpha-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "transcription_model": "gpt-4o-transcribe"
+        })
+    );
+}
+
+#[tokio::test]
+async fn settings_are_isolated_per_api_key() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    patch_settings(
+        &app,
+        "alpha-secret",
+        json!({ "transcription_model": "gpt-4o-transcribe" }),
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/settings")
+                .header("Authorization", "Bearer beta-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "transcription_model": "gpt-4o-mini-transcribe"
+        })
+    );
+}
+
+struct SettingsFixture {
+    _tempdir: TempDir,
+    config_path: std::path::PathBuf,
+}
+
+impl SettingsFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let audio_dir = tempdir.path().join("accepted-audio");
+        std::fs::create_dir(&audio_dir).expect("create dir");
+        let config_path = tempdir.path().join("oracy.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+accepted_audio_dir = "{}"
+database_path = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "alpha-secret"
+
+[[api_keys]]
+api_key_id = "beta"
+key = "beta-secret"
+"#,
+                audio_dir.display(),
+                tempdir.path().join("oracy.sqlite").display()
+            )
+            .trim_start(),
+        )
+        .expect("write config");
+
+        Self {
+            _tempdir: tempdir,
+            config_path,
+        }
+    }
+
+    async fn app(&self) -> axum::Router {
+        let (_, state) = load_runtime_from_path(&self.config_path)
+            .await
+            .expect("valid runtime");
+        build_router(state)
+    }
+}
+
+async fn patch_settings(app: &axum::Router, bearer: &str, body: Value) -> Value {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/v1/settings")
+                .header("Authorization", format!("Bearer {bearer}"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    json_body(response).await
+}
+
+async fn json_body(response: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&bytes).expect("valid json")
+}

--- a/backend/tests/settings.rs
+++ b/backend/tests/settings.rs
@@ -162,6 +162,89 @@ async fn settings_routes_require_valid_authentication() {
 }
 
 #[tokio::test]
+async fn unsupported_settings_method_returns_shared_error_envelope() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/v1/settings")
+                .header("Authorization", "Bearer alpha-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "error_code": "method_not_allowed",
+            "message": "Method not allowed."
+        })
+    );
+}
+
+#[tokio::test]
+async fn malformed_settings_patch_json_returns_shared_error_envelope() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/v1/settings")
+                .header("Authorization", "Bearer alpha-secret")
+                .header("Content-Type", "application/json")
+                .body(Body::from(r#"{"transcription_model":"#))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "error_code": "malformed_json",
+            "message": "Request body must be valid JSON."
+        })
+    );
+}
+
+#[tokio::test]
+async fn non_json_settings_patch_returns_shared_error_envelope() {
+    let fixture = SettingsFixture::new().await;
+    let app = fixture.app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/v1/settings")
+                .header("Authorization", "Bearer alpha-secret")
+                .header("Content-Type", "text/plain")
+                .body(Body::from(r#"{"transcription_model":"gpt-4o-transcribe"}"#))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "error_code": "unsupported_content_type",
+            "message": "Request content type must be application/json."
+        })
+    );
+}
+
+#[tokio::test]
 async fn settings_persist_across_backend_restart() {
     let fixture = SettingsFixture::new().await;
     let app = fixture.app().await;

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -695,6 +695,7 @@ defaults.
 ### PATCH `/api/v1/settings`
 
 Partial update of settings. Omitted fields are left unchanged.
+An empty object is valid and returns the current settings unchanged.
 
 Request body:
 

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -48,6 +48,18 @@ behavior are deferred to a later revision.
 - `next_cursor` is `null` when no additional page exists.
 - `limit` defaults to `50` and must not exceed `100`.
 - All `4xx` and `5xx` responses use the same `ErrorResponse` envelope.
+- A request to an existing route with an unsupported method returns
+  `405 Method Not Allowed` with `error_code: "method_not_allowed"`.
+- JSON request body parsing preserves transport-level statuses in the
+  envelope: malformed JSON returns `400 Bad Request` with
+  `error_code: "malformed_json"`; unsupported JSON content type returns
+  `415 Unsupported Media Type` with
+  `error_code: "unsupported_content_type"`; a valid JSON body that
+  cannot be deserialized into the endpoint's typed request schema
+  returns `422 Unprocessable Entity` with
+  `error_code: "invalid_request_shape"`; a JSON body exceeding the
+  configured body limit returns `413 Payload Too Large` with
+  `error_code: "payload_too_large"`.
 
 ### `ErrorResponse`
 
@@ -140,7 +152,8 @@ Responses:
 - `200 OK`: replay against an already-terminated attempt (succeeded
   or failed) under the same `(API key, Idempotency-Key)` with a
   matching open-call body
-- `400 Bad Request`: invalid idempotency header or invalid body fields
+- `400 Bad Request`: invalid idempotency header, malformed JSON, or
+  invalid body fields
 - `401 Unauthorized`: missing or invalid API key
 - `404 Not Found`: supplied `session_id` does not exist for the
   authenticated API key
@@ -148,6 +161,11 @@ Responses:
   any open-call dimension (`recorded_at`, `chunk_count`,
   `audio_format`, `session_id`, `language`) relative to the prior
   attempt
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
+- `422 Unprocessable Entity`: valid JSON does not match the typed
+  request schema
 
 Response body is a `TranscriptionJob` resource. New attempts are in
 status `accepting_chunks`.
@@ -318,9 +336,14 @@ Request body:
 Responses:
 
 - `200 OK`
-- `400 Bad Request`
+- `400 Bad Request`: malformed JSON or invalid body fields
 - `401 Unauthorized`
 - `404 Not Found`
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
+- `422 Unprocessable Entity`: valid JSON does not match the typed
+  request schema
 
 Notes:
 
@@ -419,10 +442,15 @@ Request body:
 Responses:
 
 - `200 OK`
-- `400 Bad Request`
+- `400 Bad Request`: malformed JSON or invalid body fields
 - `401 Unauthorized`
 - `404 Not Found`: voice note or one or more referenced tags not found
   for the authenticated API key
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
+- `422 Unprocessable Entity`: valid JSON does not match the typed
+  request schema
 
 Notes:
 
@@ -476,8 +504,13 @@ Responses:
 - `201 Created`: new tag created
 - `200 OK`: a tag with the same case-insensitive name already exists
   for the authenticated API key
-- `400 Bad Request`
+- `400 Bad Request`: malformed JSON or invalid body fields
 - `401 Unauthorized`
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
+- `422 Unprocessable Entity`: valid JSON does not match the typed
+  request schema
 
 Notes:
 
@@ -513,11 +546,16 @@ Request body:
 Responses:
 
 - `200 OK`
-- `400 Bad Request`
+- `400 Bad Request`: malformed JSON or invalid body fields
 - `401 Unauthorized`
 - `404 Not Found`
 - `409 Conflict`: another tag with the same case-insensitive name
   already exists for the authenticated API key
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
+- `422 Unprocessable Entity`: valid JSON does not match the typed
+  request schema
 
 Notes:
 
@@ -581,8 +619,13 @@ Request body:
 Responses:
 
 - `201 Created`
-- `400 Bad Request`
+- `400 Bad Request`: malformed JSON or invalid body fields
 - `401 Unauthorized`
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
+- `422 Unprocessable Entity`: valid JSON does not match the typed
+  request schema
 
 Response body is a `Session` resource.
 
@@ -613,9 +656,14 @@ Request body:
 Responses:
 
 - `200 OK`
-- `400 Bad Request`
+- `400 Bad Request`: malformed JSON or invalid body fields
 - `401 Unauthorized`
 - `404 Not Found`
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
+- `422 Unprocessable Entity`: valid JSON does not match the typed
+  request schema
 
 Response body is the updated `Session` resource.
 
@@ -716,8 +764,12 @@ Validation:
 Responses:
 
 - `200 OK`
-- `400 Bad Request`: unknown field or unsupported model identifier
+- `400 Bad Request`: malformed JSON, unknown field, invalid setting
+  field value, or unsupported model identifier
 - `401 Unauthorized`
+- `413 Payload Too Large`: JSON request body exceeds the configured
+  body limit
+- `415 Unsupported Media Type`: request body is not sent as JSON
 
 Notes:
 


### PR DESCRIPTION
## Summary

- Adds the authenticated Settings resource so each API key can read and update its transcription model.
- Persists per-key settings durably with the documented default returned on first read.
- Preserves the shared `ErrorResponse` envelope for framework-owned 4xx paths introduced by the settings route.

## Changes

- Adds `GET /api/v1/settings` and `PATCH /api/v1/settings` handlers with shared auth and validation errors.
- Adds `api_key_settings` storage with closed-enum transcription model values and default-without-insert behavior.
- Adds router/extractor infrastructure for contract-shaped method-not-allowed and JSON body rejection responses.
- Updates the API contract and changelog for status-preserving framework rejection envelopes.
- Adds integration coverage for settings defaults, supported updates, no-op partial update, validation failures, auth failures, restart durability, per-key isolation, unsupported methods, malformed JSON, wrong content type, typed JSON shape rejection, and oversized JSON bodies.

## GitHub Issue(s)

Closes #36

## Test plan

- `cd backend && cargo fmt --check`
- `cd backend && cargo test`
- `git diff --check`
