### PR TITLE
docs(deployment): define backend persistent storage responsibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add the operator-facing deployment contract for backend accepted-audio
+  storage, SQLite persistence, and `OPENAI_API_KEY` provisioning.
 - Preserve the shared `ErrorResponse` envelope for framework-owned API
   rejections, including unsupported methods and JSON body parse, content-type,
   shape, and size failures.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -48,9 +48,9 @@ required, not optional.
   deployment optimization.
 - The backend must not advertise durable acceptance semantics when
   this location is unavailable or not writable.
-- `spec/deployment.md` must later define the operator's persistent-
-  storage responsibilities, including path provisioning, persistence
-  across restart, and capacity implications.
+- `spec/deployment.md` defines the operator's persistent-storage
+  responsibilities, including path provisioning, persistence across
+  restart, filesystem semantics, and capacity implications.
 
 ### `OPENAI_API_KEY`
 
@@ -60,8 +60,8 @@ required, not optional.
   variable.
 - The backend must not advertise transcription capability when
   `OPENAI_API_KEY` is unset or empty.
-- `spec/deployment.md` must later define the operator's responsibility
-  for provisioning, rotating, and protecting this credential.
+- `spec/deployment.md` defines the operator's responsibility for
+  provisioning, rotating, and protecting this credential.
 
 ## Constraints
 

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -1,0 +1,110 @@
+# Oracy Deployment Contract
+
+Target release: `v0.1.0`
+
+## Purpose
+
+This document defines the operator-provided resources required to run the
+Oracy backend. It is the operator-side contract: what the deployment
+environment must provide before the backend can start cleanly and preserve its
+durability commitments under nominal load.
+
+`backend/README.md` describes developer-facing configuration keys and startup
+behavior. This document describes the infrastructure responsibilities behind
+those settings.
+
+## Audience
+
+This document is for operators standing up Oracy on POSIX Linux
+infrastructure. It assumes familiarity with filesystem permissions, persistent
+volume management, environment-variable provisioning, and long-running backend
+processes.
+
+## Platform Scope
+
+For `v0.1.0`, Oracy's backend assumes Linux with POSIX filesystem semantics.
+The operator-provided storage described here must support atomic rename,
+`fsync`, and standard POSIX permission bits. Network filesystems are
+operator-risk: the backend assumes local-disk semantics for durability and
+crash-safety.
+
+## Accepted Audio Directory
+
+The backend stores accepted audio chunks and composed audio in the configured
+`accepted_audio_dir` while a transcription job is still active.
+
+Operators must provide a directory with these properties:
+
+- The path exists before backend startup.
+- The path is on a POSIX filesystem.
+- The directory is owned by the user the backend process runs as.
+- That user has read, write, and execute permissions on the directory.
+- Contents survive backend restarts.
+- Contents are on a volume that persists across container or host reboots in
+  the operator's deployment.
+
+Capacity must cover active chunked-submission state. The directory holds chunks
+while jobs are in `accepting_chunks`, plus composed audio while jobs are in
+`queued`, `processing`, or `retry_waiting`. The backend releases retained audio
+when the originating job reaches terminal `succeeded` or `failed`, so
+steady-state size is bounded by concurrent in-flight submissions rather than
+historical voice-note volume.
+
+## SQLite Database File
+
+The backend stores durable job, voice-note, settings, and metadata state in the
+configured `database_path`.
+
+Operators must provide a database path with these properties:
+
+- The parent directory exists before backend startup.
+- The parent directory is on a POSIX filesystem.
+- The parent directory is owned by the user the backend process runs as.
+- That user can create and write the database file and SQLite sidecar files.
+- The database file and its WAL and SHM siblings survive backend restarts.
+- The database file and its WAL and SHM siblings are on a volume that persists
+  across container or host reboots in the operator's deployment.
+
+SQLite relies on filesystem support for `fsync` and atomic rename for
+crash-safety. Filesystems or mounts that weaken those semantics do not satisfy
+Oracy's `v0.1.0` persistence assumptions.
+
+## `OPENAI_API_KEY`
+
+The backend uses `OPENAI_API_KEY` as the OpenAI transcription-engine
+credential. The credential is read from the process environment at backend
+startup.
+
+Operators must provide the credential with these properties:
+
+- The value is obtained from OpenAI and scoped to the backend's expected
+  transcription usage.
+- The value is present in the `OPENAI_API_KEY` environment variable whenever
+  the backend process starts.
+- The value is non-empty.
+- The provisioning mechanism persists across backend restarts.
+
+The mechanism is operator-owned. Examples include systemd unit environment
+directives, container runtime env files, and secret-store-backed retrieval. The
+contract is that the value reliably reaches the backend at every startup.
+
+Credential rotation happens by updating the value that will be present in the
+backend process environment and restarting the backend. The backend has no
+in-process credential rotation mechanism. Operators implementing automated
+rotation own the orchestration that updates the startup environment and
+restarts the process.
+
+Operators are responsible for protecting operator-controlled surfaces that
+carry the credential. The value should not be exposed in version control,
+shared logs, copied configuration, shell history, or diagnostic output produced
+by provisioning and deployment tooling outside the backend.
+
+## Worked Example
+
+`tesserine/ops` documents one concrete deployment pattern in
+[`babbie-services.md`](https://github.com/tesserine/ops/blob/main/babbie-services.md).
+That environment uses Podman Quadlets on Fedora CoreOS with user-scope systemd.
+
+The babbie document is illustrative, not normative. Operators on different
+infrastructure satisfy this contract through the storage, environment, and
+process-management mechanisms appropriate to their own deployment.


### PR DESCRIPTION
## Summary

- Adds `spec/deployment.md` as the operator-facing contract for Oracy backend deployment prerequisites.
- Defines accepted-audio directory, SQLite database file, and `OPENAI_API_KEY` responsibilities in operator-actionable terms.
- Replaces the backend requirements placeholders with links to the fulfilled deployment contract.

## Changes

- Documents POSIX/local-disk semantics, ownership, permissions, persistence, and capacity expectations for accepted audio storage.
- Documents SQLite database path, WAL/SHM persistence, and filesystem crash-safety assumptions.
- Documents startup provisioning, restart persistence, restart-based rotation, and operator-controlled protection surfaces for `OPENAI_API_KEY`.
- Adds the `tesserine/ops` babbie services document as an illustrative, non-normative deployment example.
- Records the operator-visible spec addition in `CHANGELOG.md`.

## GitHub Issue(s)

Closes #24
Refs #49

## Test plan

- Read `spec/deployment.md` end-to-end against #24's correctness bar: an operator following it has the storage and credential environment needed for the backend to start cleanly and operate under nominal load.
- Ran `git diff --check`.
- Confirmed this command returned no matches:

```sh
rg -n "must later define" spec/backend-requirements.md spec/deployment.md
```

- Ran acceptance-token checks against `spec/deployment.md` for accepted-audio, SQLite, `OPENAI_API_KEY`, POSIX semantics, retention states, and the babbie reference.
- Ran backend-requirements link checks for `spec/deployment.md defines`, `persistent-storage`, and `provisioning, rotating, and protecting`.

## Follow-up

#49 tracks the separate backend runtime-contract question for `OPENAI_API_KEY` non-emission. This PR intentionally keeps that out of the operator-side deployment contract.