### PR TITLE
docs(spec): remove deferred search state

### DIFF
--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -288,11 +288,6 @@ Notes:
 - Without `q`, the endpoint returns voice-note history ordered
   newest-first by voice-note `created_at`, with descending `id` as
   the deterministic tiebreaker for cursor pagination.
-- Until search semantics land, a valid `q` returns an empty
-  `{items: [], next_cursor: null}` envelope after validating all
-  supplied search and filter parameters. Search results will use the
-  same `VoiceNote` resource shape, filters, and collection envelope
-  when the tracked search work lands.
 - If `q` is present and `search_mode` is omitted, the backend uses
   `hybrid`.
 - Search results are always voice-note resources.
@@ -722,9 +717,6 @@ Notes:
 - This endpoint applies the same collection semantics as
   `GET /api/v1/voice-notes` but with the session scope fixed by the
   path, including the same ordering and time-bound semantics.
-- Until search semantics land, a valid `q` returns an empty
-  `{items: [], next_cursor: null}` envelope after validating all
-  supplied search and filter parameters.
 - If `q` is present and `search_mode` is omitted, the backend uses
   `hybrid`.
 - Repeated `tag_id` filters combine by intersection.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -506,10 +506,6 @@ Semantics:
   shape, filters, and pagination. This is an explicit `v0.1.0`
   governance decision to avoid duplicating voice-note collection
   surface with no semantic gain.
-- Until search semantics land, a valid `q` returns an empty
-  collection envelope after validating all supplied search and filter
-  parameters. This preserves the contract surface without presenting
-  history rows as search results.
 - Search results are always `VoiceNote` resources. Jobs, sessions,
   tags, versions, and segments are not returned as search hits.
 - Keyword search supports full-text matching over current voice-note
@@ -646,9 +642,8 @@ following are true:
 - Search behavior is explicit: history and search share one voice-
   note collection contract, omitted `search_mode` with `q` defaults
   to `hybrid`, repeated `tag_id` filters intersect, results are
-  voice-note-only, deferred search returns an empty collection rather
-  than history rows, and semantic search is eventually consistent
-  after edits.
+  voice-note-only, and semantic search is eventually consistent after
+  edits.
 - Deletion semantics are explicit and match resource ownership
   expectations.
 - Audio retention semantics are explicit: chunks and composed audio


### PR DESCRIPTION
## Summary

- Removes transitional empty-on-`q` implementation-state language from the API contract and backend requirements specs.
- Preserves the eventual client contract language for unified history/search collections, search mode defaults, tag-filter intersection, voice-note-only results, and eventual semantic freshness.
- Keeps today’s deferred-search behavior documented in `CHANGELOG.md`, where shipped transitional state belongs.

## Changes

- Removed the deferred-search bullets from the global and session-scoped voice-note collection endpoint notes in `spec/api-contract.md`.
- Removed the matching deferred-search bullet from `spec/backend-requirements.md`.
- Removed only the deferred-search clause from the search acceptance criterion, leaving the surrounding eventual-behavior commitments intact.

## GitHub Issue(s)

None. This is a discipline-correction PR for Principle 4: the spec describes the contract clients code against and the implementation will deliver when complete; transitional implementation state belongs in `CHANGELOG.md`.

## Test plan

- `git diff --check`
- `cargo test`
- Read each edited section end-to-end to confirm the surrounding text remains coherent and no orphaned transitional references remain.

## Documentation review

- Updated: API contract and backend requirements spec passages that were carrying implementation-state language.
- Verified accurate: `CHANGELOG.md` continues to document the shipped transitional deferred-search behavior.
- Not needed: README and ADR updates; this PR changes contract documentation boundaries only.
