### PR TITLE
feat(metadata): expose tag and session management endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add authenticated tag and session management APIs, including owner-scoped
+  CRUD, shared cursor pagination, case-insensitive tag identity with
+  latest-spelling display updates, and metadata deletion cascades.
 - Add authenticated voice-note history, detail, version-history, segment, and
   session-scoped history read APIs. Collection filters compose across tags,
   sessions, and recorded/created time ranges; search query parameters

--- a/backend/src/collections.rs
+++ b/backend/src/collections.rs
@@ -1,0 +1,191 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+use time::format_description::well_known::Rfc3339;
+use time::{OffsetDateTime, UtcOffset};
+use ulid::Ulid;
+
+use crate::errors::{ApiError, ErrorDetail};
+
+pub const DEFAULT_LIMIT: i64 = 50;
+pub const MAX_LIMIT: i64 = 100;
+
+const CURSOR_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TimeCursor {
+    v: u8,
+    kind: String,
+    created_at: String,
+    id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PositionCursor {
+    v: u8,
+    kind: String,
+    position: i64,
+}
+
+pub fn parse_query_params(raw_query: Option<&str>) -> Vec<(String, String)> {
+    raw_query
+        .map(|query| {
+            form_urlencoded::parse(query.as_bytes())
+                .into_owned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn ensure_singular_query_param(
+    params: &[(String, String)],
+    field: &str,
+) -> Result<(), ApiError> {
+    if query_values(params, field).nth(1).is_some() {
+        return Err(ApiError::repeated_singular_parameter(field));
+    }
+
+    Ok(())
+}
+
+pub fn query_first<'a>(params: &'a [(String, String)], field: &str) -> Option<&'a str> {
+    params
+        .iter()
+        .find(|(name, _)| name == field)
+        .map(|(_, value)| value.as_str())
+}
+
+pub fn query_any(params: &[(String, String)], field: &str) -> bool {
+    query_first(params, field).is_some()
+}
+
+pub fn query_values<'a>(
+    params: &'a [(String, String)],
+    field: &'a str,
+) -> impl Iterator<Item = &'a str> {
+    params
+        .iter()
+        .filter(move |(name, _)| name == field)
+        .map(|(_, value)| value.as_str())
+}
+
+pub fn parse_limit(params: &[(String, String)]) -> Result<i64, ApiError> {
+    let Some(raw_limit) = query_first(params, "limit") else {
+        return Ok(DEFAULT_LIMIT);
+    };
+    let limit = raw_limit
+        .parse::<i64>()
+        .map_err(|_| validation_error("limit", "Must be an integer in 1..100."))?;
+    if !(1..=MAX_LIMIT).contains(&limit) {
+        return Err(validation_error("limit", "Must be an integer in 1..100."));
+    }
+
+    Ok(limit)
+}
+
+pub fn parse_time_cursor(
+    cursor: &str,
+    expected_kind: &str,
+) -> Result<(OffsetDateTime, String), ApiError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| malformed_cursor())?;
+    let decoded: TimeCursor = serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
+    if decoded.v != CURSOR_VERSION || decoded.kind != expected_kind {
+        return Err(malformed_cursor());
+    }
+    let created_at =
+        OffsetDateTime::parse(&decoded.created_at, &Rfc3339).map_err(|_| malformed_cursor())?;
+    let Ok(parsed_id) = Ulid::from_string(&decoded.id) else {
+        return Err(malformed_cursor());
+    };
+    if parsed_id.to_string() != decoded.id {
+        return Err(malformed_cursor());
+    }
+
+    Ok((created_at, decoded.id))
+}
+
+pub fn parse_position_cursor(cursor: &str, expected_kind: &str) -> Result<i64, ApiError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| malformed_cursor())?;
+    let decoded: PositionCursor = serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
+    if decoded.v != CURSOR_VERSION || decoded.kind != expected_kind || decoded.position < 0 {
+        return Err(malformed_cursor());
+    }
+
+    Ok(decoded.position)
+}
+
+pub fn time_cursor(kind: &str, created_at: OffsetDateTime, id: &str) -> Result<String, ApiError> {
+    let cursor = TimeCursor {
+        v: CURSOR_VERSION,
+        kind: kind.to_owned(),
+        created_at: timestamp(created_at)?,
+        id: id.to_owned(),
+    };
+    encode_cursor(&cursor)
+}
+
+pub fn position_cursor(kind: &str, position: i64) -> Result<String, ApiError> {
+    let cursor = PositionCursor {
+        v: CURSOR_VERSION,
+        kind: kind.to_owned(),
+        position,
+    };
+    encode_cursor(&cursor)
+}
+
+pub fn timestamp(value: OffsetDateTime) -> Result<String, ApiError> {
+    value
+        .format(&Rfc3339)
+        .map_err(|_| ApiError::internal("Failed to format timestamp."))
+}
+
+pub fn validate_ulid_field(field: &str, value: &str) -> Result<(), ApiError> {
+    let parsed =
+        Ulid::from_string(value).map_err(|_| validation_error(field, "Must be a valid ULID."))?;
+    if parsed.to_string() != value {
+        return Err(validation_error(field, "Must be a valid ULID."));
+    }
+
+    Ok(())
+}
+
+pub fn validate_rfc3339_field(field: &str, value: &str) -> Result<(), ApiError> {
+    parse_rfc3339_field(field, value).map(|_| ())
+}
+
+pub fn parse_rfc3339_field(field: &str, value: &str) -> Result<OffsetDateTime, ApiError> {
+    let parsed = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| validation_error(field, "Must be an RFC 3339 UTC timestamp."))?;
+    if parsed.offset() != UtcOffset::UTC {
+        return Err(validation_error(
+            field,
+            "Must be an RFC 3339 UTC timestamp.",
+        ));
+    }
+
+    Ok(parsed)
+}
+
+pub fn validation_error(field: &str, message: &str) -> ApiError {
+    ApiError::validation(
+        "One or more request fields are invalid.",
+        Some(vec![ErrorDetail {
+            field: field.to_owned(),
+            message: message.to_owned(),
+        }]),
+    )
+}
+
+fn encode_cursor<T: Serialize>(cursor: &T) -> Result<String, ApiError> {
+    let bytes =
+        serde_json::to_vec(cursor).map_err(|_| ApiError::internal("Failed to encode cursor."))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn malformed_cursor() -> ApiError {
+    validation_error("cursor", "Malformed cursor.")
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,9 +3,11 @@
 pub mod audio_hash;
 pub mod auth;
 pub mod bootstrap;
+pub mod collections;
 pub mod config;
 pub mod errors;
 pub mod json;
+pub mod metadata;
 pub mod router;
 pub mod settings;
 pub mod state;

--- a/backend/src/metadata.rs
+++ b/backend/src/metadata.rs
@@ -1,0 +1,345 @@
+use axum::Json;
+use axum::extract::{Path, RawQuery, State};
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use ulid::Ulid;
+
+use crate::auth::AuthenticatedKey;
+use crate::collections::{
+    ensure_singular_query_param, parse_limit, parse_query_params, parse_time_cursor, query_first,
+    time_cursor, timestamp, validate_ulid_field,
+};
+use crate::errors::{ApiError, CollectionEnvelope};
+use crate::json::JsonBody;
+use crate::state::AppState;
+use crate::storage::{
+    CreateTagOutcome, NewSession, NewTag, RenameTagOutcome, SessionRecord, TagRecord,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MetadataCollection {
+    Tags,
+    Sessions,
+}
+
+#[derive(Debug, Clone)]
+struct PageQuery {
+    limit: i64,
+    cursor: Option<(OffsetDateTime, String)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TagResource {
+    id: String,
+    name: String,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SessionResource {
+    id: String,
+    name: String,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NameRequest {
+    name: String,
+}
+
+pub async fn list_tags(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<Json<CollectionEnvelope<TagResource>>, ApiError> {
+    let page = parse_page_query(raw_query.as_deref(), MetadataCollection::Tags)?;
+    let rows = state
+        .storage
+        .list_tags(
+            authenticated_key.api_key_id.as_str(),
+            page.cursor,
+            page.limit + 1,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to list tags."))?;
+    render_tag_page(rows, page.limit, MetadataCollection::Tags)
+}
+
+pub async fn create_tag(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    JsonBody(body): JsonBody<NameRequest>,
+) -> Result<(StatusCode, Json<TagResource>), ApiError> {
+    let outcome = state
+        .storage
+        .create_tag(NewTag {
+            id: Ulid::new().to_string(),
+            api_key_id: authenticated_key.api_key_id.to_string(),
+            name: body.name,
+            created_at: OffsetDateTime::now_utc(),
+        })
+        .await
+        .map_err(|_| ApiError::internal("Failed to create tag."))?;
+
+    match outcome {
+        CreateTagOutcome::Created(tag) => Ok((StatusCode::CREATED, Json(tag_resource(tag)?))),
+        CreateTagOutcome::Existing(tag) => Ok((StatusCode::OK, Json(tag_resource(tag)?))),
+    }
+}
+
+pub async fn get_tag(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(tag_id): Path<String>,
+) -> Result<Json<TagResource>, ApiError> {
+    validate_ulid_field("tag_id", &tag_id)?;
+    let Some(tag) = state
+        .storage
+        .get_tag(authenticated_key.api_key_id.as_str(), &tag_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load tag."))?
+    else {
+        return Err(ApiError::not_found("Tag not found."));
+    };
+
+    Ok(Json(tag_resource(tag)?))
+}
+
+pub async fn patch_tag(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(tag_id): Path<String>,
+    JsonBody(body): JsonBody<NameRequest>,
+) -> Result<Json<TagResource>, ApiError> {
+    validate_ulid_field("tag_id", &tag_id)?;
+    match state
+        .storage
+        .rename_tag(authenticated_key.api_key_id.as_str(), &tag_id, &body.name)
+        .await
+        .map_err(|_| ApiError::internal("Failed to rename tag."))?
+    {
+        RenameTagOutcome::Renamed(tag) => Ok(Json(tag_resource(tag)?)),
+        RenameTagOutcome::NotFound => Err(ApiError::not_found("Tag not found.")),
+        RenameTagOutcome::Conflict => Err(ApiError::conflict("Tag name already exists.", None)),
+    }
+}
+
+pub async fn delete_tag(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(tag_id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    validate_ulid_field("tag_id", &tag_id)?;
+    if !state
+        .storage
+        .delete_tag(authenticated_key.api_key_id.as_str(), &tag_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to delete tag."))?
+    {
+        return Err(ApiError::not_found("Tag not found."));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn list_sessions(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<Json<CollectionEnvelope<SessionResource>>, ApiError> {
+    let page = parse_page_query(raw_query.as_deref(), MetadataCollection::Sessions)?;
+    let rows = state
+        .storage
+        .list_sessions(
+            authenticated_key.api_key_id.as_str(),
+            page.cursor,
+            page.limit + 1,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to list sessions."))?;
+    render_session_page(rows, page.limit, MetadataCollection::Sessions)
+}
+
+pub async fn create_session(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    JsonBody(body): JsonBody<NameRequest>,
+) -> Result<(StatusCode, Json<SessionResource>), ApiError> {
+    let session = state
+        .storage
+        .create_session(NewSession {
+            id: Ulid::new().to_string(),
+            api_key_id: authenticated_key.api_key_id.to_string(),
+            name: body.name,
+            created_at: OffsetDateTime::now_utc(),
+        })
+        .await
+        .map_err(|_| ApiError::internal("Failed to create session."))?;
+
+    Ok((StatusCode::CREATED, Json(session_resource(session)?)))
+}
+
+pub async fn get_session(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<Json<SessionResource>, ApiError> {
+    validate_ulid_field("session_id", &session_id)?;
+    let Some(session) = state
+        .storage
+        .get_session(authenticated_key.api_key_id.as_str(), &session_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load session."))?
+    else {
+        return Err(ApiError::not_found("Session not found."));
+    };
+
+    Ok(Json(session_resource(session)?))
+}
+
+pub async fn patch_session(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    JsonBody(body): JsonBody<NameRequest>,
+) -> Result<Json<SessionResource>, ApiError> {
+    validate_ulid_field("session_id", &session_id)?;
+    let Some(session) = state
+        .storage
+        .rename_session(
+            authenticated_key.api_key_id.as_str(),
+            &session_id,
+            &body.name,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to rename session."))?
+    else {
+        return Err(ApiError::not_found("Session not found."));
+    };
+
+    Ok(Json(session_resource(session)?))
+}
+
+pub async fn delete_session(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    validate_ulid_field("session_id", &session_id)?;
+    if !state
+        .storage
+        .delete_session(authenticated_key.api_key_id.as_str(), &session_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to delete session."))?
+    {
+        return Err(ApiError::not_found("Session not found."));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn render_tag_page(
+    mut rows: Vec<TagRecord>,
+    limit: i64,
+    collection: MetadataCollection,
+) -> Result<Json<CollectionEnvelope<TagResource>>, ApiError> {
+    let has_next = rows.len() as i64 > limit;
+    if has_next {
+        rows.truncate(limit as usize);
+    }
+    let next_cursor = next_cursor(
+        &rows,
+        has_next,
+        collection,
+        |tag| tag.created_at,
+        |tag| tag.id.as_str(),
+    )?;
+    let items = rows
+        .into_iter()
+        .map(tag_resource)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Json(CollectionEnvelope { items, next_cursor }))
+}
+
+fn render_session_page(
+    mut rows: Vec<SessionRecord>,
+    limit: i64,
+    collection: MetadataCollection,
+) -> Result<Json<CollectionEnvelope<SessionResource>>, ApiError> {
+    let has_next = rows.len() as i64 > limit;
+    if has_next {
+        rows.truncate(limit as usize);
+    }
+    let next_cursor = next_cursor(
+        &rows,
+        has_next,
+        collection,
+        |session| session.created_at,
+        |session| session.id.as_str(),
+    )?;
+    let items = rows
+        .into_iter()
+        .map(session_resource)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Json(CollectionEnvelope { items, next_cursor }))
+}
+
+fn next_cursor<T>(
+    rows: &[T],
+    has_next: bool,
+    collection: MetadataCollection,
+    created_at: impl Fn(&T) -> OffsetDateTime,
+    id: impl Fn(&T) -> &str,
+) -> Result<Option<String>, ApiError> {
+    if !has_next {
+        return Ok(None);
+    }
+    rows.last()
+        .map(|row| time_cursor(collection.as_str(), created_at(row), id(row)))
+        .transpose()
+}
+
+fn parse_page_query(
+    raw_query: Option<&str>,
+    collection: MetadataCollection,
+) -> Result<PageQuery, ApiError> {
+    let params = parse_query_params(raw_query);
+    for field in ["cursor", "limit"] {
+        ensure_singular_query_param(&params, field)?;
+    }
+    Ok(PageQuery {
+        limit: parse_limit(&params)?,
+        cursor: query_first(&params, "cursor")
+            .map(|cursor| parse_time_cursor(cursor, collection.as_str()))
+            .transpose()?,
+    })
+}
+
+fn tag_resource(record: TagRecord) -> Result<TagResource, ApiError> {
+    Ok(TagResource {
+        id: record.id,
+        name: record.name,
+        created_at: timestamp(record.created_at)?,
+    })
+}
+
+fn session_resource(record: SessionRecord) -> Result<SessionResource, ApiError> {
+    Ok(SessionResource {
+        id: record.id,
+        name: record.name,
+        created_at: timestamp(record.created_at)?,
+    })
+}
+
+impl MetadataCollection {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Tags => "tags",
+            Self::Sessions => "sessions",
+        }
+    }
+}

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -2,6 +2,10 @@ use axum::Router;
 use axum::routing::get;
 
 use crate::errors::ApiError;
+use crate::metadata::{
+    create_session, create_tag, delete_session, delete_tag, get_session, get_tag, list_sessions,
+    list_tags, patch_session, patch_tag,
+};
 use crate::settings::{get_settings, patch_settings};
 use crate::state::AppState;
 use crate::voice_notes::{
@@ -12,6 +16,16 @@ use crate::voice_notes::{
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/api/v1/settings", get(get_settings).patch(patch_settings))
+        .route("/api/v1/tags", get(list_tags).post(create_tag))
+        .route(
+            "/api/v1/tags/{tag_id}",
+            get(get_tag).patch(patch_tag).delete(delete_tag),
+        )
+        .route("/api/v1/sessions", get(list_sessions).post(create_session))
+        .route(
+            "/api/v1/sessions/{session_id}",
+            get(get_session).patch(patch_session).delete(delete_session),
+        )
         .route("/api/v1/voice-notes", get(list_voice_notes))
         .route("/api/v1/voice-notes/{voice_note_id}", get(get_voice_note))
         .route(

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -898,6 +898,80 @@ impl Storage {
         Ok(exists.is_some())
     }
 
+    pub async fn list_tags(
+        &self,
+        api_key_id: &str,
+        cursor: Option<(OffsetDateTime, String)>,
+        limit: i64,
+    ) -> Result<Vec<TagRecord>, StorageError> {
+        let cursor_created_at = cursor
+            .as_ref()
+            .map(|(created_at, _)| format_timestamp(*created_at))
+            .transpose()?;
+        let cursor_id = cursor.as_ref().map(|(_, id)| id.as_str());
+        let rows = sqlx::query(
+            r#"
+            SELECT id, api_key_id, name, created_at
+            FROM tags
+            WHERE api_key_id = ?
+                AND (
+                    ? IS NULL
+                    OR created_at < ?
+                    OR (created_at = ? AND id < ?)
+                )
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(cursor_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(tag_from_row).collect()
+    }
+
+    pub async fn list_sessions(
+        &self,
+        api_key_id: &str,
+        cursor: Option<(OffsetDateTime, String)>,
+        limit: i64,
+    ) -> Result<Vec<SessionRecord>, StorageError> {
+        let cursor_created_at = cursor
+            .as_ref()
+            .map(|(created_at, _)| format_timestamp(*created_at))
+            .transpose()?;
+        let cursor_id = cursor.as_ref().map(|(_, id)| id.as_str());
+        let rows = sqlx::query(
+            r#"
+            SELECT id, api_key_id, name, created_at
+            FROM sessions
+            WHERE api_key_id = ?
+                AND (
+                    ? IS NULL
+                    OR created_at < ?
+                    OR (created_at = ? AND id < ?)
+                )
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(&cursor_created_at)
+        .bind(cursor_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(session_from_row).collect()
+    }
+
     pub async fn replace_current_embedding(
         &self,
         api_key_id: &str,
@@ -1003,11 +1077,13 @@ impl Storage {
         } else {
             sqlx::query(
                 r#"
-                SELECT id, api_key_id, name, created_at
-                FROM tags
+                UPDATE tags
+                SET name = ?
                 WHERE api_key_id = ? AND name_folded = ?
+                RETURNING id, api_key_id, name, created_at
                 "#,
             )
+            .bind(&input.name)
             .bind(&input.api_key_id)
             .bind(&name_folded)
             .fetch_one(&mut *tx)
@@ -1109,6 +1185,26 @@ impl Storage {
         row.map(tag_from_row).transpose()
     }
 
+    pub async fn get_session(
+        &self,
+        api_key_id: &str,
+        session_id: &str,
+    ) -> Result<Option<SessionRecord>, StorageError> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, api_key_id, name, created_at
+            FROM sessions
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(session_from_row).transpose()
+    }
+
     pub async fn rename_tag(
         &self,
         api_key_id: &str,
@@ -1171,6 +1267,29 @@ impl Storage {
         } else {
             Ok(RenameTagOutcome::NotFound)
         }
+    }
+
+    pub async fn rename_session(
+        &self,
+        api_key_id: &str,
+        session_id: &str,
+        name: &str,
+    ) -> Result<Option<SessionRecord>, StorageError> {
+        let row = sqlx::query(
+            r#"
+            UPDATE sessions
+            SET name = ?
+            WHERE api_key_id = ? AND id = ?
+            RETURNING id, api_key_id, name, created_at
+            "#,
+        )
+        .bind(name)
+        .bind(api_key_id)
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(session_from_row).transpose()
     }
 
     pub async fn replace_transcript_tags(

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -1,22 +1,19 @@
 use axum::Json;
 use axum::extract::{Path, RawQuery, State};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use serde::{Deserialize, Serialize};
-use time::format_description::well_known::Rfc3339;
-use time::{OffsetDateTime, UtcOffset};
-use ulid::Ulid;
+use serde::Serialize;
+use time::OffsetDateTime;
 
 use crate::auth::AuthenticatedKey;
-use crate::errors::{ApiError, CollectionEnvelope, ErrorDetail};
+use crate::collections::{
+    ensure_singular_query_param, parse_limit, parse_position_cursor, parse_query_params,
+    parse_rfc3339_field, parse_time_cursor, position_cursor, query_any, query_first, query_values,
+    time_cursor, timestamp, validate_rfc3339_field, validate_ulid_field, validation_error,
+};
+use crate::errors::{ApiError, CollectionEnvelope};
 use crate::state::AppState;
 use crate::storage::{
     SegmentRecord, TagRecord, TranscriptFilters, TranscriptRecord, TranscriptVersionRecord,
 };
-
-const DEFAULT_LIMIT: i64 = 50;
-const MAX_LIMIT: i64 = 100;
-const CURSOR_VERSION: u8 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CursorKind {
@@ -80,21 +77,6 @@ pub struct TagResource {
     id: String,
     name: String,
     created_at: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct TimeCursor {
-    v: u8,
-    kind: String,
-    created_at: String,
-    id: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct PositionCursor {
-    v: u8,
-    kind: String,
-    position: i64,
 }
 
 pub async fn list_voice_notes(
@@ -185,7 +167,7 @@ pub async fn list_voice_note_versions(
         rows.last()
             .map(|version| {
                 time_cursor(
-                    CursorKind::VoiceNoteVersions,
+                    CursorKind::VoiceNoteVersions.as_str(),
                     version.created_at,
                     &version.id,
                 )
@@ -233,7 +215,9 @@ pub async fn list_voice_note_segments(
     }
     let next_cursor = if has_next {
         rows.last()
-            .map(|segment| position_cursor(CursorKind::VoiceNoteSegments, segment.position))
+            .map(|segment| {
+                position_cursor(CursorKind::VoiceNoteSegments.as_str(), segment.position)
+            })
             .transpose()?
     } else {
         None
@@ -318,7 +302,9 @@ async fn render_voice_note_page(
     }
     let next_cursor = if has_next {
         rows.last()
-            .map(|voice_note| time_cursor(cursor_kind, voice_note.created_at, &voice_note.id))
+            .map(|voice_note| {
+                time_cursor(cursor_kind.as_str(), voice_note.created_at, &voice_note.id)
+            })
             .transpose()?
     } else {
         None
@@ -357,7 +343,7 @@ fn parse_voice_note_collection_query(
         page: PageQuery {
             limit: parse_limit(params)?,
             cursor: query_first(params, "cursor")
-                .map(|cursor| parse_time_cursor(cursor, cursor_kind))
+                .map(|cursor| parse_time_cursor(cursor, cursor_kind.as_str()))
                 .transpose()?,
         },
         filters: parse_transcript_filters(params, cursor_kind)?,
@@ -374,7 +360,7 @@ fn parse_time_page_query(
     Ok(PageQuery {
         limit: parse_limit(params)?,
         cursor: query_first(params, "cursor")
-            .map(|cursor| parse_time_cursor(cursor, cursor_kind))
+            .map(|cursor| parse_time_cursor(cursor, cursor_kind.as_str()))
             .transpose()?,
     })
 }
@@ -388,7 +374,7 @@ fn parse_position_page_query(
     Ok(PageQuery {
         limit: parse_limit(params)?,
         cursor: query_first(params, "cursor")
-            .map(|cursor| parse_position_cursor(cursor, cursor_kind))
+            .map(|cursor| parse_position_cursor(cursor, cursor_kind.as_str()))
             .transpose()?,
     })
 }
@@ -414,14 +400,6 @@ fn validate_repeated_singular_query_params(
         if cursor_kind == CursorKind::VoiceNoteHistory {
             ensure_singular_query_param(params, "session_id")?;
         }
-    }
-
-    Ok(())
-}
-
-fn ensure_singular_query_param(params: &[(String, String)], field: &str) -> Result<(), ApiError> {
-    if query_values(params, field).nth(1).is_some() {
-        return Err(ApiError::repeated_singular_parameter(field));
     }
 
     Ok(())
@@ -504,109 +482,6 @@ fn parse_optional_rfc3339_filter(
         .transpose()
 }
 
-fn parse_limit(params: &[(String, String)]) -> Result<i64, ApiError> {
-    let Some(raw_limit) = query_first(params, "limit") else {
-        return Ok(DEFAULT_LIMIT);
-    };
-    let limit = raw_limit
-        .parse::<i64>()
-        .map_err(|_| validation_error("limit", "Must be an integer in 1..100."))?;
-    if !(1..=MAX_LIMIT).contains(&limit) {
-        return Err(validation_error("limit", "Must be an integer in 1..100."));
-    }
-
-    Ok(limit)
-}
-
-fn parse_query_params(raw_query: Option<&str>) -> Vec<(String, String)> {
-    raw_query
-        .map(|query| {
-            form_urlencoded::parse(query.as_bytes())
-                .into_owned()
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn query_first<'a>(params: &'a [(String, String)], field: &str) -> Option<&'a str> {
-    params
-        .iter()
-        .find(|(name, _)| name == field)
-        .map(|(_, value)| value.as_str())
-}
-
-fn query_any(params: &[(String, String)], field: &str) -> bool {
-    query_first(params, field).is_some()
-}
-
-fn query_values<'a>(
-    params: &'a [(String, String)],
-    field: &'a str,
-) -> impl Iterator<Item = &'a str> {
-    params
-        .iter()
-        .filter(move |(name, _)| name == field)
-        .map(|(_, value)| value.as_str())
-}
-
-fn parse_time_cursor(
-    cursor: &str,
-    expected_kind: CursorKind,
-) -> Result<(OffsetDateTime, String), ApiError> {
-    let bytes = URL_SAFE_NO_PAD
-        .decode(cursor)
-        .map_err(|_| malformed_cursor())?;
-    let decoded: TimeCursor = serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
-    if decoded.v != CURSOR_VERSION || decoded.kind != expected_kind.as_str() {
-        return Err(malformed_cursor());
-    }
-    let created_at =
-        OffsetDateTime::parse(&decoded.created_at, &Rfc3339).map_err(|_| malformed_cursor())?;
-    if decoded.id.is_empty() {
-        return Err(malformed_cursor());
-    }
-
-    Ok((created_at, decoded.id))
-}
-
-fn parse_position_cursor(cursor: &str, expected_kind: CursorKind) -> Result<i64, ApiError> {
-    let bytes = URL_SAFE_NO_PAD
-        .decode(cursor)
-        .map_err(|_| malformed_cursor())?;
-    let decoded: PositionCursor = serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
-    if decoded.v != CURSOR_VERSION || decoded.kind != expected_kind.as_str() || decoded.position < 0
-    {
-        return Err(malformed_cursor());
-    }
-
-    Ok(decoded.position)
-}
-
-fn time_cursor(kind: CursorKind, created_at: OffsetDateTime, id: &str) -> Result<String, ApiError> {
-    let cursor = TimeCursor {
-        v: CURSOR_VERSION,
-        kind: kind.as_str().to_owned(),
-        created_at: timestamp(created_at)?,
-        id: id.to_owned(),
-    };
-    encode_cursor(&cursor)
-}
-
-fn position_cursor(kind: CursorKind, position: i64) -> Result<String, ApiError> {
-    let cursor = PositionCursor {
-        v: CURSOR_VERSION,
-        kind: kind.as_str().to_owned(),
-        position,
-    };
-    encode_cursor(&cursor)
-}
-
-fn encode_cursor<T: Serialize>(cursor: &T) -> Result<String, ApiError> {
-    let bytes =
-        serde_json::to_vec(cursor).map_err(|_| ApiError::internal("Failed to encode cursor."))?;
-    Ok(URL_SAFE_NO_PAD.encode(bytes))
-}
-
 fn voice_note_resource(
     record: TranscriptRecord,
     tags: Vec<TagRecord>,
@@ -660,53 +535,6 @@ fn tag_resource(record: TagRecord) -> Result<TagResource, ApiError> {
         name: record.name,
         created_at: timestamp(record.created_at)?,
     })
-}
-
-fn timestamp(value: OffsetDateTime) -> Result<String, ApiError> {
-    value
-        .format(&Rfc3339)
-        .map_err(|_| ApiError::internal("Failed to format timestamp."))
-}
-
-fn validation_error(field: &str, message: &str) -> ApiError {
-    ApiError::validation(
-        "One or more request fields are invalid.",
-        Some(vec![ErrorDetail {
-            field: field.to_owned(),
-            message: message.to_owned(),
-        }]),
-    )
-}
-
-fn validate_ulid_field(field: &str, value: &str) -> Result<(), ApiError> {
-    let parsed =
-        Ulid::from_string(value).map_err(|_| validation_error(field, "Must be a valid ULID."))?;
-    if parsed.to_string() != value {
-        return Err(validation_error(field, "Must be a valid ULID."));
-    }
-
-    Ok(())
-}
-
-fn validate_rfc3339_field(field: &str, value: &str) -> Result<(), ApiError> {
-    parse_rfc3339_field(field, value).map(|_| ())
-}
-
-fn parse_rfc3339_field(field: &str, value: &str) -> Result<OffsetDateTime, ApiError> {
-    let parsed = OffsetDateTime::parse(value, &Rfc3339)
-        .map_err(|_| validation_error(field, "Must be an RFC 3339 UTC timestamp."))?;
-    if parsed.offset() != UtcOffset::UTC {
-        return Err(validation_error(
-            field,
-            "Must be an RFC 3339 UTC timestamp.",
-        ));
-    }
-
-    Ok(parsed)
-}
-
-fn malformed_cursor() -> ApiError {
-    validation_error("cursor", "Malformed cursor.")
 }
 
 impl CursorKind {

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -1,0 +1,669 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use oracy_backend::auth::AuthStore;
+use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::router::build_router;
+use oracy_backend::state::AppState;
+use oracy_backend::storage::Storage;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+const TAG_ALPHA: &str = "01JS9P0Q0THR2X3E4A5B6C7D8E";
+const TAG_BETA: &str = "01JS9P0Q0THR2X3E4A5B6C7D8F";
+const TAG_GAMMA: &str = "01JS9P0Q0THR2X3E4A5B6C7D8G";
+const TAG_MISSING: &str = "01JS9P0Q0THR2X3E4A5B6C7D8H";
+const SESSION_ALPHA: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X1";
+const SESSION_BETA: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X2";
+const SESSION_MISSING: &str = "01JS9P0X3NM4Q5R6S7T8V9W0X3";
+const NOTE_ALPHA: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5R";
+const VERSION_ALPHA: &str = "01JS9P1D6CK9M0N1P2Q3R4S5T6";
+const JOB_ALPHA: &str = "01JS8D6E2S3T1J7H9J2Q2N4P63";
+
+#[tokio::test]
+async fn tag_endpoints_manage_owner_scoped_case_insensitive_tags() {
+    let fixture = MetadataFixture::new().await;
+
+    let created = fixture
+        .json_request(
+            "POST",
+            "/api/v1/tags",
+            "alpha-secret",
+            Some(json!({"name": "Meeting"})),
+        )
+        .await;
+    assert_eq!(created.status, StatusCode::CREATED);
+    assert_eq!(created.body["name"], "Meeting");
+    let tag_id = created.body["id"].as_str().expect("tag id");
+
+    let duplicate = fixture
+        .json_request(
+            "POST",
+            "/api/v1/tags",
+            "alpha-secret",
+            Some(json!({"name": "meeting"})),
+        )
+        .await;
+    assert_eq!(duplicate.status, StatusCode::OK);
+    assert_eq!(duplicate.body["id"], tag_id);
+    assert_eq!(duplicate.body["name"], "meeting");
+
+    let fetched = fixture
+        .get_json(&format!("/api/v1/tags/{tag_id}"), "alpha-secret")
+        .await;
+    assert_eq!(fetched["name"], "meeting");
+
+    let renamed = fixture
+        .json_request(
+            "PATCH",
+            &format!("/api/v1/tags/{tag_id}"),
+            "alpha-secret",
+            Some(json!({"name": "Planning"})),
+        )
+        .await;
+    assert_eq!(renamed.status, StatusCode::OK);
+    assert_eq!(renamed.body["id"], tag_id);
+    assert_eq!(renamed.body["name"], "Planning");
+
+    let hidden = fixture
+        .get(&format!("/api/v1/tags/{tag_id}"), "beta-secret")
+        .await;
+    assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+
+    let deleted = fixture
+        .request(
+            "DELETE",
+            &format!("/api/v1/tags/{tag_id}"),
+            "alpha-secret",
+            None,
+        )
+        .await;
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+    let missing = fixture
+        .get(&format!("/api/v1/tags/{tag_id}"), "alpha-secret")
+        .await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn tag_listing_paginates_validates_and_ignores_unknown_parameters() {
+    let fixture = MetadataFixture::new().await;
+    fixture
+        .insert_tag("alpha", TAG_ALPHA, "Old", "2026-04-24T18:00:00.000000000Z")
+        .await;
+    fixture
+        .insert_tag(
+            "alpha",
+            TAG_GAMMA,
+            "Tie High",
+            "2026-04-24T18:01:00.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_tag(
+            "alpha",
+            TAG_BETA,
+            "Tie Low",
+            "2026-04-24T18:01:00.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_tag(
+            "beta",
+            TAG_MISSING,
+            "Hidden",
+            "2026-04-24T18:02:00.000000000Z",
+        )
+        .await;
+
+    let first = fixture
+        .get_json("/api/v1/tags?limit=2&unknown=value", "alpha-secret")
+        .await;
+    assert_eq!(ids(&first), vec![TAG_GAMMA, TAG_BETA]);
+    let cursor = first["next_cursor"].as_str().expect("next cursor");
+
+    let second = fixture
+        .get_json(
+            &format!("/api/v1/tags?limit=2&cursor={cursor}"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(ids(&second), vec![TAG_ALPHA]);
+    assert_eq!(second["next_cursor"], Value::Null);
+
+    for path in [
+        "/api/v1/tags?cursor=not-a-cursor",
+        "/api/v1/tags?limit=0",
+        "/api/v1/tags?limit=101",
+        "/api/v1/tags?limit=abc",
+        "/api/v1/tags?cursor=a&cursor=b",
+        "/api/v1/tags?limit=1&limit=2",
+    ] {
+        let response = fixture.get(path, "alpha-secret").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
+async fn tag_rename_reports_not_found_before_conflict() {
+    let fixture = MetadataFixture::new().await;
+    fixture
+        .insert_tag(
+            "alpha",
+            TAG_ALPHA,
+            "Notes",
+            "2026-04-24T18:00:00.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_tag("beta", TAG_BETA, "Other", "2026-04-24T18:00:00.000000000Z")
+        .await;
+
+    for tag_id in [TAG_MISSING, TAG_BETA] {
+        let response = fixture
+            .json_request(
+                "PATCH",
+                &format!("/api/v1/tags/{tag_id}"),
+                "alpha-secret",
+                Some(json!({"name": "notes"})),
+            )
+            .await;
+        assert_eq!(response.status, StatusCode::NOT_FOUND);
+    }
+
+    fixture
+        .insert_tag(
+            "alpha",
+            TAG_GAMMA,
+            "Planning",
+            "2026-04-24T18:01:00.000000000Z",
+        )
+        .await;
+    let conflict = fixture
+        .json_request(
+            "PATCH",
+            &format!("/api/v1/tags/{TAG_GAMMA}"),
+            "alpha-secret",
+            Some(json!({"name": "notes"})),
+        )
+        .await;
+    assert_eq!(conflict.status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn tag_rename_visibility_and_delete_cascade_flow_through_voice_note_associations() {
+    let fixture = MetadataFixture::new().await;
+    fixture
+        .insert_tag(
+            "alpha",
+            TAG_ALPHA,
+            "Meeting",
+            "2026-04-24T18:00:00.000000000Z",
+        )
+        .await;
+    fixture.insert_voice_note_with_tag("alpha", TAG_ALPHA).await;
+
+    let renamed = fixture
+        .json_request(
+            "PATCH",
+            &format!("/api/v1/tags/{TAG_ALPHA}"),
+            "alpha-secret",
+            Some(json!({"name": "Planning"})),
+        )
+        .await;
+    assert_eq!(renamed.status, StatusCode::OK);
+    let note = fixture
+        .get_json(&format!("/api/v1/voice-notes/{NOTE_ALPHA}"), "alpha-secret")
+        .await;
+    assert_eq!(note["tags"][0]["name"], "Planning");
+
+    let deleted = fixture
+        .request(
+            "DELETE",
+            &format!("/api/v1/tags/{TAG_ALPHA}"),
+            "alpha-secret",
+            None,
+        )
+        .await;
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+    let note = fixture
+        .get_json(&format!("/api/v1/voice-notes/{NOTE_ALPHA}"), "alpha-secret")
+        .await;
+    assert_eq!(note["tags"], json!([]));
+}
+
+#[tokio::test]
+async fn session_endpoints_manage_owner_scoped_sessions_without_name_uniqueness() {
+    let fixture = MetadataFixture::new().await;
+
+    let created = fixture
+        .json_request(
+            "POST",
+            "/api/v1/sessions",
+            "alpha-secret",
+            Some(json!({"name": "Planning"})),
+        )
+        .await;
+    assert_eq!(created.status, StatusCode::CREATED);
+    assert_eq!(created.body["name"], "Planning");
+    let session_id = created.body["id"].as_str().expect("session id");
+
+    let same_name = fixture
+        .json_request(
+            "POST",
+            "/api/v1/sessions",
+            "alpha-secret",
+            Some(json!({"name": "Planning"})),
+        )
+        .await;
+    assert_eq!(same_name.status, StatusCode::CREATED);
+    assert_ne!(same_name.body["id"], session_id);
+
+    let renamed = fixture
+        .json_request(
+            "PATCH",
+            &format!("/api/v1/sessions/{session_id}"),
+            "alpha-secret",
+            Some(json!({"name": "Interviews"})),
+        )
+        .await;
+    assert_eq!(renamed.status, StatusCode::OK);
+    assert_eq!(renamed.body["name"], "Interviews");
+
+    let hidden = fixture
+        .get(&format!("/api/v1/sessions/{session_id}"), "beta-secret")
+        .await;
+    assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+
+    let deleted = fixture
+        .request(
+            "DELETE",
+            &format!("/api/v1/sessions/{session_id}"),
+            "alpha-secret",
+            None,
+        )
+        .await;
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn session_listing_paginates_and_validates_like_other_collections() {
+    let fixture = MetadataFixture::new().await;
+    fixture
+        .insert_session(
+            "alpha",
+            SESSION_ALPHA,
+            "Old",
+            "2026-04-24T18:00:00.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_session(
+            "alpha",
+            SESSION_BETA,
+            "New",
+            "2026-04-24T18:01:00.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_session(
+            "beta",
+            SESSION_MISSING,
+            "Hidden",
+            "2026-04-24T18:02:00.000000000Z",
+        )
+        .await;
+
+    let first = fixture
+        .get_json("/api/v1/sessions?limit=1&unknown=value", "alpha-secret")
+        .await;
+    assert_eq!(ids(&first), vec![SESSION_BETA]);
+    let cursor = first["next_cursor"].as_str().expect("next cursor");
+    let second = fixture
+        .get_json(
+            &format!("/api/v1/sessions?limit=1&cursor={cursor}"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(ids(&second), vec![SESSION_ALPHA]);
+    assert_eq!(second["next_cursor"], Value::Null);
+
+    for path in [
+        "/api/v1/sessions?cursor=not-a-cursor",
+        "/api/v1/sessions?limit=0",
+        "/api/v1/sessions?limit=101",
+        "/api/v1/sessions?limit=abc",
+        "/api/v1/sessions?cursor=a&cursor=b",
+        "/api/v1/sessions?limit=1&limit=2",
+    ] {
+        let response = fixture.get(path, "alpha-secret").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
+async fn session_deletion_nulls_voice_notes_without_mutating_replay_tuple() {
+    let fixture = MetadataFixture::new().await;
+    fixture
+        .insert_session(
+            "alpha",
+            SESSION_ALPHA,
+            "Planning",
+            "2026-04-24T18:00:00.000000000Z",
+        )
+        .await;
+    fixture.insert_job_and_voice_note_in_session().await;
+
+    let deleted = fixture
+        .request(
+            "DELETE",
+            &format!("/api/v1/sessions/{SESSION_ALPHA}"),
+            "alpha-secret",
+            None,
+        )
+        .await;
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+
+    let note = fixture
+        .get_json(&format!("/api/v1/voice-notes/{NOTE_ALPHA}"), "alpha-secret")
+        .await;
+    assert_eq!(note["session_id"], Value::Null);
+    let job_session_id: Option<String> = sqlx::query_scalar(
+        "SELECT session_id FROM transcription_jobs WHERE api_key_id = 'alpha' AND id = ?",
+    )
+    .bind(JOB_ALPHA)
+    .fetch_one(fixture.storage.pool())
+    .await
+    .expect("job session lookup");
+    assert_eq!(job_session_id.as_deref(), Some(SESSION_ALPHA));
+}
+
+#[tokio::test]
+async fn metadata_path_validation_precedes_existence_checks() {
+    let fixture = MetadataFixture::new().await;
+
+    for (method, path, body, field) in [
+        ("GET", "/api/v1/tags/not-a-ulid", None, "tag_id"),
+        (
+            "PATCH",
+            "/api/v1/tags/not-a-ulid",
+            Some(json!({"name": "x"})),
+            "tag_id",
+        ),
+        ("DELETE", "/api/v1/tags/not-a-ulid", None, "tag_id"),
+        ("GET", "/api/v1/sessions/not-a-ulid", None, "session_id"),
+        (
+            "PATCH",
+            "/api/v1/sessions/not-a-ulid",
+            Some(json!({"name": "x"})),
+            "session_id",
+        ),
+        ("DELETE", "/api/v1/sessions/not-a-ulid", None, "session_id"),
+    ] {
+        let response = fixture
+            .request(
+                method,
+                path,
+                "alpha-secret",
+                body.map(|value| value.to_string()),
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(json_body(response).await["details"][0]["field"], field);
+    }
+}
+
+#[tokio::test]
+async fn metadata_routes_require_authentication() {
+    let fixture = MetadataFixture::new().await;
+
+    for request in [
+        Request::builder()
+            .uri("/api/v1/tags")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .method("POST")
+            .uri("/api/v1/sessions")
+            .header("Content-Type", "application/json")
+            .body(Body::from(json!({"name": "Planning"}).to_string()))
+            .unwrap(),
+        Request::builder()
+            .uri("/api/v1/sessions")
+            .header("Authorization", "Bearer unknown-secret")
+            .body(Body::empty())
+            .unwrap(),
+    ] {
+        let response = fixture.app().oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+struct MetadataFixture {
+    _tempdir: TempDir,
+    app: axum::Router,
+    storage: Storage,
+}
+
+impl MetadataFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let accepted_audio_dir = tempdir.path().join("accepted-audio");
+        std::fs::create_dir(&accepted_audio_dir).expect("create accepted audio dir");
+        let storage = Storage::connect(&tempdir.path().join("oracy.sqlite"))
+            .await
+            .expect("connect storage");
+        let auth_store = AuthStore::try_from_configs(&[
+            ApiKeyConfig {
+                api_key_id: "alpha".to_owned(),
+                key: "alpha-secret".to_owned(),
+            },
+            ApiKeyConfig {
+                api_key_id: "beta".to_owned(),
+                key: "beta-secret".to_owned(),
+            },
+        ])
+        .expect("auth config");
+        let app = build_router(AppState {
+            accepted_audio_dir,
+            auth_store: Arc::new(auth_store),
+            storage: storage.clone(),
+        });
+
+        Self {
+            _tempdir: tempdir,
+            app,
+            storage,
+        }
+    }
+
+    fn app(&self) -> axum::Router {
+        self.app.clone()
+    }
+
+    async fn get(&self, path: &str, bearer: &str) -> axum::response::Response {
+        self.request("GET", path, bearer, None).await
+    }
+
+    async fn get_json(&self, path: &str, bearer: &str) -> Value {
+        let response = self.get(path, bearer).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        json_body(response).await
+    }
+
+    async fn json_request(
+        &self,
+        method: &str,
+        path: &str,
+        bearer: &str,
+        body: Option<Value>,
+    ) -> JsonResponse {
+        let response = self
+            .request(method, path, bearer, body.map(|value| value.to_string()))
+            .await;
+        let status = response.status();
+        let body = json_body(response).await;
+        JsonResponse { status, body }
+    }
+
+    async fn request(
+        &self,
+        method: &str,
+        path: &str,
+        bearer: &str,
+        body: Option<String>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(path)
+            .header("Authorization", format!("Bearer {bearer}"));
+        let body = match body {
+            Some(body) => {
+                builder = builder.header("Content-Type", "application/json");
+                Body::from(body)
+            }
+            None => Body::empty(),
+        };
+        self.app()
+            .oneshot(builder.body(body).unwrap())
+            .await
+            .expect("response")
+    }
+
+    async fn insert_tag(&self, owner: &str, id: &str, name: &str, created_at: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO tags (id, api_key_id, name, name_folded, created_at)
+            VALUES (?, ?, ?, lower(?), ?)
+            "#,
+        )
+        .bind(id)
+        .bind(owner)
+        .bind(name)
+        .bind(name)
+        .bind(created_at)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert tag");
+    }
+
+    async fn insert_session(&self, owner: &str, id: &str, name: &str, created_at: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO sessions (id, api_key_id, name, created_at)
+            VALUES (?, ?, ?, ?)
+            "#,
+        )
+        .bind(id)
+        .bind(owner)
+        .bind(name)
+        .bind(created_at)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert session");
+    }
+
+    async fn insert_voice_note_with_tag(&self, owner: &str, tag_id: &str) {
+        self.insert_transcript(owner, None).await;
+        sqlx::query(
+            r#"
+            INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+            VALUES (?, ?, ?)
+            "#,
+        )
+        .bind(owner)
+        .bind(NOTE_ALPHA)
+        .bind(tag_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert transcript tag");
+    }
+
+    async fn insert_job_and_voice_note_in_session(&self) {
+        self.insert_transcript("alpha", Some(SESSION_ALPHA)).await;
+        sqlx::query(
+            r#"
+            INSERT INTO transcription_jobs (
+                id, api_key_id, idempotency_key, audio_sha256_hex,
+                audio_content_hash_algorithm, recorded_at, session_id,
+                accepted_audio_path, status, created_at, updated_at,
+                retry_count, max_retries, transcript_id
+            )
+            VALUES (
+                ?, 'alpha', 'attempt-a', 'hash', 'sha256:chunk-sha256-v1',
+                '2026-04-24T17:59:00.000000000Z', ?, '/tmp/audio',
+                'succeeded', '2026-04-24T18:00:00.000000000Z',
+                '2026-04-24T18:00:00.000000000Z', 0, 3, ?
+            )
+            "#,
+        )
+        .bind(JOB_ALPHA)
+        .bind(SESSION_ALPHA)
+        .bind(NOTE_ALPHA)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert job");
+    }
+
+    async fn insert_transcript(&self, owner: &str, session_id: Option<&str>) {
+        sqlx::query(
+            r#"
+            INSERT INTO transcripts (
+                id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+                transcript_language, model, processing_time_ms, cost_cents,
+                created_at, recorded_at, session_id
+            )
+            VALUES (?, ?, 12.5, 'wav', 401280, 'en', 'gpt-4o-mini-transcribe', 1843, NULL, ?, ?, ?)
+            "#,
+        )
+        .bind(NOTE_ALPHA)
+        .bind(owner)
+        .bind("2026-04-24T18:00:00.000000000Z")
+        .bind("2026-04-24T17:59:00.000000000Z")
+        .bind(session_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert transcript");
+
+        sqlx::query(
+            r#"
+            INSERT INTO transcript_versions (
+                id, api_key_id, transcript_id, version_number, transcript, created_at
+            )
+            VALUES (?, ?, ?, 1, 'note text', '2026-04-24T18:00:00.000000000Z')
+            "#,
+        )
+        .bind(VERSION_ALPHA)
+        .bind(owner)
+        .bind(NOTE_ALPHA)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert transcript version");
+    }
+}
+
+async fn json_body(response: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    if bytes.is_empty() {
+        return Value::Null;
+    }
+    serde_json::from_slice(&bytes).expect("valid json")
+}
+
+fn ids(body: &Value) -> Vec<&str> {
+    body["items"]
+        .as_array()
+        .expect("items array")
+        .iter()
+        .map(|item| item["id"].as_str().expect("id"))
+        .collect()
+}

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -722,7 +722,8 @@ async fn completed_job_transcript_link_must_match_the_job_owner() {
 }
 
 #[tokio::test]
-async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcripts() {
+async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many_with_transcripts()
+{
     let (_tempdir, storage) = storage().await;
     insert_transcript_only(&storage, "owner-a", "transcript-a").await;
     insert_transcript_only(&storage, "owner-a", "transcript-b").await;
@@ -745,7 +746,7 @@ async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcript
         other => panic!("expected existing tag, got {other:?}"),
     };
     assert_eq!(replayed.id, meeting.id);
-    assert_eq!(replayed.name, "Meeting");
+    assert_eq!(replayed.name, "meeting");
 
     let other_owner = match storage
         .create_tag(new_tag("owner-b", "tag-meeting-owner-b", "meeting"))
@@ -784,7 +785,7 @@ async fn tags_are_owner_scoped_case_insensitive_and_many_to_many_with_transcript
             .list_transcript_tags("owner-a", "transcript-a")
             .await
             .expect("list transcript tags"),
-        vec![meeting.clone()]
+        vec![replayed.clone()]
     );
 
     assert!(
@@ -831,7 +832,7 @@ async fn unicode_case_equivalent_tag_names_share_one_owner_scoped_identity() {
         };
 
         assert_eq!(replayed.id, created.id);
-        assert_eq!(replayed.name, created_name);
+        assert_eq!(replayed.name, replayed_name);
     }
 }
 

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -523,7 +523,9 @@ Responses:
 Notes:
 
 - Tag identity is case-insensitive within one API-key scope.
-- The returned `Tag.name` preserves the stored spelling.
+- When a duplicate create matches an existing tag case-insensitively,
+  the existing tag keeps its `id` and its stored `name` updates to the
+  spelling supplied by the latest create request.
 
 Response body is a `Tag` resource.
 


### PR DESCRIPTION
## Summary

- Exposes the owner-scoped tag and session CRUD endpoints from the v0.1.0 API contract.
- Adds shared collection query/cursor handling for metadata and existing voice-note listings.
- Clarifies duplicate tag creation so the existing tag keeps its ID while adopting the latest requested spelling.

## Changes

- Adds `/api/v1/tags` and `/api/v1/sessions` list/create/fetch/rename/delete handlers with per-API-key ownership, ULID path validation, cursor pagination, and shared error envelopes.
- Extends storage with tag/session listing, session fetch/rename, and latest-spelling duplicate tag create behavior.
- Adds metadata integration tests for pagination, validation, auth, cross-owner 404s, tag rename conflicts, association visibility, tag deletion cascades, session deletion cascades, and replay tuple preservation.
- Updates `spec/api-contract.md` and `CHANGELOG.md` for the public behavior.

## GitHub Issue(s)

Closes #18

## Test plan

- `cd backend && cargo fmt --check`
- `cd backend && cargo test`
- `cd backend && cargo clippy -- -D warnings`
