### PR TITLE
feat(voice-notes): expose voice-note history and read surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Add authenticated voice-note history, detail, version-history, segment, and
   session-scoped history read APIs. Search and filter query parameters are
-  accepted on the collection surfaces for wire compatibility but return
-  history until the tracked search work lands.
+  accepted on the collection surfaces for wire compatibility but
+  conservatively return no results until the tracked search work lands.
 - Define the backend runtime commitment not to emit the literal
   `OPENAI_API_KEY` value through backend-controlled logs, diagnostics, or error
   surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add authenticated voice-note history, detail, version-history, segment, and
+  session-scoped history read APIs. Search and filter query parameters are
+  accepted on the collection surfaces for wire compatibility but return
+  history until the tracked search work lands.
 - Define the backend runtime commitment not to emit the literal
   `OPENAI_API_KEY` value through backend-controlled logs, diagnostics, or error
   surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Add authenticated voice-note history, detail, version-history, segment, and
-  session-scoped history read APIs. Search and filter query parameters are
-  accepted on the collection surfaces for wire compatibility but
+  session-scoped history read APIs. Collection filters compose across tags,
+  sessions, and recorded/created time ranges; search query parameters
   conservatively return no results until the tracked search work lands.
 - Define the backend runtime commitment not to emit the literal
   `OPENAI_API_KEY` value through backend-controlled logs, diagnostics, or error

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "axum",
  "base64",
  "caseless",
+ "form_urlencoded",
  "serde",
  "serde_json",
  "sha2",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -963,6 +963,7 @@ name = "oracy-backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64",
  "caseless",
  "serde",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/pentaxis93/oracy"
 axum = "0.8.9"
 base64 = "0.22"
 caseless = "0.2.2"
+form_urlencoded = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/pentaxis93/oracy"
 
 [dependencies]
 axum = "0.8.9"
+base64 = "0.22"
 caseless = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -53,6 +53,20 @@ impl ApiError {
         }
     }
 
