### PR TITLE
spec(runtime): define credential non-emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Define the backend runtime commitment not to emit the literal
+  `OPENAI_API_KEY` value through backend-controlled logs, diagnostics, or error
+  surfaces.
 - Add the operator-facing deployment contract for backend accepted-audio
   storage, SQLite persistence, and `OPENAI_API_KEY` provisioning.
 - Preserve the shared `ErrorResponse` envelope for framework-owned API

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -131,6 +131,45 @@ async fn startup_accepts_non_empty_openai_api_key_env_helper() {
 }
 
 #[tokio::test]
+async fn startup_error_diagnostics_do_not_emit_openai_api_key_value() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &tempdir,
+        r#"
+accepted_audio_dir = "missing"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#
+        .to_owned(),
+    );
+
+    support::assert_ignored_test_passes_with_env(
+        "startup_error_diagnostics_do_not_emit_openai_api_key_value_helper",
+        &[
+            ("ORACY_CONFIG", config_path.as_os_str()),
+            (
+                "OPENAI_API_KEY",
+                std::ffi::OsStr::new("sentinel-openai-key-value"),
+            ),
+        ],
+        &[],
+    );
+}
+
+#[tokio::test]
+#[ignore = "helper subprocess only"]
+async fn startup_error_diagnostics_do_not_emit_openai_api_key_value_helper() {
+    let error = load_runtime_from_env()
+        .await
+        .expect_err("invalid runtime should fail");
+    let diagnostic = error.to_string();
+
+    assert!(!diagnostic.contains("sentinel-openai-key-value"));
+}
+
+#[tokio::test]
 async fn startup_rejects_when_no_api_keys_are_configured() {
     let tempdir = TempDir::new().expect("tempdir");
     let config_path = write_config(

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -60,8 +60,19 @@ required, not optional.
   variable.
 - The backend must not advertise transcription capability when
   `OPENAI_API_KEY` is unset or empty.
+- Backend-controlled output must not emit the literal
+  `OPENAI_API_KEY` value. This includes logs, startup diagnostics,
+  HTTP error bodies, backend error messages, and other diagnostics
+  produced by backend code.
+- Backend-controlled output may name the `OPENAI_API_KEY` environment
+  variable and may report that it is missing or empty.
 - `spec/deployment.md` defines the operator's responsibility for
-  provisioning, rotating, and protecting this credential.
+  provisioning, rotating, and protecting this credential. Operator-
+  controlled provisioning surfaces are outside the backend-side
+  non-emission commitment, including environment files, service
+  manager configuration, secret-store tooling, copied configuration,
+  shell history, and diagnostics produced by deployment tooling
+  outside the backend.
 
 ## Constraints
 
@@ -586,6 +597,8 @@ following are true:
 - The operator's persistent storage location and `OPENAI_API_KEY` are
   named as required prerequisites, and the backend refuses to
   advertise the dependent capabilities when either is missing.
+- The backend-side `OPENAI_API_KEY` non-emission commitment and its
+  boundary with operator-controlled provisioning surfaces are explicit.
 - A valid open call returns a `TranscriptionJob` in
   `accepting_chunks` with the declared `chunk_count`.
 - Each accepted chunk push moves `chunks_received` toward


### PR DESCRIPTION
## Summary

- Defines the backend runtime commitment not to emit the literal `OPENAI_API_KEY` value through backend-controlled logs, diagnostics, or error surfaces.
- Draws the boundary between backend-controlled output and operator-controlled provisioning surfaces covered by deployment responsibilities.
- Adds startup regression coverage proving a provided OpenAI credential is absent from backend startup error diagnostics.

## Changes

- Updates `spec/backend-requirements.md` with the credential non-emission contract and acceptance checklist coverage.
- Adds a `backend/tests/startup.rs` regression test for startup diagnostic non-emission.
- Records the runtime contract clarification in `CHANGELOG.md`.

## GitHub Issue(s)

Closes #49

## Test plan

- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy -- -D warnings`
- `cd backend && cargo test`
- `git diff --check`