+    pub fn repeated_singular_parameter(field: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            body: ErrorResponse {
+                error_code: "repeated_singular_parameter".to_owned(),
+                message: "A singular query parameter was supplied more than once.".to_owned(),
+                details: Some(vec![ErrorDetail {
+                    field: field.into(),
+                    message: "Must be supplied at most once.".to_owned(),
+                }]),
+            },
+        }
+    }
+
     pub fn from_json_rejection(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonSyntaxError(_) => Self::malformed_json(),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,3 +10,4 @@ pub mod router;
 pub mod settings;
 pub mod state;
 pub mod storage;
+pub mod voice_notes;

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -4,10 +4,28 @@ use axum::routing::get;
 use crate::errors::ApiError;
 use crate::settings::{get_settings, patch_settings};
 use crate::state::AppState;
+use crate::voice_notes::{
+    get_voice_note, list_session_voice_notes, list_voice_note_segments, list_voice_note_versions,
+    list_voice_notes,
+};
 
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/api/v1/settings", get(get_settings).patch(patch_settings))
+        .route("/api/v1/voice-notes", get(list_voice_notes))
+        .route("/api/v1/voice-notes/{voice_note_id}", get(get_voice_note))
+        .route(
+            "/api/v1/voice-notes/{voice_note_id}/versions",
+            get(list_voice_note_versions),
+        )
+        .route(
+            "/api/v1/voice-notes/{voice_note_id}/segments",
+            get(list_voice_note_segments),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/voice-notes",
+            get(list_session_voice_notes),
+        )
         .fallback(|| async { Err::<(), _>(ApiError::not_found("Resource not found.")) })
         .method_not_allowed_fallback(|| async { Err::<(), _>(ApiError::method_not_allowed()) })
         .with_state(state)

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use caseless::Caseless;
 use sqlx::migrate::Migrator;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
-use sqlx::{Row, SqlitePool};
+use sqlx::{QueryBuilder, Row, SqlitePool};
 use thiserror::Error;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
@@ -223,6 +223,14 @@ pub struct TranscriptRecord {
     pub created_at: OffsetDateTime,
     pub recorded_at: OffsetDateTime,
     pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptVersionRecord {
+    pub id: String,
+    pub transcript_id: String,
+    pub transcript: String,
+    pub created_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -652,6 +660,118 @@ impl Storage {
         row.map(transcript_from_row).transpose()
     }
 
+    pub async fn list_transcripts(
+        &self,
+        api_key_id: &str,
+        cursor: Option<(OffsetDateTime, String)>,
+        limit: i64,
+    ) -> Result<Vec<TranscriptRecord>, StorageError> {
+        self.list_transcripts_in_session(api_key_id, None, cursor, limit)
+            .await
+    }
+
+    pub async fn list_session_transcripts(
+        &self,
+        api_key_id: &str,
+        session_id: &str,
+        cursor: Option<(OffsetDateTime, String)>,
+        limit: i64,
+    ) -> Result<Vec<TranscriptRecord>, StorageError> {
+        self.list_transcripts_in_session(api_key_id, Some(session_id), cursor, limit)
+            .await
+    }
+
+    async fn list_transcripts_in_session(
+        &self,
+        api_key_id: &str,
+        session_id: Option<&str>,
+        cursor: Option<(OffsetDateTime, String)>,
+        limit: i64,
+    ) -> Result<Vec<TranscriptRecord>, StorageError> {
+        let cursor_created_at = cursor
+            .as_ref()
+            .map(|(created_at, _)| format_timestamp(*created_at))
+            .transpose()?;
+        let cursor_id = cursor.as_ref().map(|(_, id)| id.as_str());
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                transcripts.*,
+                transcript_versions.id AS current_version_id,
+                transcript_versions.transcript AS current_transcript
+            FROM transcripts
+            JOIN transcript_versions
+                ON transcript_versions.transcript_id = transcripts.id
+            WHERE transcripts.api_key_id = ?
+                AND (? IS NULL OR transcripts.session_id = ?)
+                AND transcript_versions.version_number = (
+                    SELECT MAX(version_number)
+                    FROM transcript_versions
+                    WHERE transcript_id = transcripts.id
+                )
+                AND (
+                    ? IS NULL
+                    OR transcripts.created_at < ?
+                    OR (transcripts.created_at = ? AND transcripts.id < ?)
+                )
+            ORDER BY transcripts.created_at DESC, transcripts.id DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(session_id)
+        .bind(session_id)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(cursor_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(transcript_from_row).collect()
+    }
+
+    pub async fn list_transcript_versions(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+        cursor: Option<(OffsetDateTime, String)>,
+        limit: i64,
+    ) -> Result<Vec<TranscriptVersionRecord>, StorageError> {
+        let cursor_created_at = cursor
+            .as_ref()
+            .map(|(created_at, _)| format_timestamp(*created_at))
+            .transpose()?;
+        let cursor_id = cursor.as_ref().map(|(_, id)| id.as_str());
+        let rows = sqlx::query(
+            r#"
+            SELECT id, transcript_id, transcript, created_at
+            FROM transcript_versions
+            WHERE api_key_id = ?
+                AND transcript_id = ?
+                AND (
+                    ? IS NULL
+                    OR created_at < ?
+                    OR (created_at = ? AND id < ?)
+                )
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(cursor_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(transcript_version_from_row).collect()
+    }
+
     pub async fn list_segments(
         &self,
         api_key_id: &str,
@@ -671,6 +791,55 @@ impl Storage {
         .await?;
 
         rows.into_iter().map(segment_from_row).collect()
+    }
+
+    pub async fn list_segments_page(
+        &self,
+        api_key_id: &str,
+        transcript_id: &str,
+        cursor: Option<i64>,
+        limit: i64,
+    ) -> Result<Vec<SegmentRecord>, StorageError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, transcript_id, position, start_ms, end_ms, text
+            FROM segments
+            WHERE api_key_id = ?
+                AND transcript_id = ?
+                AND (? IS NULL OR position > ?)
+            ORDER BY position ASC
+            LIMIT ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(transcript_id)
+        .bind(cursor)
+        .bind(cursor)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(segment_from_row).collect()
+    }
+
+    pub async fn session_exists(
+        &self,
+        api_key_id: &str,
+        session_id: &str,
+    ) -> Result<bool, StorageError> {
+        let exists: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT 1
+            FROM sessions
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(exists.is_some())
     }
 
     pub async fn replace_current_embedding(
@@ -1049,6 +1218,58 @@ impl Storage {
 
         rows.into_iter().map(tag_from_row).collect()
     }
+
+    pub async fn list_tags_for_transcripts(
+        &self,
+        api_key_id: &str,
+        transcript_ids: &[String],
+    ) -> Result<HashMap<String, Vec<TagRecord>>, StorageError> {
+        if transcript_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut query = QueryBuilder::new(
+            r#"
+            SELECT
+                transcript_tags.transcript_id AS transcript_id,
+                tags.id AS tag_id,
+                tags.api_key_id AS api_key_id,
+                tags.name AS name,
+                tags.created_at AS created_at
+            FROM transcript_tags
+            JOIN tags
+                ON tags.api_key_id = transcript_tags.api_key_id
+                AND tags.id = transcript_tags.tag_id
+            WHERE transcript_tags.api_key_id =
+            "#,
+        );
+        query.push_bind(api_key_id);
+        query.push(" AND transcript_tags.transcript_id IN (");
+        let mut separated = query.separated(", ");
+        for transcript_id in transcript_ids {
+            separated.push_bind(transcript_id);
+        }
+        separated.push_unseparated(")");
+        query.push(
+            " ORDER BY transcript_tags.transcript_id ASC, tags.created_at DESC, tags.id DESC",
+        );
+
+        let rows = query.build().fetch_all(&self.pool).await?;
+        let mut tags_by_transcript = HashMap::new();
+        for transcript_id in transcript_ids {
+            tags_by_transcript.insert(transcript_id.clone(), Vec::new());
+        }
+        for row in rows {
+            let transcript_id: String = row.try_get("transcript_id")?;
+            let tag = tag_from_prefixed_row(row)?;
+            tags_by_transcript
+                .entry(transcript_id)
+                .or_default()
+                .push(tag);
+        }
+
+        Ok(tags_by_transcript)
+    }
 }
 
 impl TranscriptionJobRecord {
@@ -1200,6 +1421,17 @@ fn transcript_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptRecord,
     })
 }
 
+fn transcript_version_from_row(
+    row: sqlx::sqlite::SqliteRow,
+) -> Result<TranscriptVersionRecord, StorageError> {
+    Ok(TranscriptVersionRecord {
+        id: row.try_get("id")?,
+        transcript_id: row.try_get("transcript_id")?,
+        transcript: row.try_get("transcript")?,
+        created_at: parse_timestamp(row.try_get("created_at")?)?,
+    })
+}
+
 fn segment_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SegmentRecord, StorageError> {
     Ok(SegmentRecord {
         id: row.try_get("id")?,
@@ -1223,6 +1455,15 @@ fn embedding_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EmbeddingRecord, S
 fn tag_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TagRecord, StorageError> {
     Ok(TagRecord {
         id: row.try_get("id")?,
+        api_key_id: row.try_get("api_key_id")?,
+        name: row.try_get("name")?,
+        created_at: parse_timestamp(row.try_get("created_at")?)?,
+    })
+}
+
+fn tag_from_prefixed_row(row: sqlx::sqlite::SqliteRow) -> Result<TagRecord, StorageError> {
+    Ok(TagRecord {
+        id: row.try_get("tag_id")?,
         api_key_id: row.try_get("api_key_id")?,
         name: row.try_get("name")?,
         created_at: parse_timestamp(row.try_get("created_at")?)?,

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -233,6 +233,16 @@ pub struct TranscriptVersionRecord {
     pub created_at: OffsetDateTime,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TranscriptFilters {
+    pub tag_ids: Vec<String>,
+    pub session_id: Option<String>,
+    pub recorded_after: Option<OffsetDateTime>,
+    pub recorded_before: Option<OffsetDateTime>,
+    pub created_after: Option<OffsetDateTime>,
+    pub created_before: Option<OffsetDateTime>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentRecord {
     pub id: String,
@@ -663,10 +673,11 @@ impl Storage {
     pub async fn list_transcripts(
         &self,
         api_key_id: &str,
+        filters: &TranscriptFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
     ) -> Result<Vec<TranscriptRecord>, StorageError> {
-        self.list_transcripts_in_session(api_key_id, None, cursor, limit)
+        self.list_transcripts_in_session(api_key_id, None, filters, cursor, limit)
             .await
     }
 
@@ -674,10 +685,11 @@ impl Storage {
         &self,
         api_key_id: &str,
         session_id: &str,
+        filters: &TranscriptFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
     ) -> Result<Vec<TranscriptRecord>, StorageError> {
-        self.list_transcripts_in_session(api_key_id, Some(session_id), cursor, limit)
+        self.list_transcripts_in_session(api_key_id, Some(session_id), filters, cursor, limit)
             .await
     }
 
@@ -685,6 +697,7 @@ impl Storage {
         &self,
         api_key_id: &str,
         session_id: Option<&str>,
+        filters: &TranscriptFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
     ) -> Result<Vec<TranscriptRecord>, StorageError> {
@@ -693,7 +706,12 @@ impl Storage {
             .map(|(created_at, _)| format_timestamp(*created_at))
             .transpose()?;
         let cursor_id = cursor.as_ref().map(|(_, id)| id.as_str());
-        let rows = sqlx::query(
+        let recorded_after = filters.recorded_after.map(format_timestamp).transpose()?;
+        let recorded_before = filters.recorded_before.map(format_timestamp).transpose()?;
+        let created_after = filters.created_after.map(format_timestamp).transpose()?;
+        let created_before = filters.created_before.map(format_timestamp).transpose()?;
+        let effective_session_id = session_id.or(filters.session_id.as_deref());
+        let mut query = QueryBuilder::new(
             r#"
             SELECT
                 transcripts.*,
@@ -702,32 +720,70 @@ impl Storage {
             FROM transcripts
             JOIN transcript_versions
                 ON transcript_versions.transcript_id = transcripts.id
-            WHERE transcripts.api_key_id = ?
-                AND (? IS NULL OR transcripts.session_id = ?)
+            WHERE transcripts.api_key_id =
+            "#,
+        );
+        query.push_bind(api_key_id);
+        if let Some(session_id) = effective_session_id {
+            query.push(" AND transcripts.session_id = ");
+            query.push_bind(session_id);
+        }
+        if let Some(recorded_after) = recorded_after.as_deref() {
+            query.push(" AND transcripts.recorded_at > ");
+            query.push_bind(recorded_after);
+        }
+        if let Some(recorded_before) = recorded_before.as_deref() {
+            query.push(" AND transcripts.recorded_at <= ");
+            query.push_bind(recorded_before);
+        }
+        if let Some(created_after) = created_after.as_deref() {
+            query.push(" AND transcripts.created_at > ");
+            query.push_bind(created_after);
+        }
+        if let Some(created_before) = created_before.as_deref() {
+            query.push(" AND transcripts.created_at <= ");
+            query.push_bind(created_before);
+        }
+        for tag_id in &filters.tag_ids {
+            query.push(
+                r#"
+                AND EXISTS (
+                    SELECT 1
+                    FROM transcript_tags
+                    WHERE transcript_tags.api_key_id = transcripts.api_key_id
+                        AND transcript_tags.transcript_id = transcripts.id
+                        AND transcript_tags.tag_id =
+                "#,
+            );
+            query.push_bind(tag_id);
+            query.push(")");
+        }
+        query.push(
+            r#"
                 AND transcript_versions.version_number = (
                     SELECT MAX(version_number)
                     FROM transcript_versions
                     WHERE transcript_id = transcripts.id
                 )
-                AND (
-                    ? IS NULL
-                    OR transcripts.created_at < ?
-                    OR (transcripts.created_at = ? AND transcripts.id < ?)
-                )
-            ORDER BY transcripts.created_at DESC, transcripts.id DESC
-            LIMIT ?
             "#,
-        )
-        .bind(api_key_id)
-        .bind(session_id)
-        .bind(session_id)
-        .bind(&cursor_created_at)
-        .bind(&cursor_created_at)
-        .bind(&cursor_created_at)
-        .bind(cursor_id)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        if let Some(cursor_created_at) = cursor_created_at.as_deref() {
+            query.push(
+                r#"
+                AND (
+                    transcripts.created_at <
+                "#,
+            );
+            query.push_bind(cursor_created_at);
+            query.push(" OR (transcripts.created_at = ");
+            query.push_bind(cursor_created_at);
+            query.push(" AND transcripts.id < ");
+            query.push_bind(cursor_id.expect("cursor id is present with cursor timestamp"));
+            query.push("))");
+        }
+        query.push(" ORDER BY transcripts.created_at DESC, transcripts.id DESC LIMIT ");
+        query.push_bind(limit);
+        let rows = query.build().fetch_all(&self.pool).await?;
 
         rows.into_iter().map(transcript_from_row).collect()
     }

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -1,12 +1,11 @@
-use std::collections::HashMap;
-
 use axum::Json;
-use axum::extract::{Path, Query, State};
+use axum::extract::{Path, RawQuery, State};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
+use time::{OffsetDateTime, UtcOffset};
+use ulid::Ulid;
 
 use crate::auth::AuthenticatedKey;
 use crate::errors::{ApiError, CollectionEnvelope, ErrorDetail};
@@ -92,8 +91,9 @@ struct PositionCursor {
 pub async fn list_voice_notes(
     authenticated_key: AuthenticatedKey,
     State(state): State<AppState>,
-    Query(params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
+    let params = parse_query_params(raw_query.as_deref());
     let page = parse_time_page_query(&params, CursorKind::VoiceNoteHistory)?;
     let rows = state
         .storage
@@ -120,6 +120,7 @@ pub async fn get_voice_note(
     State(state): State<AppState>,
     Path(voice_note_id): Path<String>,
 ) -> Result<Json<VoiceNoteResource>, ApiError> {
+    validate_ulid_field("voice_note_id", &voice_note_id)?;
     let Some(record) = state
         .storage
         .get_transcript(authenticated_key.api_key_id.as_str(), &voice_note_id)
@@ -141,8 +142,10 @@ pub async fn list_voice_note_versions(
     authenticated_key: AuthenticatedKey,
     State(state): State<AppState>,
     Path(voice_note_id): Path<String>,
-    Query(params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<Json<CollectionEnvelope<VoiceNoteVersionResource>>, ApiError> {
+    validate_ulid_field("voice_note_id", &voice_note_id)?;
+    let params = parse_query_params(raw_query.as_deref());
     ensure_voice_note_exists(
         &state,
         authenticated_key.api_key_id.as_str(),
@@ -189,8 +192,10 @@ pub async fn list_voice_note_segments(
     authenticated_key: AuthenticatedKey,
     State(state): State<AppState>,
     Path(voice_note_id): Path<String>,
-    Query(params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<Json<CollectionEnvelope<SegmentResource>>, ApiError> {
+    validate_ulid_field("voice_note_id", &voice_note_id)?;
+    let params = parse_query_params(raw_query.as_deref());
     ensure_voice_note_exists(
         &state,
         authenticated_key.api_key_id.as_str(),
@@ -228,8 +233,10 @@ pub async fn list_session_voice_notes(
     authenticated_key: AuthenticatedKey,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-    Query(params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
+    validate_ulid_field("session_id", &session_id)?;
+    let params = parse_query_params(raw_query.as_deref());
     if !state
         .storage
         .session_exists(authenticated_key.api_key_id.as_str(), &session_id)
@@ -315,52 +322,79 @@ async fn render_voice_note_page(
 }
 
 fn parse_time_page_query(
-    params: &HashMap<String, String>,
+    params: &[(String, String)],
     cursor_kind: CursorKind,
 ) -> Result<PageQuery<(OffsetDateTime, String)>, ApiError> {
     validate_transitional_query(params, cursor_kind)?;
     Ok(PageQuery {
         limit: parse_limit(params)?,
-        cursor: params
-            .get("cursor")
+        cursor: query_first(params, "cursor")
             .map(|cursor| parse_time_cursor(cursor, cursor_kind))
             .transpose()?,
     })
 }
 
 fn parse_position_page_query(
-    params: &HashMap<String, String>,
+    params: &[(String, String)],
     cursor_kind: CursorKind,
 ) -> Result<PageQuery<i64>, ApiError> {
     validate_transitional_query(params, cursor_kind)?;
     Ok(PageQuery {
         limit: parse_limit(params)?,
-        cursor: params
-            .get("cursor")
+        cursor: query_first(params, "cursor")
             .map(|cursor| parse_position_cursor(cursor, cursor_kind))
             .transpose()?,
     })
 }
 
 fn validate_transitional_query(
-    params: &HashMap<String, String>,
+    params: &[(String, String)],
     cursor_kind: CursorKind,
 ) -> Result<(), ApiError> {
-    if cursor_kind.is_voice_note_collection()
-        && params.contains_key("search_mode")
-        && !params.contains_key("q")
-    {
-        return Err(validation_error(
-            "search_mode",
-            "Must be supplied only when q is present.",
-        ));
+    if cursor_kind.is_voice_note_collection() {
+        let has_q = query_any(params, "q");
+        for search_mode in query_values(params, "search_mode") {
+            if !has_q {
+                return Err(validation_error(
+                    "search_mode",
+                    "Must be supplied only when q is present.",
+                ));
+            }
+            if !matches!(search_mode, "keyword" | "semantic" | "hybrid") {
+                return Err(validation_error(
+                    "search_mode",
+                    "Must be one of keyword, semantic, hybrid.",
+                ));
+            }
+        }
+
+        for tag_id in query_values(params, "tag_id") {
+            validate_ulid_field("tag_id", tag_id)?;
+        }
+
+        if cursor_kind == CursorKind::VoiceNoteHistory {
+            for session_id in query_values(params, "session_id") {
+                validate_ulid_field("session_id", session_id)?;
+            }
+        }
+
+        for field in [
+            "recorded_after",
+            "recorded_before",
+            "created_after",
+            "created_before",
+        ] {
+            for value in query_values(params, field) {
+                validate_rfc3339_field(field, value)?;
+            }
+        }
     }
 
     Ok(())
 }
 
-fn parse_limit(params: &HashMap<String, String>) -> Result<i64, ApiError> {
-    let Some(raw_limit) = params.get("limit") else {
+fn parse_limit(params: &[(String, String)]) -> Result<i64, ApiError> {
+    let Some(raw_limit) = query_first(params, "limit") else {
         return Ok(DEFAULT_LIMIT);
     };
     let limit = raw_limit
@@ -371,6 +405,37 @@ fn parse_limit(params: &HashMap<String, String>) -> Result<i64, ApiError> {
     }
 
     Ok(limit)
+}
+
+fn parse_query_params(raw_query: Option<&str>) -> Vec<(String, String)> {
+    raw_query
+        .map(|query| {
+            form_urlencoded::parse(query.as_bytes())
+                .into_owned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn query_first<'a>(params: &'a [(String, String)], field: &str) -> Option<&'a str> {
+    params
+        .iter()
+        .find(|(name, _)| name == field)
+        .map(|(_, value)| value.as_str())
+}
+
+fn query_any(params: &[(String, String)], field: &str) -> bool {
+    query_first(params, field).is_some()
+}
+
+fn query_values<'a>(
+    params: &'a [(String, String)],
+    field: &'a str,
+) -> impl Iterator<Item = &'a str> {
+    params
+        .iter()
+        .filter(move |(name, _)| name == field)
+        .map(|(_, value)| value.as_str())
 }
 
 fn parse_time_cursor(
@@ -500,6 +565,29 @@ fn validation_error(field: &str, message: &str) -> ApiError {
             message: message.to_owned(),
         }]),
     )
+}
+
+fn validate_ulid_field(field: &str, value: &str) -> Result<(), ApiError> {
+    let parsed =
+        Ulid::from_string(value).map_err(|_| validation_error(field, "Must be a valid ULID."))?;
+    if parsed.to_string() != value {
+        return Err(validation_error(field, "Must be a valid ULID."));
+    }
+
+    Ok(())
+}
+
+fn validate_rfc3339_field(field: &str, value: &str) -> Result<(), ApiError> {
+    let parsed = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| validation_error(field, "Must be an RFC 3339 UTC timestamp."))?;
+    if parsed.offset() != UtcOffset::UTC {
+        return Err(validation_error(
+            field,
+            "Must be an RFC 3339 UTC timestamp.",
+        ));
+    }
+
+    Ok(())
 }
 
 fn malformed_cursor() -> ApiError {

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -95,6 +95,10 @@ pub async fn list_voice_notes(
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
     let params = parse_query_params(raw_query.as_deref());
     let page = parse_time_page_query(&params, CursorKind::VoiceNoteHistory)?;
+    if has_deferred_collection_filter(&params, CursorKind::VoiceNoteHistory) {
+        return Ok(empty_collection());
+    }
+
     let rows = state
         .storage
         .list_transcripts(
@@ -146,13 +150,13 @@ pub async fn list_voice_note_versions(
 ) -> Result<Json<CollectionEnvelope<VoiceNoteVersionResource>>, ApiError> {
     validate_ulid_field("voice_note_id", &voice_note_id)?;
     let params = parse_query_params(raw_query.as_deref());
+    let page = parse_time_page_query(&params, CursorKind::VoiceNoteVersions)?;
     ensure_voice_note_exists(
         &state,
         authenticated_key.api_key_id.as_str(),
         &voice_note_id,
     )
     .await?;
-    let page = parse_time_page_query(&params, CursorKind::VoiceNoteVersions)?;
     let mut rows = state
         .storage
         .list_transcript_versions(
@@ -196,13 +200,13 @@ pub async fn list_voice_note_segments(
 ) -> Result<Json<CollectionEnvelope<SegmentResource>>, ApiError> {
     validate_ulid_field("voice_note_id", &voice_note_id)?;
     let params = parse_query_params(raw_query.as_deref());
+    let page = parse_position_page_query(&params, CursorKind::VoiceNoteSegments)?;
     ensure_voice_note_exists(
         &state,
         authenticated_key.api_key_id.as_str(),
         &voice_note_id,
     )
     .await?;
-    let page = parse_position_page_query(&params, CursorKind::VoiceNoteSegments)?;
     let mut rows = state
         .storage
         .list_segments_page(
@@ -237,6 +241,7 @@ pub async fn list_session_voice_notes(
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
     validate_ulid_field("session_id", &session_id)?;
     let params = parse_query_params(raw_query.as_deref());
+    let page = parse_time_page_query(&params, CursorKind::SessionVoiceNoteHistory)?;
     if !state
         .storage
         .session_exists(authenticated_key.api_key_id.as_str(), &session_id)
@@ -246,7 +251,10 @@ pub async fn list_session_voice_notes(
         return Err(ApiError::not_found("Session not found."));
     }
 
-    let page = parse_time_page_query(&params, CursorKind::SessionVoiceNoteHistory)?;
+    if has_deferred_collection_filter(&params, CursorKind::SessionVoiceNoteHistory) {
+        return Ok(empty_collection());
+    }
+
     let rows = state
         .storage
         .list_session_transcripts(
@@ -321,6 +329,13 @@ async fn render_voice_note_page(
     Ok(Json(CollectionEnvelope { items, next_cursor }))
 }
 
+fn empty_collection<T>() -> Json<CollectionEnvelope<T>> {
+    Json(CollectionEnvelope {
+        items: Vec::new(),
+        next_cursor: None,
+    })
+}
+
 fn parse_time_page_query(
     params: &[(String, String)],
     cursor_kind: CursorKind,
@@ -391,6 +406,25 @@ fn validate_transitional_query(
     }
 
     Ok(())
+}
+
+fn has_deferred_collection_filter(params: &[(String, String)], cursor_kind: CursorKind) -> bool {
+    if !cursor_kind.is_voice_note_collection() {
+        return false;
+    }
+
+    query_any(params, "q")
+        || query_any(params, "search_mode")
+        || query_any(params, "tag_id")
+        || (cursor_kind == CursorKind::VoiceNoteHistory && query_any(params, "session_id"))
+        || [
+            "recorded_after",
+            "recorded_before",
+            "created_after",
+            "created_before",
+        ]
+        .into_iter()
+        .any(|field| query_any(params, field))
 }
 
 fn parse_limit(params: &[(String, String)]) -> Result<i64, ApiError> {

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -1,0 +1,522 @@
+use std::collections::HashMap;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use crate::auth::AuthenticatedKey;
+use crate::errors::{ApiError, CollectionEnvelope, ErrorDetail};
+use crate::state::AppState;
+use crate::storage::{SegmentRecord, TagRecord, TranscriptRecord, TranscriptVersionRecord};
+
+const DEFAULT_LIMIT: i64 = 50;
+const MAX_LIMIT: i64 = 100;
+const CURSOR_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CursorKind {
+    VoiceNoteHistory,
+    SessionVoiceNoteHistory,
+    VoiceNoteVersions,
+    VoiceNoteSegments,
+}
+
+#[derive(Debug, Clone)]
+struct PageQuery<T> {
+    limit: i64,
+    cursor: Option<T>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VoiceNoteResource {
+    id: String,
+    current_version_id: String,
+    text: String,
+    audio_duration_seconds: f64,
+    audio_format: String,
+    audio_size_bytes: i64,
+    language: Option<String>,
+    model: String,
+    processing_time_ms: i64,
+    cost_cents: Option<i64>,
+    created_at: String,
+    recorded_at: String,
+    session_id: Option<String>,
+    tags: Vec<TagResource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct VoiceNoteVersionResource {
+    id: String,
+    voice_note_id: String,
+    text: String,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SegmentResource {
+    id: String,
+    voice_note_id: String,
+    position: i64,
+    start_ms: i64,
+    end_ms: i64,
+    text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TagResource {
+    id: String,
+    name: String,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TimeCursor {
+    v: u8,
+    kind: String,
+    created_at: String,
+    id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PositionCursor {
+    v: u8,
+    kind: String,
+    position: i64,
+}
+
+pub async fn list_voice_notes(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
+    let page = parse_time_page_query(&params, CursorKind::VoiceNoteHistory)?;
+    let rows = state
+        .storage
+        .list_transcripts(
+            authenticated_key.api_key_id.as_str(),
+            page.cursor,
+            page.limit + 1,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to list voice notes."))?;
+
+    render_voice_note_page(
+        authenticated_key.api_key_id.as_str(),
+        &state,
+        rows,
+        page.limit,
+        CursorKind::VoiceNoteHistory,
+    )
+    .await
+}
+
+pub async fn get_voice_note(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(voice_note_id): Path<String>,
+) -> Result<Json<VoiceNoteResource>, ApiError> {
+    let Some(record) = state
+        .storage
+        .get_transcript(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load voice note."))?
+    else {
+        return Err(ApiError::not_found("Voice note not found."));
+    };
+    let tags = state
+        .storage
+        .list_transcript_tags(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
+
+    Ok(Json(voice_note_resource(record, tags)?))
+}
+
+pub async fn list_voice_note_versions(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(voice_note_id): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<CollectionEnvelope<VoiceNoteVersionResource>>, ApiError> {
+    ensure_voice_note_exists(
+        &state,
+        authenticated_key.api_key_id.as_str(),
+        &voice_note_id,
+    )
+    .await?;
+    let page = parse_time_page_query(&params, CursorKind::VoiceNoteVersions)?;
+    let mut rows = state
+        .storage
+        .list_transcript_versions(
+            authenticated_key.api_key_id.as_str(),
+            &voice_note_id,
+            page.cursor,
+            page.limit + 1,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to list voice note versions."))?;
+    let has_next = rows.len() as i64 > page.limit;
+    if has_next {
+        rows.truncate(page.limit as usize);
+    }
+    let next_cursor = if has_next {
+        rows.last()
+            .map(|version| {
+                time_cursor(
+                    CursorKind::VoiceNoteVersions,
+                    version.created_at,
+                    &version.id,
+                )
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let items = rows
+        .into_iter()
+        .map(voice_note_version_resource)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Json(CollectionEnvelope { items, next_cursor }))
+}
+
+pub async fn list_voice_note_segments(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(voice_note_id): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<CollectionEnvelope<SegmentResource>>, ApiError> {
+    ensure_voice_note_exists(
+        &state,
+        authenticated_key.api_key_id.as_str(),
+        &voice_note_id,
+    )
+    .await?;
+    let page = parse_position_page_query(&params, CursorKind::VoiceNoteSegments)?;
+    let mut rows = state
+        .storage
+        .list_segments_page(
+            authenticated_key.api_key_id.as_str(),
+            &voice_note_id,
+            page.cursor,
+            page.limit + 1,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to list voice note segments."))?;
+    let has_next = rows.len() as i64 > page.limit;
+    if has_next {
+        rows.truncate(page.limit as usize);
+    }
+    let next_cursor = if has_next {
+        rows.last()
+            .map(|segment| position_cursor(CursorKind::VoiceNoteSegments, segment.position))
+            .transpose()?
+    } else {
+        None
+    };
+    let items = rows.into_iter().map(segment_resource).collect::<Vec<_>>();
+
+    Ok(Json(CollectionEnvelope { items, next_cursor }))
+}
+
+pub async fn list_session_voice_notes(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
+    if !state
+        .storage
+        .session_exists(authenticated_key.api_key_id.as_str(), &session_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load session."))?
+    {
+        return Err(ApiError::not_found("Session not found."));
+    }
+
+    let page = parse_time_page_query(&params, CursorKind::SessionVoiceNoteHistory)?;
+    let rows = state
+        .storage
+        .list_session_transcripts(
+            authenticated_key.api_key_id.as_str(),
+            &session_id,
+            page.cursor,
+            page.limit + 1,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to list session voice notes."))?;
+
+    render_voice_note_page(
+        authenticated_key.api_key_id.as_str(),
+        &state,
+        rows,
+        page.limit,
+        CursorKind::SessionVoiceNoteHistory,
+    )
+    .await
+}
+
+async fn ensure_voice_note_exists(
+    state: &AppState,
+    api_key_id: &str,
+    voice_note_id: &str,
+) -> Result<(), ApiError> {
+    if state
+        .storage
+        .get_transcript(api_key_id, voice_note_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load voice note."))?
+        .is_none()
+    {
+        return Err(ApiError::not_found("Voice note not found."));
+    }
+
+    Ok(())
+}
+
+async fn render_voice_note_page(
+    api_key_id: &str,
+    state: &AppState,
+    mut rows: Vec<TranscriptRecord>,
+    limit: i64,
+    cursor_kind: CursorKind,
+) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
+    let has_next = rows.len() as i64 > limit;
+    if has_next {
+        rows.truncate(limit as usize);
+    }
+    let next_cursor = if has_next {
+        rows.last()
+            .map(|voice_note| time_cursor(cursor_kind, voice_note.created_at, &voice_note.id))
+            .transpose()?
+    } else {
+        None
+    };
+    let transcript_ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+    let mut tags_by_transcript = state
+        .storage
+        .list_tags_for_transcripts(api_key_id, &transcript_ids)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
+    let items = rows
+        .into_iter()
+        .map(|row| {
+            let tags = tags_by_transcript.remove(&row.id).unwrap_or_default();
+            voice_note_resource(row, tags)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Json(CollectionEnvelope { items, next_cursor }))
+}
+
+fn parse_time_page_query(
+    params: &HashMap<String, String>,
+    cursor_kind: CursorKind,
+) -> Result<PageQuery<(OffsetDateTime, String)>, ApiError> {
+    validate_transitional_query(params, cursor_kind)?;
+    Ok(PageQuery {
+        limit: parse_limit(params)?,
+        cursor: params
+            .get("cursor")
+            .map(|cursor| parse_time_cursor(cursor, cursor_kind))
+            .transpose()?,
+    })
+}
+
+fn parse_position_page_query(
+    params: &HashMap<String, String>,
+    cursor_kind: CursorKind,
+) -> Result<PageQuery<i64>, ApiError> {
+    validate_transitional_query(params, cursor_kind)?;
+    Ok(PageQuery {
+        limit: parse_limit(params)?,
+        cursor: params
+            .get("cursor")
+            .map(|cursor| parse_position_cursor(cursor, cursor_kind))
+            .transpose()?,
+    })
+}
+
+fn validate_transitional_query(
+    params: &HashMap<String, String>,
+    cursor_kind: CursorKind,
+) -> Result<(), ApiError> {
+    if cursor_kind.is_voice_note_collection()
+        && params.contains_key("search_mode")
+        && !params.contains_key("q")
+    {
+        return Err(validation_error(
+            "search_mode",
+            "Must be supplied only when q is present.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_limit(params: &HashMap<String, String>) -> Result<i64, ApiError> {
+    let Some(raw_limit) = params.get("limit") else {
+        return Ok(DEFAULT_LIMIT);
+    };
+    let limit = raw_limit
+        .parse::<i64>()
+        .map_err(|_| validation_error("limit", "Must be an integer in 1..100."))?;
+    if !(1..=MAX_LIMIT).contains(&limit) {
+        return Err(validation_error("limit", "Must be an integer in 1..100."));
+    }
+
+    Ok(limit)
+}
+
+fn parse_time_cursor(
+    cursor: &str,
+    expected_kind: CursorKind,
+) -> Result<(OffsetDateTime, String), ApiError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| malformed_cursor())?;
+    let decoded: TimeCursor = serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
+    if decoded.v != CURSOR_VERSION || decoded.kind != expected_kind.as_str() {
+        return Err(malformed_cursor());
+    }
+    let created_at =
+        OffsetDateTime::parse(&decoded.created_at, &Rfc3339).map_err(|_| malformed_cursor())?;
+    if decoded.id.is_empty() {
+        return Err(malformed_cursor());
+    }
+
+    Ok((created_at, decoded.id))
+}
+
+fn parse_position_cursor(cursor: &str, expected_kind: CursorKind) -> Result<i64, ApiError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| malformed_cursor())?;
+    let decoded: PositionCursor = serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
+    if decoded.v != CURSOR_VERSION || decoded.kind != expected_kind.as_str() || decoded.position < 0
+    {
+        return Err(malformed_cursor());
+    }
+
+    Ok(decoded.position)
+}
+
+fn time_cursor(kind: CursorKind, created_at: OffsetDateTime, id: &str) -> Result<String, ApiError> {
+    let cursor = TimeCursor {
+        v: CURSOR_VERSION,
+        kind: kind.as_str().to_owned(),
+        created_at: timestamp(created_at)?,
+        id: id.to_owned(),
+    };
+    encode_cursor(&cursor)
+}
+
+fn position_cursor(kind: CursorKind, position: i64) -> Result<String, ApiError> {
+    let cursor = PositionCursor {
+        v: CURSOR_VERSION,
+        kind: kind.as_str().to_owned(),
+        position,
+    };
+    encode_cursor(&cursor)
+}
+
+fn encode_cursor<T: Serialize>(cursor: &T) -> Result<String, ApiError> {
+    let bytes =
+        serde_json::to_vec(cursor).map_err(|_| ApiError::internal("Failed to encode cursor."))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn voice_note_resource(
+    record: TranscriptRecord,
+    tags: Vec<TagRecord>,
+) -> Result<VoiceNoteResource, ApiError> {
+    Ok(VoiceNoteResource {
+        id: record.id,
+        current_version_id: record.current_version_id,
+        text: record.transcript,
+        audio_duration_seconds: record.audio_duration_seconds,
+        audio_format: record.audio_format,
+        audio_size_bytes: record.audio_size_bytes,
+        language: record.transcript_language,
+        model: record.model,
+        processing_time_ms: record.processing_time_ms,
+        cost_cents: record.cost_cents,
+        created_at: timestamp(record.created_at)?,
+        recorded_at: timestamp(record.recorded_at)?,
+        session_id: record.session_id,
+        tags: tags
+            .into_iter()
+            .map(tag_resource)
+            .collect::<Result<Vec<_>, _>>()?,
+    })
+}
+
+fn voice_note_version_resource(
+    record: TranscriptVersionRecord,
+) -> Result<VoiceNoteVersionResource, ApiError> {
+    Ok(VoiceNoteVersionResource {
+        id: record.id,
+        voice_note_id: record.transcript_id,
+        text: record.transcript,
+        created_at: timestamp(record.created_at)?,
+    })
+}
+
+fn segment_resource(record: SegmentRecord) -> SegmentResource {
+    SegmentResource {
+        id: record.id,
+        voice_note_id: record.transcript_id,
+        position: record.position,
+        start_ms: record.start_ms,
+        end_ms: record.end_ms,
+        text: record.text,
+    }
+}
+
+fn tag_resource(record: TagRecord) -> Result<TagResource, ApiError> {
+    Ok(TagResource {
+        id: record.id,
+        name: record.name,
+        created_at: timestamp(record.created_at)?,
+    })
+}
+
+fn timestamp(value: OffsetDateTime) -> Result<String, ApiError> {
+    value
+        .format(&Rfc3339)
+        .map_err(|_| ApiError::internal("Failed to format timestamp."))
+}
+
+fn validation_error(field: &str, message: &str) -> ApiError {
+    ApiError::validation(
+        "One or more request fields are invalid.",
+        Some(vec![ErrorDetail {
+            field: field.to_owned(),
+            message: message.to_owned(),
+        }]),
+    )
+}
+
+fn malformed_cursor() -> ApiError {
+    validation_error("cursor", "Malformed cursor.")
+}
+
+impl CursorKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::VoiceNoteHistory => "voice_note_history",
+            Self::SessionVoiceNoteHistory => "session_voice_note_history",
+            Self::VoiceNoteVersions => "voice_note_versions",
+            Self::VoiceNoteSegments => "voice_note_segments",
+        }
+    }
+
+    fn is_voice_note_collection(self) -> bool {
+        matches!(self, Self::VoiceNoteHistory | Self::SessionVoiceNoteHistory)
+    }
+}

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -10,7 +10,9 @@ use ulid::Ulid;
 use crate::auth::AuthenticatedKey;
 use crate::errors::{ApiError, CollectionEnvelope, ErrorDetail};
 use crate::state::AppState;
-use crate::storage::{SegmentRecord, TagRecord, TranscriptRecord, TranscriptVersionRecord};
+use crate::storage::{
+    SegmentRecord, TagRecord, TranscriptFilters, TranscriptRecord, TranscriptVersionRecord,
+};
 
 const DEFAULT_LIMIT: i64 = 50;
 const MAX_LIMIT: i64 = 100;
@@ -28,6 +30,13 @@ enum CursorKind {
 struct PageQuery<T> {
     limit: i64,
     cursor: Option<T>,
+}
+
+#[derive(Debug, Clone)]
+struct VoiceNoteCollectionQuery {
+    page: PageQuery<(OffsetDateTime, String)>,
+    filters: TranscriptFilters,
+    search_requested: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -94,17 +103,18 @@ pub async fn list_voice_notes(
     RawQuery(raw_query): RawQuery,
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
     let params = parse_query_params(raw_query.as_deref());
-    let page = parse_time_page_query(&params, CursorKind::VoiceNoteHistory)?;
-    if has_deferred_collection_filter(&params, CursorKind::VoiceNoteHistory) {
-        return Ok(empty_collection());
+    let query = parse_voice_note_collection_query(&params, CursorKind::VoiceNoteHistory)?;
+    if query.search_requested {
+        return Ok(empty_voice_note_collection());
     }
 
     let rows = state
         .storage
         .list_transcripts(
             authenticated_key.api_key_id.as_str(),
-            page.cursor,
-            page.limit + 1,
+            &query.filters,
+            query.page.cursor,
+            query.page.limit + 1,
         )
         .await
         .map_err(|_| ApiError::internal("Failed to list voice notes."))?;
@@ -113,7 +123,7 @@ pub async fn list_voice_notes(
         authenticated_key.api_key_id.as_str(),
         &state,
         rows,
-        page.limit,
+        query.page.limit,
         CursorKind::VoiceNoteHistory,
     )
     .await
@@ -241,7 +251,7 @@ pub async fn list_session_voice_notes(
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
     validate_ulid_field("session_id", &session_id)?;
     let params = parse_query_params(raw_query.as_deref());
-    let page = parse_time_page_query(&params, CursorKind::SessionVoiceNoteHistory)?;
+    let query = parse_voice_note_collection_query(&params, CursorKind::SessionVoiceNoteHistory)?;
     if !state
         .storage
         .session_exists(authenticated_key.api_key_id.as_str(), &session_id)
@@ -251,8 +261,8 @@ pub async fn list_session_voice_notes(
         return Err(ApiError::not_found("Session not found."));
     }
 
-    if has_deferred_collection_filter(&params, CursorKind::SessionVoiceNoteHistory) {
-        return Ok(empty_collection());
+    if query.search_requested {
+        return Ok(empty_voice_note_collection());
     }
 
     let rows = state
@@ -260,8 +270,9 @@ pub async fn list_session_voice_notes(
         .list_session_transcripts(
             authenticated_key.api_key_id.as_str(),
             &session_id,
-            page.cursor,
-            page.limit + 1,
+            &query.filters,
+            query.page.cursor,
+            query.page.limit + 1,
         )
         .await
         .map_err(|_| ApiError::internal("Failed to list session voice notes."))?;
@@ -270,7 +281,7 @@ pub async fn list_session_voice_notes(
         authenticated_key.api_key_id.as_str(),
         &state,
         rows,
-        page.limit,
+        query.page.limit,
         CursorKind::SessionVoiceNoteHistory,
     )
     .await
@@ -329,10 +340,28 @@ async fn render_voice_note_page(
     Ok(Json(CollectionEnvelope { items, next_cursor }))
 }
 
-fn empty_collection<T>() -> Json<CollectionEnvelope<T>> {
+fn empty_voice_note_collection() -> Json<CollectionEnvelope<VoiceNoteResource>> {
     Json(CollectionEnvelope {
         items: Vec::new(),
         next_cursor: None,
+    })
+}
+
+fn parse_voice_note_collection_query(
+    params: &[(String, String)],
+    cursor_kind: CursorKind,
+) -> Result<VoiceNoteCollectionQuery, ApiError> {
+    validate_repeated_singular_query_params(params, cursor_kind)?;
+    validate_collection_query_values(params, cursor_kind)?;
+    Ok(VoiceNoteCollectionQuery {
+        page: PageQuery {
+            limit: parse_limit(params)?,
+            cursor: query_first(params, "cursor")
+                .map(|cursor| parse_time_cursor(cursor, cursor_kind))
+                .transpose()?,
+        },
+        filters: parse_transcript_filters(params, cursor_kind)?,
+        search_requested: query_any(params, "q"),
     })
 }
 
@@ -340,7 +369,8 @@ fn parse_time_page_query(
     params: &[(String, String)],
     cursor_kind: CursorKind,
 ) -> Result<PageQuery<(OffsetDateTime, String)>, ApiError> {
-    validate_transitional_query(params, cursor_kind)?;
+    validate_repeated_singular_query_params(params, cursor_kind)?;
+    validate_collection_query_values(params, cursor_kind)?;
     Ok(PageQuery {
         limit: parse_limit(params)?,
         cursor: query_first(params, "cursor")
@@ -353,7 +383,8 @@ fn parse_position_page_query(
     params: &[(String, String)],
     cursor_kind: CursorKind,
 ) -> Result<PageQuery<i64>, ApiError> {
-    validate_transitional_query(params, cursor_kind)?;
+    validate_repeated_singular_query_params(params, cursor_kind)?;
+    validate_collection_query_values(params, cursor_kind)?;
     Ok(PageQuery {
         limit: parse_limit(params)?,
         cursor: query_first(params, "cursor")
@@ -362,7 +393,41 @@ fn parse_position_page_query(
     })
 }
 
-fn validate_transitional_query(
+fn validate_repeated_singular_query_params(
+    params: &[(String, String)],
+    cursor_kind: CursorKind,
+) -> Result<(), ApiError> {
+    for field in ["cursor", "limit"] {
+        ensure_singular_query_param(params, field)?;
+    }
+    if cursor_kind.is_voice_note_collection() {
+        for field in [
+            "q",
+            "search_mode",
+            "recorded_after",
+            "recorded_before",
+            "created_after",
+            "created_before",
+        ] {
+            ensure_singular_query_param(params, field)?;
+        }
+        if cursor_kind == CursorKind::VoiceNoteHistory {
+            ensure_singular_query_param(params, "session_id")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_singular_query_param(params: &[(String, String)], field: &str) -> Result<(), ApiError> {
+    if query_values(params, field).nth(1).is_some() {
+        return Err(ApiError::repeated_singular_parameter(field));
+    }
+
+    Ok(())
+}
+
+fn validate_collection_query_values(
     params: &[(String, String)],
     cursor_kind: CursorKind,
 ) -> Result<(), ApiError> {
@@ -408,23 +473,35 @@ fn validate_transitional_query(
     Ok(())
 }
 
-fn has_deferred_collection_filter(params: &[(String, String)], cursor_kind: CursorKind) -> bool {
-    if !cursor_kind.is_voice_note_collection() {
-        return false;
+fn parse_transcript_filters(
+    params: &[(String, String)],
+    cursor_kind: CursorKind,
+) -> Result<TranscriptFilters, ApiError> {
+    let mut filters = TranscriptFilters::default();
+    for tag_id in query_values(params, "tag_id") {
+        let tag_id = tag_id.to_owned();
+        if !filters.tag_ids.contains(&tag_id) {
+            filters.tag_ids.push(tag_id);
+        }
     }
+    if cursor_kind == CursorKind::VoiceNoteHistory {
+        filters.session_id = query_first(params, "session_id").map(str::to_owned);
+    }
+    filters.recorded_after = parse_optional_rfc3339_filter(params, "recorded_after")?;
+    filters.recorded_before = parse_optional_rfc3339_filter(params, "recorded_before")?;
+    filters.created_after = parse_optional_rfc3339_filter(params, "created_after")?;
+    filters.created_before = parse_optional_rfc3339_filter(params, "created_before")?;
 
-    query_any(params, "q")
-        || query_any(params, "search_mode")
-        || query_any(params, "tag_id")
-        || (cursor_kind == CursorKind::VoiceNoteHistory && query_any(params, "session_id"))
-        || [
-            "recorded_after",
-            "recorded_before",
-            "created_after",
-            "created_before",
-        ]
-        .into_iter()
-        .any(|field| query_any(params, field))
+    Ok(filters)
+}
+
+fn parse_optional_rfc3339_filter(
+    params: &[(String, String)],
+    field: &str,
+) -> Result<Option<OffsetDateTime>, ApiError> {
+    query_first(params, field)
+        .map(|value| parse_rfc3339_field(field, value))
+        .transpose()
 }
 
 fn parse_limit(params: &[(String, String)]) -> Result<i64, ApiError> {
@@ -612,6 +689,10 @@ fn validate_ulid_field(field: &str, value: &str) -> Result<(), ApiError> {
 }
 
 fn validate_rfc3339_field(field: &str, value: &str) -> Result<(), ApiError> {
+    parse_rfc3339_field(field, value).map(|_| ())
+}
+
+fn parse_rfc3339_field(field: &str, value: &str) -> Result<OffsetDateTime, ApiError> {
     let parsed = OffsetDateTime::parse(value, &Rfc3339)
         .map_err(|_| validation_error(field, "Must be an RFC 3339 UTC timestamp."))?;
     if parsed.offset() != UtcOffset::UTC {
@@ -621,7 +702,7 @@ fn validate_rfc3339_field(field: &str, value: &str) -> Result<(), ApiError> {
         ));
     }
 
-    Ok(())
+    Ok(parsed)
 }
 
 fn malformed_cursor() -> ApiError {

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -370,7 +370,7 @@ async fn session_voice_note_history_requires_owned_session_and_lists_only_sessio
 }
 
 #[tokio::test]
-async fn collection_queries_accept_valid_deferred_parameters_and_ignore_unknown_parameters() {
+async fn root_collection_deferred_filters_return_empty_results_without_false_positives() {
     let fixture = VoiceNoteFixture::new().await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
@@ -385,13 +385,77 @@ async fn collection_queries_accept_valid_deferred_parameters_and_ignore_unknown_
         })
         .await;
 
-    let accepted = fixture
-        .get_json(
-            &format!("/api/v1/voice-notes?q=hello&search_mode=keyword&tag_id={TAG_MISSING}&tag_id={TAG_MEETING}&session_id={SESSION_MISSING}&recorded_after=2026-01-01T00%3A00%3A00Z&recorded_before=2026-01-02T00%3A00%3A00Z&created_after=2026-01-01T00%3A00%3A00Z&created_before=2026-01-02T00%3A00%3A00Z&unknown=value"),
-            "alpha-secret",
-        )
+    for path in [
+        "/api/v1/voice-notes?q=hello".to_owned(),
+        "/api/v1/voice-notes?q=hello&search_mode=keyword".to_owned(),
+        format!("/api/v1/voice-notes?tag_id={TAG_MEETING}"),
+        format!("/api/v1/voice-notes?tag_id={TAG_MISSING}&tag_id={TAG_MEETING}"),
+        format!("/api/v1/voice-notes?session_id={SESSION_MISSING}"),
+        "/api/v1/voice-notes?recorded_after=2026-01-01T00%3A00%3A00Z".to_owned(),
+        "/api/v1/voice-notes?recorded_before=2026-01-02T00%3A00%3A00Z".to_owned(),
+        "/api/v1/voice-notes?created_after=2026-01-01T00%3A00%3A00Z".to_owned(),
+        "/api/v1/voice-notes?created_before=2026-01-02T00%3A00%3A00Z".to_owned(),
+    ] {
+        assert_empty_collection(fixture.get_json(&path, "alpha-secret").await);
+    }
+}
+
+#[tokio::test]
+async fn root_collection_ignores_unknown_parameters_without_deferring_history() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "history result",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
         .await;
-    assert_eq!(accepted["items"][0]["id"], NOTE_OLD);
+
+    let body = fixture
+        .get_json("/api/v1/voice-notes?unknown=value", "alpha-secret")
+        .await;
+    assert_eq!(body["items"][0]["id"], NOTE_OLD);
+}
+
+#[tokio::test]
+async fn session_collection_deferred_filters_return_empty_results_for_owned_session() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture.insert_session("alpha", SESSION_A).await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_IN_SESSION,
+            version_id: VERSION_OLD,
+            text: "in session",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: Some(SESSION_A),
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
+
+    for path in [
+        format!("/api/v1/sessions/{SESSION_A}/voice-notes?q=hello"),
+        format!("/api/v1/sessions/{SESSION_A}/voice-notes?q=hello&search_mode=keyword"),
+        format!("/api/v1/sessions/{SESSION_A}/voice-notes?tag_id={TAG_MEETING}"),
+        format!("/api/v1/sessions/{SESSION_A}/voice-notes?recorded_after=2026-01-01T00%3A00%3A00Z"),
+        format!(
+            "/api/v1/sessions/{SESSION_A}/voice-notes?recorded_before=2026-01-02T00%3A00%3A00Z"
+        ),
+        format!("/api/v1/sessions/{SESSION_A}/voice-notes?created_after=2026-01-01T00%3A00%3A00Z"),
+        format!("/api/v1/sessions/{SESSION_A}/voice-notes?created_before=2026-01-02T00%3A00%3A00Z"),
+    ] {
+        assert_empty_collection(fixture.get_json(&path, "alpha-secret").await);
+    }
 }
 
 #[tokio::test]
@@ -465,7 +529,7 @@ async fn each_valid_search_mode_is_accepted_while_search_is_deferred() {
                 "alpha-secret",
             )
             .await;
-        assert_eq!(accepted["items"][0]["id"], NOTE_OLD);
+        assert_empty_collection(accepted);
     }
 }
 
@@ -511,6 +575,33 @@ async fn malformed_cursor_and_invalid_limit_return_validation_errors() {
         let response = fixture.get(path, "alpha-secret").await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert_eq!(json_body(response).await["error_code"], "validation_error");
+    }
+}
+
+#[tokio::test]
+async fn collection_query_validation_precedes_existence_checks() {
+    let fixture = VoiceNoteFixture::new().await;
+
+    for (path, field) in [
+        (
+            format!("/api/v1/sessions/{SESSION_MISSING}/voice-notes?limit=0"),
+            "limit",
+        ),
+        (
+            format!("/api/v1/sessions/{SESSION_MISSING}/voice-notes?recorded_after=not-a-time"),
+            "recorded_after",
+        ),
+        (
+            format!("/api/v1/voice-notes/{NOTE_MISSING}/versions?cursor=not-a-cursor"),
+            "cursor",
+        ),
+        (
+            format!("/api/v1/voice-notes/{NOTE_MISSING}/segments?limit=abc"),
+            "limit",
+        ),
+    ] {
+        let response = fixture.get(&path, "alpha-secret").await;
+        assert_validation_error(response, field).await;
     }
 }
 
@@ -771,4 +862,14 @@ async fn assert_validation_error(response: axum::response::Response, field: &str
     let body = json_body(response).await;
     assert_eq!(body["error_code"], "validation_error");
     assert_eq!(body["details"][0]["field"], field);
+}
+
+fn assert_empty_collection(body: Value) {
+    assert_eq!(
+        body,
+        json!({
+            "items": [],
+            "next_cursor": null
+        })
+    );
 }

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -26,6 +26,7 @@ const SEGMENT_FIRST: &str = "01JS9P1K2AQ3B4C5D6E7F8G9H0";
 const SEGMENT_SECOND: &str = "01JS9P1K2AQ3B4C5D6E7F8G9H1";
 const TAG_MEETING: &str = "01JS9P0Q0THR2X3E4A5B6C7D8E";
 const TAG_MISSING: &str = "01JS9P0Q0THR2X3E4A5B6C7D8F";
+const TAG_ACTION: &str = "01JS9P0Q0THR2X3E4A5B6C7D8G";
 const SESSION_A: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X1";
 const SESSION_BETA: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X2";
 const SESSION_MISSING: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X3";
@@ -370,34 +371,164 @@ async fn session_voice_note_history_requires_owned_session_and_lists_only_sessio
 }
 
 #[tokio::test]
-async fn root_collection_deferred_filters_return_empty_results_without_false_positives() {
+async fn root_collection_filters_compose_by_tag_session_time_and_cursor() {
     let fixture = VoiceNoteFixture::new().await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
             id: NOTE_OLD,
             version_id: VERSION_OLD,
-            text: "history result",
+            text: "older tagged session note",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: Some(SESSION_A),
+            tags: vec![
+                TagSeed {
+                    id: TAG_MEETING,
+                    name: "Meeting",
+                    created_at: "2026-04-24T18:01:30.000000000Z",
+                },
+                TagSeed {
+                    id: TAG_ACTION,
+                    name: "Action",
+                    created_at: "2026-04-24T18:01:40.000000000Z",
+                },
+            ],
+        })
+        .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_NEW,
+            version_id: VERSION_NEW,
+            text: "newer meeting note",
+            created_at: "2026-04-24T18:01:00.000000000Z",
+            recorded_at: "2026-04-24T18:00:00.000000000Z",
+            session_id: Some(SESSION_BETA),
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OUTSIDE_SESSION,
+            version_id: NOTE_OUTSIDE_SESSION,
+            text: "newest action note",
+            created_at: "2026-04-24T18:02:00.000000000Z",
+            recorded_at: "2026-04-24T18:01:00.000000000Z",
             session_id: None,
-            tags: vec![],
+            tags: vec![TagSeed {
+                id: TAG_ACTION,
+                name: "Action",
+                created_at: "2026-04-24T18:01:40.000000000Z",
+            }],
         })
         .await;
 
-    for path in [
-        "/api/v1/voice-notes?q=hello".to_owned(),
-        "/api/v1/voice-notes?q=hello&search_mode=keyword".to_owned(),
-        format!("/api/v1/voice-notes?tag_id={TAG_MEETING}"),
-        format!("/api/v1/voice-notes?tag_id={TAG_MISSING}&tag_id={TAG_MEETING}"),
-        format!("/api/v1/voice-notes?session_id={SESSION_MISSING}"),
-        "/api/v1/voice-notes?recorded_after=2026-01-01T00%3A00%3A00Z".to_owned(),
-        "/api/v1/voice-notes?recorded_before=2026-01-02T00%3A00%3A00Z".to_owned(),
-        "/api/v1/voice-notes?created_after=2026-01-01T00%3A00%3A00Z".to_owned(),
-        "/api/v1/voice-notes?created_before=2026-01-02T00%3A00%3A00Z".to_owned(),
-    ] {
-        assert_empty_collection(fixture.get_json(&path, "alpha-secret").await);
-    }
+    assert_collection_ids(
+        fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?tag_id={TAG_MEETING}"),
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_NEW, NOTE_OLD],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?tag_id={TAG_MEETING}&tag_id={TAG_ACTION}"),
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_OLD],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?session_id={SESSION_A}"),
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_OLD],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?recorded_after=2026-04-24T18%3A00%3A00Z",
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_OUTSIDE_SESSION],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?recorded_before=2026-04-24T18%3A00%3A00Z",
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_NEW, NOTE_OLD],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?created_after=2026-04-24T18%3A00%3A00Z",
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_OUTSIDE_SESSION, NOTE_NEW],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?created_before=2026-04-24T18%3A01%3A00Z",
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_NEW, NOTE_OLD],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?created_after=2026-04-24T18%3A00%3A00Z&created_before=2026-04-24T18%3A01%3A00Z",
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_NEW],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                &format!(
+                    "/api/v1/voice-notes?tag_id={TAG_ACTION}&recorded_before=2026-04-24T18%3A00%3A00Z"
+                ),
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_OLD],
+    );
+
+    let first = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes?tag_id={TAG_MEETING}&limit=1"),
+            "alpha-secret",
+        )
+        .await;
+    assert_collection_ids(first.clone(), &[NOTE_NEW]);
+    let cursor = first["next_cursor"].as_str().expect("next cursor");
+    let second = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes?tag_id={TAG_MEETING}&limit=1&cursor={cursor}"),
+            "alpha-secret",
+        )
+        .await;
+    assert_collection_ids(second.clone(), &[NOTE_OLD]);
+    assert_eq!(second["next_cursor"], Value::Null);
 }
 
 #[tokio::test]
@@ -423,7 +554,57 @@ async fn root_collection_ignores_unknown_parameters_without_deferring_history() 
 }
 
 #[tokio::test]
-async fn session_collection_deferred_filters_return_empty_results_for_owned_session() {
+async fn tag_filters_match_only_owned_existing_tags() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "alpha note",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "beta",
+            id: NOTE_OTHER_OWNER,
+            version_id: NOTE_OTHER_OWNER,
+            text: "beta tagged note",
+            created_at: "2026-04-24T18:01:00.000000000Z",
+            recorded_at: "2026-04-24T18:00:00.000000000Z",
+            session_id: None,
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
+
+    assert_empty_collection(
+        fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?tag_id={TAG_MEETING}"),
+                "alpha-secret",
+            )
+            .await,
+    );
+    assert_empty_collection(
+        fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?tag_id={TAG_MISSING}"),
+                "alpha-secret",
+            )
+            .await,
+    );
+}
+
+#[tokio::test]
+async fn session_collection_filters_apply_inside_path_session() {
     let fixture = VoiceNoteFixture::new().await;
     fixture.insert_session("alpha", SESSION_A).await;
     fixture
@@ -442,24 +623,47 @@ async fn session_collection_deferred_filters_return_empty_results_for_owned_sess
             }],
         })
         .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OUTSIDE_SESSION,
+            version_id: VERSION_NEW,
+            text: "outside session",
+            created_at: "2026-04-24T18:01:00.000000000Z",
+            recorded_at: "2026-04-24T18:00:00.000000000Z",
+            session_id: None,
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
 
-    for path in [
-        format!("/api/v1/sessions/{SESSION_A}/voice-notes?q=hello"),
-        format!("/api/v1/sessions/{SESSION_A}/voice-notes?q=hello&search_mode=keyword"),
-        format!("/api/v1/sessions/{SESSION_A}/voice-notes?tag_id={TAG_MEETING}"),
-        format!("/api/v1/sessions/{SESSION_A}/voice-notes?recorded_after=2026-01-01T00%3A00%3A00Z"),
-        format!(
-            "/api/v1/sessions/{SESSION_A}/voice-notes?recorded_before=2026-01-02T00%3A00%3A00Z"
-        ),
-        format!("/api/v1/sessions/{SESSION_A}/voice-notes?created_after=2026-01-01T00%3A00%3A00Z"),
-        format!("/api/v1/sessions/{SESSION_A}/voice-notes?created_before=2026-01-02T00%3A00%3A00Z"),
-    ] {
-        assert_empty_collection(fixture.get_json(&path, "alpha-secret").await);
-    }
+    assert_collection_ids(
+        fixture
+            .get_json(
+                &format!("/api/v1/sessions/{SESSION_A}/voice-notes?tag_id={TAG_MEETING}"),
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_IN_SESSION],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                &format!(
+                    "/api/v1/sessions/{SESSION_A}/voice-notes?recorded_after=2026-04-24T17%3A58%3A00Z&created_before=2026-04-24T18%3A00%3A00Z"
+                ),
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_IN_SESSION],
+    );
 }
 
 #[tokio::test]
-async fn invalid_deferred_collection_query_values_return_validation_errors() {
+async fn invalid_collection_query_values_return_validation_errors() {
     let fixture = VoiceNoteFixture::new().await;
 
     for (path, field) in [
@@ -518,9 +722,27 @@ async fn each_valid_search_mode_is_accepted_while_search_is_deferred() {
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
             session_id: None,
-            tags: vec![],
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
         })
         .await;
+
+    assert_empty_collection(
+        fixture
+            .get_json("/api/v1/voice-notes?q=hello", "alpha-secret")
+            .await,
+    );
+    assert_empty_collection(
+        fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?q=hello&tag_id={TAG_MEETING}"),
+                "alpha-secret",
+            )
+            .await,
+    );
 
     for mode in ["keyword", "semantic", "hybrid"] {
         let accepted = fixture
@@ -531,6 +753,52 @@ async fn each_valid_search_mode_is_accepted_while_search_is_deferred() {
             .await;
         assert_empty_collection(accepted);
     }
+}
+
+#[tokio::test]
+async fn repeated_singular_query_parameters_return_repeated_parameter_errors() {
+    let fixture = VoiceNoteFixture::new().await;
+
+    for (path, field) in [
+        ("/api/v1/voice-notes?cursor=a&cursor=b", "cursor"),
+        ("/api/v1/voice-notes?limit=1&limit=2", "limit"),
+        ("/api/v1/voice-notes?q=hello&q=again", "q"),
+        (
+            "/api/v1/voice-notes?q=hello&search_mode=keyword&search_mode=hybrid",
+            "search_mode",
+        ),
+        (
+            &format!("/api/v1/voice-notes?session_id={SESSION_A}&session_id={SESSION_BETA}"),
+            "session_id",
+        ),
+        (
+            "/api/v1/voice-notes?recorded_after=2026-04-24T18%3A00%3A00Z&recorded_after=2026-04-24T18%3A01%3A00Z",
+            "recorded_after",
+        ),
+        (
+            "/api/v1/voice-notes?recorded_before=2026-04-24T18%3A00%3A00Z&recorded_before=2026-04-24T18%3A01%3A00Z",
+            "recorded_before",
+        ),
+        (
+            "/api/v1/voice-notes?created_after=2026-04-24T18%3A00%3A00Z&created_after=2026-04-24T18%3A01%3A00Z",
+            "created_after",
+        ),
+        (
+            "/api/v1/voice-notes?created_before=2026-04-24T18%3A00%3A00Z&created_before=2026-04-24T18%3A01%3A00Z",
+            "created_before",
+        ),
+    ] {
+        let response = fixture.get(path, "alpha-secret").await;
+        assert_repeated_singular_parameter_error(response, field).await;
+    }
+
+    let ignored = fixture
+        .get(
+            &format!("/api/v1/sessions/{SESSION_A}/voice-notes?session_id={SESSION_A}&session_id={SESSION_BETA}"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(ignored.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -864,6 +1132,13 @@ async fn assert_validation_error(response: axum::response::Response, field: &str
     assert_eq!(body["details"][0]["field"], field);
 }
 
+async fn assert_repeated_singular_parameter_error(response: axum::response::Response, field: &str) {
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = json_body(response).await;
+    assert_eq!(body["error_code"], "repeated_singular_parameter");
+    assert_eq!(body["details"][0]["field"], field);
+}
+
 fn assert_empty_collection(body: Value) {
     assert_eq!(
         body,
@@ -871,5 +1146,17 @@ fn assert_empty_collection(body: Value) {
             "items": [],
             "next_cursor": null
         })
+    );
+}
+
+fn assert_collection_ids(body: Value, expected_ids: &[&str]) {
+    assert_eq!(
+        body["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .map(|item| item["id"].as_str().expect("id"))
+            .collect::<Vec<_>>(),
+        expected_ids
     );
 }

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -11,14 +11,34 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 use tower::util::ServiceExt;
 
+const NOTE_OLD: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5R";
+const NOTE_NEW: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5S";
+const NOTE_OTHER_OWNER: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5T";
+const NOTE_PAGE_A: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5A";
+const NOTE_PAGE_B: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5B";
+const NOTE_PAGE_C: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5C";
+const NOTE_IN_SESSION: &str = "01JS8D6E2S3T1J7H9J2Q2N4P60";
+const NOTE_OUTSIDE_SESSION: &str = "01JS8D6E2S3T1J7H9J2Q2N4P61";
+const NOTE_MISSING: &str = "01JS8D6E2S3T1J7H9J2Q2N4P62";
+const VERSION_OLD: &str = "01JS9P1D6CK9M0N1P2Q3R4S5T6";
+const VERSION_NEW: &str = "01JS9P1D6CK9M0N1P2Q3R4S5T7";
+const SEGMENT_FIRST: &str = "01JS9P1K2AQ3B4C5D6E7F8G9H0";
+const SEGMENT_SECOND: &str = "01JS9P1K2AQ3B4C5D6E7F8G9H1";
+const TAG_MEETING: &str = "01JS9P0Q0THR2X3E4A5B6C7D8E";
+const TAG_MISSING: &str = "01JS9P0Q0THR2X3E4A5B6C7D8F";
+const SESSION_A: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X1";
+const SESSION_BETA: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X2";
+const SESSION_MISSING: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X3";
+const JOB_ALPHA: &str = "01JS8D6E2S3T1J7H9J2Q2N4P63";
+
 #[tokio::test]
 async fn voice_note_history_returns_owner_scoped_notes_newest_first() {
     let fixture = VoiceNoteFixture::new().await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
-            id: "note-old",
-            version_id: "version-old",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
             text: "older note",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
@@ -29,14 +49,14 @@ async fn voice_note_history_returns_owner_scoped_notes_newest_first() {
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
-            id: "note-new",
-            version_id: "version-new",
+            id: NOTE_NEW,
+            version_id: VERSION_NEW,
             text: "newer note",
             created_at: "2026-04-24T18:01:00.000000000Z",
             recorded_at: "2026-04-24T18:00:30.000000000Z",
             session_id: None,
             tags: vec![TagSeed {
-                id: "tag-meeting",
+                id: TAG_MEETING,
                 name: "Meeting",
                 created_at: "2026-04-24T18:01:30.000000000Z",
             }],
@@ -45,8 +65,8 @@ async fn voice_note_history_returns_owner_scoped_notes_newest_first() {
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "beta",
-            id: "note-other-owner",
-            version_id: "version-other-owner",
+            id: NOTE_OTHER_OWNER,
+            version_id: NOTE_OTHER_OWNER,
             text: "hidden note",
             created_at: "2026-04-24T18:02:00.000000000Z",
             recorded_at: "2026-04-24T18:01:30.000000000Z",
@@ -73,8 +93,8 @@ async fn voice_note_history_returns_owner_scoped_notes_newest_first() {
         json!({
             "items": [
                 {
-                    "id": "note-new",
-                    "current_version_id": "version-new",
+                    "id": NOTE_NEW,
+                    "current_version_id": VERSION_NEW,
                     "text": "newer note",
                     "audio_duration_seconds": 12.5,
                     "audio_format": "wav",
@@ -88,15 +108,15 @@ async fn voice_note_history_returns_owner_scoped_notes_newest_first() {
                     "session_id": null,
                     "tags": [
                         {
-                            "id": "tag-meeting",
+                            "id": TAG_MEETING,
                             "name": "Meeting",
                             "created_at": "2026-04-24T18:01:30Z"
                         }
                     ]
                 },
                 {
-                    "id": "note-old",
-                    "current_version_id": "version-old",
+                    "id": NOTE_OLD,
+                    "current_version_id": VERSION_OLD,
                     "text": "older note",
                     "audio_duration_seconds": 12.5,
                     "audio_format": "wav",
@@ -119,12 +139,12 @@ async fn voice_note_history_returns_owner_scoped_notes_newest_first() {
 #[tokio::test]
 async fn voice_note_history_paginates_with_descending_id_tiebreaker() {
     let fixture = VoiceNoteFixture::new().await;
-    for id in ["note-a", "note-c", "note-b"] {
+    for id in [NOTE_PAGE_A, NOTE_PAGE_C, NOTE_PAGE_B] {
         fixture
             .insert_voice_note(VoiceNoteSeed {
                 owner: "alpha",
                 id,
-                version_id: &format!("{id}-version"),
+                version_id: id,
                 text: id,
                 created_at: "2026-04-24T18:00:00.000000000Z",
                 recorded_at: "2026-04-24T17:59:00.000000000Z",
@@ -144,7 +164,7 @@ async fn voice_note_history_paginates_with_descending_id_tiebreaker() {
             .iter()
             .map(|item| item["id"].as_str().expect("id"))
             .collect::<Vec<_>>(),
-        vec!["note-c", "note-b"]
+        vec![NOTE_PAGE_C, NOTE_PAGE_B]
     );
     let cursor = first["next_cursor"].as_str().expect("next cursor");
 
@@ -161,7 +181,7 @@ async fn voice_note_history_paginates_with_descending_id_tiebreaker() {
             .iter()
             .map(|item| item["id"].as_str().expect("id"))
             .collect::<Vec<_>>(),
-        vec!["note-a"]
+        vec![NOTE_PAGE_A]
     );
     assert_eq!(second["next_cursor"], Value::Null);
 }
@@ -172,8 +192,8 @@ async fn voice_note_detail_returns_not_found_for_missing_other_owner_and_job_ids
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "beta",
-            id: "note-beta",
-            version_id: "version-beta",
+            id: NOTE_OTHER_OWNER,
+            version_id: VERSION_OLD,
             text: "other owner",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
@@ -181,14 +201,15 @@ async fn voice_note_detail_returns_not_found_for_missing_other_owner_and_job_ids
             tags: vec![],
         })
         .await;
-    fixture.insert_job("alpha", "job-alpha").await;
+    fixture.insert_job("alpha", JOB_ALPHA).await;
 
-    for path in [
-        "/api/v1/voice-notes/note-missing",
-        "/api/v1/voice-notes/note-beta",
-        "/api/v1/voice-notes/job-alpha",
-    ] {
-        let response = fixture.get(path, "alpha-secret").await;
+    for voice_note_id in [NOTE_MISSING, NOTE_OTHER_OWNER, JOB_ALPHA] {
+        let response = fixture
+            .get(
+                &format!("/api/v1/voice-notes/{voice_note_id}"),
+                "alpha-secret",
+            )
+            .await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert_eq!(json_body(response).await["error_code"], "not_found");
     }
@@ -200,8 +221,8 @@ async fn version_history_returns_versions_newest_first_in_shared_envelope() {
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
-            id: "note-a",
-            version_id: "version-1",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
             text: "initial text",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
@@ -212,8 +233,8 @@ async fn version_history_returns_versions_newest_first_in_shared_envelope() {
     fixture
         .insert_version(
             "alpha",
-            "note-a",
-            "version-2",
+            NOTE_OLD,
+            VERSION_NEW,
             2,
             "edited text",
             "2026-04-24T18:01:00.000000000Z",
@@ -221,7 +242,10 @@ async fn version_history_returns_versions_newest_first_in_shared_envelope() {
         .await;
 
     let body = fixture
-        .get_json("/api/v1/voice-notes/note-a/versions", "alpha-secret")
+        .get_json(
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/versions"),
+            "alpha-secret",
+        )
         .await;
 
     assert_eq!(
@@ -229,14 +253,14 @@ async fn version_history_returns_versions_newest_first_in_shared_envelope() {
         json!({
             "items": [
                 {
-                    "id": "version-2",
-                    "voice_note_id": "note-a",
+                    "id": VERSION_NEW,
+                    "voice_note_id": NOTE_OLD,
                     "text": "edited text",
                     "created_at": "2026-04-24T18:01:00Z"
                 },
                 {
-                    "id": "version-1",
-                    "voice_note_id": "note-a",
+                    "id": VERSION_OLD,
+                    "voice_note_id": NOTE_OLD,
                     "text": "initial text",
                     "created_at": "2026-04-24T18:00:00Z"
                 }
@@ -252,8 +276,8 @@ async fn segments_return_in_position_order_with_pagination() {
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
-            id: "note-a",
-            version_id: "version-1",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
             text: "initial text",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
@@ -262,53 +286,53 @@ async fn segments_return_in_position_order_with_pagination() {
         })
         .await;
     fixture
-        .insert_segment("alpha", "note-a", "segment-2", 1, "second")
+        .insert_segment("alpha", NOTE_OLD, SEGMENT_SECOND, 1, "second")
         .await;
     fixture
-        .insert_segment("alpha", "note-a", "segment-1", 0, "first")
+        .insert_segment("alpha", NOTE_OLD, SEGMENT_FIRST, 0, "first")
         .await;
 
     let first = fixture
         .get_json(
-            "/api/v1/voice-notes/note-a/segments?limit=1",
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/segments?limit=1"),
             "alpha-secret",
         )
         .await;
-    assert_eq!(first["items"][0]["id"], "segment-1");
+    assert_eq!(first["items"][0]["id"], SEGMENT_FIRST);
     let cursor = first["next_cursor"].as_str().expect("next cursor");
 
     let second = fixture
         .get_json(
-            &format!("/api/v1/voice-notes/note-a/segments?limit=1&cursor={cursor}"),
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/segments?limit=1&cursor={cursor}"),
             "alpha-secret",
         )
         .await;
-    assert_eq!(second["items"][0]["id"], "segment-2");
+    assert_eq!(second["items"][0]["id"], SEGMENT_SECOND);
     assert_eq!(second["next_cursor"], Value::Null);
 }
 
 #[tokio::test]
 async fn session_voice_note_history_requires_owned_session_and_lists_only_session_notes() {
     let fixture = VoiceNoteFixture::new().await;
-    fixture.insert_session("alpha", "session-a").await;
-    fixture.insert_session("beta", "session-beta").await;
+    fixture.insert_session("alpha", SESSION_A).await;
+    fixture.insert_session("beta", SESSION_BETA).await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
-            id: "note-in-session",
-            version_id: "version-in-session",
+            id: NOTE_IN_SESSION,
+            version_id: VERSION_OLD,
             text: "in session",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
-            session_id: Some("session-a"),
+            session_id: Some(SESSION_A),
             tags: vec![],
         })
         .await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
-            id: "note-outside-session",
-            version_id: "version-outside-session",
+            id: NOTE_OUTSIDE_SESSION,
+            version_id: VERSION_NEW,
             text: "outside session",
             created_at: "2026-04-24T18:01:00.000000000Z",
             recorded_at: "2026-04-24T18:00:30.000000000Z",
@@ -318,29 +342,41 @@ async fn session_voice_note_history_requires_owned_session_and_lists_only_sessio
         .await;
 
     let body = fixture
-        .get_json("/api/v1/sessions/session-a/voice-notes", "alpha-secret")
+        .get_json(
+            &format!("/api/v1/sessions/{SESSION_A}/voice-notes"),
+            "alpha-secret",
+        )
         .await;
-    assert_eq!(body["items"][0]["id"], "note-in-session");
+    assert_eq!(body["items"][0]["id"], NOTE_IN_SESSION);
     assert_eq!(body["items"].as_array().expect("items").len(), 1);
 
-    for path in [
-        "/api/v1/sessions/session-missing/voice-notes",
-        "/api/v1/sessions/session-beta/voice-notes",
-    ] {
-        let response = fixture.get(path, "alpha-secret").await;
+    let body = fixture
+        .get_json(
+            &format!("/api/v1/sessions/{SESSION_A}/voice-notes?session_id=not-a-ulid"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(body["items"][0]["id"], NOTE_IN_SESSION);
+
+    for session_id in [SESSION_MISSING, SESSION_BETA] {
+        let response = fixture
+            .get(
+                &format!("/api/v1/sessions/{session_id}/voice-notes"),
+                "alpha-secret",
+            )
+            .await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }
 
 #[tokio::test]
-async fn collection_queries_accept_deferred_and_unknown_parameters_but_reject_search_mode_without_q()
- {
+async fn collection_queries_accept_valid_deferred_parameters_and_ignore_unknown_parameters() {
     let fixture = VoiceNoteFixture::new().await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
-            id: "note-a",
-            version_id: "version-a",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
             text: "history result",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
@@ -351,17 +387,115 @@ async fn collection_queries_accept_deferred_and_unknown_parameters_but_reject_se
 
     let accepted = fixture
         .get_json(
-            "/api/v1/voice-notes?q=hello&search_mode=keyword&tag_id=tag-missing&session_id=session-missing&recorded_after=2026-01-01T00%3A00%3A00Z&unknown=value",
+            &format!("/api/v1/voice-notes?q=hello&search_mode=keyword&tag_id={TAG_MISSING}&tag_id={TAG_MEETING}&session_id={SESSION_MISSING}&recorded_after=2026-01-01T00%3A00%3A00Z&recorded_before=2026-01-02T00%3A00%3A00Z&created_after=2026-01-01T00%3A00%3A00Z&created_before=2026-01-02T00%3A00%3A00Z&unknown=value"),
             "alpha-secret",
         )
         .await;
-    assert_eq!(accepted["items"][0]["id"], "note-a");
+    assert_eq!(accepted["items"][0]["id"], NOTE_OLD);
+}
 
-    let rejected = fixture
-        .get("/api/v1/voice-notes?search_mode=keyword", "alpha-secret")
+#[tokio::test]
+async fn invalid_deferred_collection_query_values_return_validation_errors() {
+    let fixture = VoiceNoteFixture::new().await;
+
+    for (path, field) in [
+        (
+            "/api/v1/voice-notes?q=hello&search_mode=typo".to_owned(),
+            "search_mode",
+        ),
+        ("/api/v1/voice-notes?tag_id=not-a-ulid".to_owned(), "tag_id"),
+        (
+            format!("/api/v1/voice-notes?tag_id={TAG_MISSING}&tag_id=not-a-ulid"),
+            "tag_id",
+        ),
+        (
+            "/api/v1/voice-notes?session_id=not-a-ulid".to_owned(),
+            "session_id",
+        ),
+        (
+            "/api/v1/voice-notes?recorded_after=not-a-time".to_owned(),
+            "recorded_after",
+        ),
+        (
+            "/api/v1/voice-notes?recorded_after=2026-01-01T00%3A00%3A00%2B01%3A00".to_owned(),
+            "recorded_after",
+        ),
+        (
+            "/api/v1/voice-notes?recorded_before=not-a-time".to_owned(),
+            "recorded_before",
+        ),
+        (
+            "/api/v1/voice-notes?created_after=not-a-time".to_owned(),
+            "created_after",
+        ),
+        (
+            "/api/v1/voice-notes?created_before=not-a-time".to_owned(),
+            "created_before",
+        ),
+        (
+            "/api/v1/voice-notes?search_mode=keyword".to_owned(),
+            "search_mode",
+        ),
+    ] {
+        let response = fixture.get(&path, "alpha-secret").await;
+        assert_validation_error(response, field).await;
+    }
+}
+
+#[tokio::test]
+async fn each_valid_search_mode_is_accepted_while_search_is_deferred() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "history result",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
         .await;
-    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
-    assert_eq!(json_body(rejected).await["error_code"], "validation_error");
+
+    for mode in ["keyword", "semantic", "hybrid"] {
+        let accepted = fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?q=hello&search_mode={mode}"),
+                "alpha-secret",
+            )
+            .await;
+        assert_eq!(accepted["items"][0]["id"], NOTE_OLD);
+    }
+}
+
+#[tokio::test]
+async fn malformed_path_ids_return_validation_errors_before_existence_checks() {
+    let fixture = VoiceNoteFixture::new().await;
+    let lowercase_ulid = NOTE_MISSING.to_ascii_lowercase();
+
+    for (path, field) in [
+        ("/api/v1/voice-notes/not-a-ulid".to_owned(), "voice_note_id"),
+        (
+            format!("/api/v1/voice-notes/{lowercase_ulid}"),
+            "voice_note_id",
+        ),
+        (
+            "/api/v1/voice-notes/not-a-ulid/versions".to_owned(),
+            "voice_note_id",
+        ),
+        (
+            "/api/v1/voice-notes/not-a-ulid/segments".to_owned(),
+            "voice_note_id",
+        ),
+        (
+            "/api/v1/sessions/not-a-ulid/voice-notes".to_owned(),
+            "session_id",
+        ),
+    ] {
+        let response = fixture.get(&path, "alpha-secret").await;
+        assert_validation_error(response, field).await;
+    }
 }
 
 #[tokio::test]
@@ -630,4 +764,11 @@ async fn json_body(response: axum::response::Response) -> Value {
         .await
         .expect("read body");
     serde_json::from_slice(&bytes).expect("valid json")
+}
+
+async fn assert_validation_error(response: axum::response::Response, field: &str) {
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = json_body(response).await;
+    assert_eq!(body["error_code"], "validation_error");
+    assert_eq!(body["details"][0]["field"], field);
 }

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -1,0 +1,633 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use oracy_backend::auth::AuthStore;
+use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::router::build_router;
+use oracy_backend::state::AppState;
+use oracy_backend::storage::Storage;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+#[tokio::test]
+async fn voice_note_history_returns_owner_scoped_notes_newest_first() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: "note-old",
+            version_id: "version-old",
+            text: "older note",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: "note-new",
+            version_id: "version-new",
+            text: "newer note",
+            created_at: "2026-04-24T18:01:00.000000000Z",
+            recorded_at: "2026-04-24T18:00:30.000000000Z",
+            session_id: None,
+            tags: vec![TagSeed {
+                id: "tag-meeting",
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "beta",
+            id: "note-other-owner",
+            version_id: "version-other-owner",
+            text: "hidden note",
+            created_at: "2026-04-24T18:02:00.000000000Z",
+            recorded_at: "2026-04-24T18:01:30.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    let response = fixture
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/voice-notes")
+                .header("Authorization", "Bearer alpha-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        json_body(response).await,
+        json!({
+            "items": [
+                {
+                    "id": "note-new",
+                    "current_version_id": "version-new",
+                    "text": "newer note",
+                    "audio_duration_seconds": 12.5,
+                    "audio_format": "wav",
+                    "audio_size_bytes": 401280,
+                    "language": "en",
+                    "model": "gpt-4o-mini-transcribe",
+                    "processing_time_ms": 1843,
+                    "cost_cents": null,
+                    "created_at": "2026-04-24T18:01:00Z",
+                    "recorded_at": "2026-04-24T18:00:30Z",
+                    "session_id": null,
+                    "tags": [
+                        {
+                            "id": "tag-meeting",
+                            "name": "Meeting",
+                            "created_at": "2026-04-24T18:01:30Z"
+                        }
+                    ]
+                },
+                {
+                    "id": "note-old",
+                    "current_version_id": "version-old",
+                    "text": "older note",
+                    "audio_duration_seconds": 12.5,
+                    "audio_format": "wav",
+                    "audio_size_bytes": 401280,
+                    "language": "en",
+                    "model": "gpt-4o-mini-transcribe",
+                    "processing_time_ms": 1843,
+                    "cost_cents": null,
+                    "created_at": "2026-04-24T18:00:00Z",
+                    "recorded_at": "2026-04-24T17:59:00Z",
+                    "session_id": null,
+                    "tags": []
+                }
+            ],
+            "next_cursor": null
+        })
+    );
+}
+
+#[tokio::test]
+async fn voice_note_history_paginates_with_descending_id_tiebreaker() {
+    let fixture = VoiceNoteFixture::new().await;
+    for id in ["note-a", "note-c", "note-b"] {
+        fixture
+            .insert_voice_note(VoiceNoteSeed {
+                owner: "alpha",
+                id,
+                version_id: &format!("{id}-version"),
+                text: id,
+                created_at: "2026-04-24T18:00:00.000000000Z",
+                recorded_at: "2026-04-24T17:59:00.000000000Z",
+                session_id: None,
+                tags: vec![],
+            })
+            .await;
+    }
+
+    let first = fixture
+        .get_json("/api/v1/voice-notes?limit=2", "alpha-secret")
+        .await;
+    assert_eq!(
+        first["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .map(|item| item["id"].as_str().expect("id"))
+            .collect::<Vec<_>>(),
+        vec!["note-c", "note-b"]
+    );
+    let cursor = first["next_cursor"].as_str().expect("next cursor");
+
+    let second = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes?limit=2&cursor={cursor}"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(
+        second["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .map(|item| item["id"].as_str().expect("id"))
+            .collect::<Vec<_>>(),
+        vec!["note-a"]
+    );
+    assert_eq!(second["next_cursor"], Value::Null);
+}
+
+#[tokio::test]
+async fn voice_note_detail_returns_not_found_for_missing_other_owner_and_job_ids() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "beta",
+            id: "note-beta",
+            version_id: "version-beta",
+            text: "other owner",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+    fixture.insert_job("alpha", "job-alpha").await;
+
+    for path in [
+        "/api/v1/voice-notes/note-missing",
+        "/api/v1/voice-notes/note-beta",
+        "/api/v1/voice-notes/job-alpha",
+    ] {
+        let response = fixture.get(path, "alpha-secret").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(json_body(response).await["error_code"], "not_found");
+    }
+}
+
+#[tokio::test]
+async fn version_history_returns_versions_newest_first_in_shared_envelope() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: "note-a",
+            version_id: "version-1",
+            text: "initial text",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+    fixture
+        .insert_version(
+            "alpha",
+            "note-a",
+            "version-2",
+            2,
+            "edited text",
+            "2026-04-24T18:01:00.000000000Z",
+        )
+        .await;
+
+    let body = fixture
+        .get_json("/api/v1/voice-notes/note-a/versions", "alpha-secret")
+        .await;
+
+    assert_eq!(
+        body,
+        json!({
+            "items": [
+                {
+                    "id": "version-2",
+                    "voice_note_id": "note-a",
+                    "text": "edited text",
+                    "created_at": "2026-04-24T18:01:00Z"
+                },
+                {
+                    "id": "version-1",
+                    "voice_note_id": "note-a",
+                    "text": "initial text",
+                    "created_at": "2026-04-24T18:00:00Z"
+                }
+            ],
+            "next_cursor": null
+        })
+    );
+}
+
+#[tokio::test]
+async fn segments_return_in_position_order_with_pagination() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: "note-a",
+            version_id: "version-1",
+            text: "initial text",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+    fixture
+        .insert_segment("alpha", "note-a", "segment-2", 1, "second")
+        .await;
+    fixture
+        .insert_segment("alpha", "note-a", "segment-1", 0, "first")
+        .await;
+
+    let first = fixture
+        .get_json(
+            "/api/v1/voice-notes/note-a/segments?limit=1",
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(first["items"][0]["id"], "segment-1");
+    let cursor = first["next_cursor"].as_str().expect("next cursor");
+
+    let second = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes/note-a/segments?limit=1&cursor={cursor}"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(second["items"][0]["id"], "segment-2");
+    assert_eq!(second["next_cursor"], Value::Null);
+}
+
+#[tokio::test]
+async fn session_voice_note_history_requires_owned_session_and_lists_only_session_notes() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture.insert_session("alpha", "session-a").await;
+    fixture.insert_session("beta", "session-beta").await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: "note-in-session",
+            version_id: "version-in-session",
+            text: "in session",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: Some("session-a"),
+            tags: vec![],
+        })
+        .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: "note-outside-session",
+            version_id: "version-outside-session",
+            text: "outside session",
+            created_at: "2026-04-24T18:01:00.000000000Z",
+            recorded_at: "2026-04-24T18:00:30.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    let body = fixture
+        .get_json("/api/v1/sessions/session-a/voice-notes", "alpha-secret")
+        .await;
+    assert_eq!(body["items"][0]["id"], "note-in-session");
+    assert_eq!(body["items"].as_array().expect("items").len(), 1);
+
+    for path in [
+        "/api/v1/sessions/session-missing/voice-notes",
+        "/api/v1/sessions/session-beta/voice-notes",
+    ] {
+        let response = fixture.get(path, "alpha-secret").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}
+
+#[tokio::test]
+async fn collection_queries_accept_deferred_and_unknown_parameters_but_reject_search_mode_without_q()
+ {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: "note-a",
+            version_id: "version-a",
+            text: "history result",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    let accepted = fixture
+        .get_json(
+            "/api/v1/voice-notes?q=hello&search_mode=keyword&tag_id=tag-missing&session_id=session-missing&recorded_after=2026-01-01T00%3A00%3A00Z&unknown=value",
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(accepted["items"][0]["id"], "note-a");
+
+    let rejected = fixture
+        .get("/api/v1/voice-notes?search_mode=keyword", "alpha-secret")
+        .await;
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(json_body(rejected).await["error_code"], "validation_error");
+}
+
+#[tokio::test]
+async fn malformed_cursor_and_invalid_limit_return_validation_errors() {
+    let fixture = VoiceNoteFixture::new().await;
+
+    for path in [
+        "/api/v1/voice-notes?cursor=not-a-cursor",
+        "/api/v1/voice-notes?limit=0",
+        "/api/v1/voice-notes?limit=101",
+        "/api/v1/voice-notes?limit=abc",
+    ] {
+        let response = fixture.get(path, "alpha-secret").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(json_body(response).await["error_code"], "validation_error");
+    }
+}
+
+struct VoiceNoteFixture {
+    _tempdir: TempDir,
+    app: axum::Router,
+    storage: Storage,
+}
+
+struct VoiceNoteSeed<'a> {
+    owner: &'a str,
+    id: &'a str,
+    version_id: &'a str,
+    text: &'a str,
+    created_at: &'a str,
+    recorded_at: &'a str,
+    session_id: Option<&'a str>,
+    tags: Vec<TagSeed<'a>>,
+}
+
+struct TagSeed<'a> {
+    id: &'a str,
+    name: &'a str,
+    created_at: &'a str,
+}
+
+impl VoiceNoteFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let accepted_audio_dir = tempdir.path().join("accepted-audio");
+        std::fs::create_dir(&accepted_audio_dir).expect("create accepted audio dir");
+        let storage = Storage::connect(&tempdir.path().join("oracy.sqlite"))
+            .await
+            .expect("connect storage");
+        let auth_store = AuthStore::try_from_configs(&[
+            ApiKeyConfig {
+                api_key_id: "alpha".to_owned(),
+                key: "alpha-secret".to_owned(),
+            },
+            ApiKeyConfig {
+                api_key_id: "beta".to_owned(),
+                key: "beta-secret".to_owned(),
+            },
+        ])
+        .expect("auth config");
+        let app = build_router(AppState {
+            accepted_audio_dir,
+            auth_store: Arc::new(auth_store),
+            storage: storage.clone(),
+        });
+
+        Self {
+            _tempdir: tempdir,
+            app,
+            storage,
+        }
+    }
+
+    fn app(&self) -> axum::Router {
+        self.app.clone()
+    }
+
+    async fn get(&self, path: &str, bearer: &str) -> axum::response::Response {
+        self.app()
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .header("Authorization", format!("Bearer {bearer}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response")
+    }
+
+    async fn get_json(&self, path: &str, bearer: &str) -> Value {
+        let response = self.get(path, bearer).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        json_body(response).await
+    }
+
+    async fn insert_session(&self, owner: &str, session_id: &str) {
+        sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO sessions (id, api_key_id, name, created_at)
+            VALUES (?, ?, 'Session', '2026-04-24T17:58:00.000000000Z')
+            "#,
+        )
+        .bind(session_id)
+        .bind(owner)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert session");
+    }
+
+    async fn insert_voice_note(&self, seed: VoiceNoteSeed<'_>) {
+        if let Some(session_id) = seed.session_id {
+            self.insert_session(seed.owner, session_id).await;
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO transcripts (
+                id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+                transcript_language, model, processing_time_ms, cost_cents,
+                created_at, recorded_at, session_id
+            )
+            VALUES (?, ?, 12.5, 'wav', 401280, 'en', 'gpt-4o-mini-transcribe', 1843, NULL, ?, ?, ?)
+            "#,
+        )
+        .bind(seed.id)
+        .bind(seed.owner)
+        .bind(seed.created_at)
+        .bind(seed.recorded_at)
+        .bind(seed.session_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert transcript");
+
+        sqlx::query(
+            r#"
+            INSERT INTO transcript_versions (
+                id, api_key_id, transcript_id, version_number, transcript, created_at
+            )
+            VALUES (?, ?, ?, 1, ?, ?)
+            "#,
+        )
+        .bind(seed.version_id)
+        .bind(seed.owner)
+        .bind(seed.id)
+        .bind(seed.text)
+        .bind(seed.created_at)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert transcript version");
+
+        for tag in seed.tags {
+            sqlx::query(
+                r#"
+                INSERT OR IGNORE INTO tags (id, api_key_id, name, name_folded, created_at)
+                VALUES (?, ?, ?, lower(?), ?)
+                "#,
+            )
+            .bind(tag.id)
+            .bind(seed.owner)
+            .bind(tag.name)
+            .bind(tag.name)
+            .bind(tag.created_at)
+            .execute(self.storage.pool())
+            .await
+            .expect("insert tag");
+
+            sqlx::query(
+                r#"
+                INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+                VALUES (?, ?, ?)
+                "#,
+            )
+            .bind(seed.owner)
+            .bind(seed.id)
+            .bind(tag.id)
+            .execute(self.storage.pool())
+            .await
+            .expect("insert transcript tag");
+        }
+    }
+
+    async fn insert_version(
+        &self,
+        owner: &str,
+        voice_note_id: &str,
+        version_id: &str,
+        version_number: i64,
+        text: &str,
+        created_at: &str,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO transcript_versions (
+                id, api_key_id, transcript_id, version_number, transcript, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(version_id)
+        .bind(owner)
+        .bind(voice_note_id)
+        .bind(version_number)
+        .bind(text)
+        .bind(created_at)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert transcript version");
+    }
+
+    async fn insert_segment(
+        &self,
+        owner: &str,
+        voice_note_id: &str,
+        segment_id: &str,
+        position: i64,
+        text: &str,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO segments (
+                id, api_key_id, transcript_id, position, start_ms, end_ms, text
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(segment_id)
+        .bind(owner)
+        .bind(voice_note_id)
+        .bind(position)
+        .bind(position * 1000)
+        .bind((position + 1) * 1000)
+        .bind(text)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert segment");
+    }
+
+    async fn insert_job(&self, owner: &str, job_id: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO transcription_jobs (
+                id, api_key_id, idempotency_key, audio_sha256_hex,
+                audio_content_hash_algorithm, recorded_at, accepted_audio_path,
+                status, created_at, updated_at, retry_count, max_retries
+            )
+            VALUES (
+                ?, ?, ?, 'hash', 'sha256:chunk-sha256-v1',
+                '2026-04-24T17:59:00.000000000Z', '/tmp/audio',
+                'queued', '2026-04-24T18:00:00.000000000Z',
+                '2026-04-24T18:00:00.000000000Z', 0, 3
+            )
+            "#,
+        )
+        .bind(job_id)
+        .bind(owner)
+        .bind(format!("{job_id}-attempt"))
+        .execute(self.storage.pool())
+        .await
+        .expect("insert job");
+    }
+}
+
+async fn json_body(response: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&bytes).expect("valid json")
+}

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -35,7 +35,8 @@ behavior are deferred to a later revision.
 ## Shared Conventions
 
 - Timestamps use RFC 3339 UTC strings.
-- Resource IDs are opaque strings.
+- Resource IDs are ULID-formatted strings: Crockford base32 encoding,
+  26 characters, lexicographically sortable.
 - Collection endpoints return the same envelope shape:
 
 ```json
@@ -122,7 +123,7 @@ Request:
   "recorded_at": "2026-04-21T18:29:55Z",
   "chunk_count": 3,
   "audio_format": "m4a",
-  "session_id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
+  "session_id": "01JS9P0X3NM4Q5R6S7T8V9W0X1",
   "language": "en"
 }
 ```
@@ -875,7 +876,7 @@ Semantics:
   "cost_cents": 1,
   "created_at": "2026-04-21T18:31:19Z",
   "recorded_at": "2026-04-21T18:29:55Z",
-  "session_id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
+  "session_id": "01JS9P0X3NM4Q5R6S7T8V9W0X1",
   "tags": [
     {
       "id": "01JS9P0Q0THR2X3E4A5B6C7D8E",
@@ -975,7 +976,7 @@ Fields:
 
 ```json
 {
-  "id": "01JS9P0X3NM4Q5R6S7T8U9V0W1",
+  "id": "01JS9P0X3NM4Q5R6S7T8V9W0X1",
   "name": "Q2 Planning",
   "created_at": "2026-04-21T18:31:35Z"
 }

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -288,8 +288,11 @@ Notes:
 - Without `q`, the endpoint returns voice-note history ordered
   newest-first by voice-note `created_at`, with descending `id` as
   the deterministic tiebreaker for cursor pagination.
-- With `q`, the endpoint returns voice-note search results using the
-  same `VoiceNote` resource shape, filters, and collection envelope.
+- Until search semantics land, a valid `q` returns an empty
+  `{items: [], next_cursor: null}` envelope after validating all
+  supplied search and filter parameters. Search results will use the
+  same `VoiceNote` resource shape, filters, and collection envelope
+  when the tracked search work lands.
 - If `q` is present and `search_mode` is omitted, the backend uses
   `hybrid`.
 - Search results are always voice-note resources.
@@ -719,6 +722,9 @@ Notes:
 - This endpoint applies the same collection semantics as
   `GET /api/v1/voice-notes` but with the session scope fixed by the
   path, including the same ordering and time-bound semantics.
+- Until search semantics land, a valid `q` returns an empty
+  `{items: [], next_cursor: null}` envelope after validating all
+  supplied search and filter parameters.
 - If `q` is present and `search_mode` is omitted, the backend uses
   `hybrid`.
 - Repeated `tag_id` filters combine by intersection.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -61,6 +61,10 @@ behavior are deferred to a later revision.
   `error_code: "invalid_request_shape"`; a JSON body exceeding the
   configured body limit returns `413 Payload Too Large` with
   `error_code: "payload_too_large"`.
+- A singular query parameter supplied more than once returns
+  `400 Bad Request` with
+  `error_code: "repeated_singular_parameter"` and a `details` entry
+  naming the repeated parameter.
 
 ### `ErrorResponse`
 

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -506,6 +506,10 @@ Semantics:
   shape, filters, and pagination. This is an explicit `v0.1.0`
   governance decision to avoid duplicating voice-note collection
   surface with no semantic gain.
+- Until search semantics land, a valid `q` returns an empty
+  collection envelope after validating all supplied search and filter
+  parameters. This preserves the contract surface without presenting
+  history rows as search results.
 - Search results are always `VoiceNote` resources. Jobs, sessions,
   tags, versions, and segments are not returned as search hits.
 - Keyword search supports full-text matching over current voice-note
@@ -642,7 +646,8 @@ following are true:
 - Search behavior is explicit: history and search share one voice-
   note collection contract, omitted `search_mode` with `q` defaults
   to `hybrid`, repeated `tag_id` filters intersect, results are
-  voice-note-only, and semantic search is eventually consistent
+  voice-note-only, deferred search returns an empty collection rather
+  than history rows, and semantic search is eventually consistent
   after edits.
 - Deletion semantics are explicit and match resource ownership
   expectations.


### PR DESCRIPTION
## Summary

- Exposes the read-only voice-note API surfaces for history, detail, versions, segments, and session-scoped history.
- Adds shared cursor pagination, owner-scoped lookups, and contract-visible `VoiceNote`, `VoiceNoteVersion`, and `Segment` response shapes.
- Accepts deferred collection search/filter query parameters for wire compatibility until the tracked search work lands.

## Changes

- Registers the five authenticated GET routes for voice-note read surfaces.
- Adds storage queries for paginated voice-note history, session history, version history, segment pages, session existence checks, and batched tag loading.
- Adds opaque base64url cursor handling with limit validation and transitional query handling.
- Covers the read surfaces with integration tests and records the API-visible change in the changelog.

## GitHub Issue(s)

Closes #17

## Test plan

- `cargo test --manifest-path backend/Cargo.toml --test voice_notes`
- `cargo test --manifest-path backend/Cargo.toml`
- `git diff --check`
