### PR TITLE
feat(transcription-jobs): add chunked submission core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Add the authenticated chunked transcription-job open, chunk push, finalize,
+  read, and backend worker flow. Finalized jobs resolve the per-key
+  transcription model, persist accepted audio durably, and materialize
+  successful jobs as voice notes with one coarse segment for v0.1.0 engines.
+- Track the temporary #40/#27 implementation deviation: successful
+  transcription jobs currently materialize voice notes and segments without a
+  current embedding. #27 remains the release-blocking work-unit that restores
+  the spec invariant requiring embeddings before `succeeded`.
 - Add authenticated tag and session management APIs, including owner-scoped
   CRUD, shared cursor pagination, case-insensitive tag identity with
   latest-spelling display updates, and metadata deletion cascades.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +69,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -110,6 +117,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -131,6 +144,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -168,6 +187,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "concurrent-queue"
@@ -292,6 +317,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +362,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -455,8 +495,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -466,9 +508,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -612,6 +656,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -620,13 +681,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -751,6 +820,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +847,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -799,7 +886,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -844,6 +931,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +974,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +992,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -966,11 +1086,13 @@ dependencies = [
  "base64",
  "caseless",
  "form_urlencoded",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
  "sqlx",
  "subtle",
+ "symphonia",
  "tempfile",
  "thiserror",
  "time",
@@ -1110,6 +1232,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1372,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1204,7 +1381,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1223,6 +1400,61 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rsa"
@@ -1245,16 +1477,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1538,7 +1811,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "crc",
@@ -1579,7 +1852,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -1656,6 +1929,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +2056,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1808,6 +2196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +2269,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1948,6 +2364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2384,12 @@ dependencies = [
  "rand 0.9.4",
  "web-time",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -1995,6 +2423,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2031,6 +2465,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2073,6 +2516,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2135,10 +2588,20 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2149,6 +2612,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2173,7 +2645,25 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2191,13 +2681,46 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2207,10 +2730,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2219,10 +2766,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2231,16 +2814,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2318,7 +2937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,15 +7,17 @@ license = "MIT"
 repository = "https://github.com/pentaxis93/oracy"
 
 [dependencies]
-axum = "0.8.9"
+axum = { version = "0.8.9", features = ["multipart"] }
 base64 = "0.22"
 caseless = "0.2.2"
 form_urlencoded = "1.2"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
 subtle = "2.6"
+symphonia = { version = "0.5.5", default-features = false, features = ["aac", "isomp4", "mkv", "mp3", "wav"] }
 thiserror = "2.0"
 time = { version = "0.3.47", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "net"] }

--- a/backend/README.md
+++ b/backend/README.md
@@ -26,3 +26,8 @@ directory.
 Every API route requires `Authorization: Bearer <api_key>`. The bearer scheme is
 case-insensitive, and missing or invalid keys return the shared JSON
 `ErrorResponse` with `401 Unauthorized`.
+
+The backend runs an in-process transcription worker in the service binary. Jobs
+that reach `queued` are claimed with a processing lease, submitted to OpenAI
+using the per-API-key `transcription_model` captured at finalize time, and
+materialized as voice notes when transcription succeeds.

--- a/backend/migrations/20260424000000_create_job_transcript_substrate.sql
+++ b/backend/migrations/20260424000000_create_job_transcript_substrate.sql
@@ -4,12 +4,18 @@ CREATE TABLE transcription_jobs (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
     idempotency_key TEXT NOT NULL,
-    audio_sha256_hex TEXT NOT NULL,
+    audio_sha256_hex TEXT NOT NULL DEFAULT '',
     recorded_at TEXT NOT NULL,
     session_id TEXT,
     language TEXT,
-    accepted_audio_path TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('queued', 'processing', 'retry_waiting', 'succeeded', 'failed')),
+    audio_format TEXT NOT NULL DEFAULT 'wav',
+    chunk_count INTEGER NOT NULL DEFAULT 1 CHECK (chunk_count >= 1 AND chunk_count <= 256),
+    chunks_received INTEGER NOT NULL DEFAULT 0 CHECK (chunks_received >= 0),
+    accepted_audio_path TEXT NOT NULL DEFAULT '',
+    resolved_model TEXT,
+    finalized_at TEXT,
+    processing_lease_expires_at TEXT,
+    status TEXT NOT NULL CHECK (status IN ('accepting_chunks', 'queued', 'processing', 'retry_waiting', 'succeeded', 'failed')),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
@@ -22,7 +28,8 @@ CREATE TABLE transcription_jobs (
             'engine_rate_limited',
             'engine_error',
             'storage_error',
-            'internal_error'
+            'internal_error',
+            'submission_abandoned'
         )
     ),
     failure_message TEXT,
@@ -32,18 +39,41 @@ CREATE TABLE transcription_jobs (
     UNIQUE (api_key_id, idempotency_key)
 );
 
-CREATE INDEX transcription_jobs_owner_id_idx
+CREATE UNIQUE INDEX transcription_jobs_owner_id_idx
     ON transcription_jobs (api_key_id, id);
 
 CREATE INDEX transcription_jobs_ready_idx
     ON transcription_jobs (status, next_attempt_at, created_at, id);
 
 CREATE TRIGGER transcription_jobs_accepted_tuple_immutable
-BEFORE UPDATE OF api_key_id, idempotency_key, audio_sha256_hex, recorded_at, session_id, language
+BEFORE UPDATE OF api_key_id, idempotency_key, audio_sha256_hex, recorded_at, session_id, language, audio_format, chunk_count
 ON transcription_jobs
+WHEN NEW.api_key_id IS NOT OLD.api_key_id
+    OR NEW.idempotency_key IS NOT OLD.idempotency_key
+    OR (OLD.audio_sha256_hex != '' AND NEW.audio_sha256_hex IS NOT OLD.audio_sha256_hex)
+    OR NEW.recorded_at IS NOT OLD.recorded_at
+    OR NEW.session_id IS NOT OLD.session_id
+    OR NEW.language IS NOT OLD.language
+    OR NEW.audio_format IS NOT OLD.audio_format
+    OR NEW.chunk_count IS NOT OLD.chunk_count
 BEGIN
     SELECT RAISE(ABORT, 'accepted submission tuple is immutable');
 END;
+
+CREATE TABLE transcription_job_chunks (
+    job_id TEXT NOT NULL,
+    api_key_id TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL CHECK (chunk_index >= 0),
+    chunk_sha256 TEXT NOT NULL,
+    path TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0),
+    accepted_at TEXT NOT NULL,
+    PRIMARY KEY (job_id, chunk_index),
+    FOREIGN KEY (api_key_id, job_id) REFERENCES transcription_jobs(api_key_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX transcription_job_chunks_order_idx
+    ON transcription_job_chunks (api_key_id, job_id, chunk_index ASC);
 
 CREATE TABLE transcripts (
     id TEXT PRIMARY KEY,

--- a/backend/migrations/20260429000000_pin_audio_content_hash_algorithm.sql
+++ b/backend/migrations/20260429000000_pin_audio_content_hash_algorithm.sql
@@ -5,8 +5,17 @@ ALTER TABLE transcription_jobs
 DROP TRIGGER transcription_jobs_accepted_tuple_immutable;
 
 CREATE TRIGGER transcription_jobs_accepted_tuple_immutable
-BEFORE UPDATE OF api_key_id, idempotency_key, audio_sha256_hex, audio_content_hash_algorithm, recorded_at, session_id, language
+BEFORE UPDATE OF api_key_id, idempotency_key, audio_sha256_hex, audio_content_hash_algorithm, recorded_at, session_id, language, audio_format, chunk_count
 ON transcription_jobs
+WHEN NEW.api_key_id IS NOT OLD.api_key_id
+    OR NEW.idempotency_key IS NOT OLD.idempotency_key
+    OR (OLD.audio_sha256_hex != '' AND NEW.audio_sha256_hex IS NOT OLD.audio_sha256_hex)
+    OR NEW.audio_content_hash_algorithm IS NOT OLD.audio_content_hash_algorithm
+    OR NEW.recorded_at IS NOT OLD.recorded_at
+    OR NEW.session_id IS NOT OLD.session_id
+    OR NEW.language IS NOT OLD.language
+    OR NEW.audio_format IS NOT OLD.audio_format
+    OR NEW.chunk_count IS NOT OLD.chunk_count
 BEGIN
     SELECT RAISE(ABORT, 'accepted submission tuple is immutable');
 END;

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -138,7 +138,7 @@ impl ApiError {
         }
     }
 
-    fn payload_too_large() -> Self {
+    pub fn payload_too_large() -> Self {
         Self {
             status: StatusCode::PAYLOAD_TOO_LARGE,
             body: ErrorResponse {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -12,4 +12,6 @@ pub mod router;
 pub mod settings;
 pub mod state;
 pub mod storage;
+pub mod transcription_jobs;
+pub mod transcription_worker;
 pub mod voice_notes;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,8 @@
 use std::net::SocketAddr;
 
-use oracy_backend::bootstrap::load_runtime_from_env;
+use oracy_backend::bootstrap::{OPENAI_API_KEY_ENV_VAR, load_runtime_from_env};
 use oracy_backend::router::build_router;
+use oracy_backend::transcription_worker::{OpenAiTranscriptionEngine, run_transcription_worker};
 use tracing::error;
 
 #[tokio::main]
@@ -16,6 +17,12 @@ async fn main() {
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let (listen_addr, state) = load_runtime_from_env().await?;
+    let openai_api_key = std::env::var(OPENAI_API_KEY_ENV_VAR)?;
+    let worker_storage = state.storage.clone();
+    tokio::spawn(run_transcription_worker(
+        worker_storage,
+        OpenAiTranscriptionEngine::new(openai_api_key),
+    ));
     serve(listen_addr, build_router(state)).await
 }
 

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -8,6 +8,9 @@ use crate::metadata::{
 };
 use crate::settings::{get_settings, patch_settings};
 use crate::state::AppState;
+use crate::transcription_jobs::{
+    finalize_job, get_transcription_job, open_transcription_job, push_chunk,
+};
 use crate::voice_notes::{
     get_voice_note, list_session_voice_notes, list_voice_note_segments, list_voice_note_versions,
     list_voice_notes,
@@ -16,6 +19,22 @@ use crate::voice_notes::{
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/api/v1/settings", get(get_settings).patch(patch_settings))
+        .route(
+            "/api/v1/transcription-jobs",
+            axum::routing::post(open_transcription_job),
+        )
+        .route(
+            "/api/v1/transcription-jobs/{job_id}",
+            get(get_transcription_job),
+        )
+        .route(
+            "/api/v1/transcription-jobs/{job_id}/chunks",
+            axum::routing::post(push_chunk),
+        )
+        .route(
+            "/api/v1/transcription-jobs/{job_id}/finalize",
+            axum::routing::post(finalize_job),
+        )
         .route("/api/v1/tags", get(list_tags).post(create_tag))
         .route(
             "/api/v1/tags/{tag_id}",

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -76,6 +76,24 @@ pub enum AcceptJobOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PushChunkOutcome {
+    Accepted,
+    Replayed,
+    NotFound,
+    Conflict,
+    InvalidIndex,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinalizeJobOutcome {
+    Finalized(TranscriptionJobRecord),
+    Replayed(TranscriptionJobRecord),
+    NotFound,
+    Conflict,
+    MissingChunks,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CreateTagOutcome {
     Created(TagRecord),
     Existing(TagRecord),
@@ -124,6 +142,40 @@ pub struct NewTranscriptionJob {
 }
 
 #[derive(Debug, Clone)]
+pub struct NewOpenTranscriptionJob {
+    pub api_key_id: String,
+    pub idempotency_key: String,
+    pub recorded_at: OffsetDateTime,
+    pub session_id: Option<String>,
+    pub language: Option<String>,
+    pub audio_format: String,
+    pub chunk_count: i64,
+    pub max_retries: i64,
+    pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct AcceptedChunk {
+    pub api_key_id: String,
+    pub job_id: String,
+    pub chunk_index: i64,
+    pub chunk_sha256: String,
+    pub path: PathBuf,
+    pub size_bytes: i64,
+    pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct FinalizedJob {
+    pub api_key_id: String,
+    pub job_id: String,
+    pub audio_sha256_hex: String,
+    pub accepted_audio_path: PathBuf,
+    pub resolved_model: String,
+    pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
 pub struct NewTag {
     pub id: String,
     pub api_key_id: String,
@@ -149,7 +201,13 @@ pub struct TranscriptionJobRecord {
     pub recorded_at: OffsetDateTime,
     pub session_id: Option<String>,
     pub language: Option<String>,
+    pub audio_format: String,
+    pub chunk_count: i64,
+    pub chunks_received: i64,
     pub accepted_audio_path: PathBuf,
+    pub resolved_model: Option<String>,
+    pub finalized_at: Option<OffsetDateTime>,
+    pub processing_lease_expires_at: Option<OffsetDateTime>,
     pub status: String,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
@@ -451,6 +509,315 @@ impl Storage {
         }
     }
 
+    pub async fn open_transcription_job(
+        &self,
+        input: NewOpenTranscriptionJob,
+    ) -> Result<AcceptJobOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let id = new_id();
+        let now = format_timestamp(input.now)?;
+        let recorded_at = format_timestamp(input.recorded_at)?;
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO transcription_jobs (
+                id, api_key_id, idempotency_key, audio_sha256_hex,
+                audio_content_hash_algorithm, recorded_at, session_id, language,
+                audio_format, chunk_count, chunks_received, accepted_audio_path,
+                status, created_at, updated_at, retry_count, max_retries
+            )
+            SELECT ?, ?, ?, '', ?, ?, ?, ?, ?, ?, 0, '', 'accepting_chunks', ?, ?, 0, ?
+            WHERE ? IS NULL
+                OR EXISTS (
+                    SELECT 1 FROM sessions
+                    WHERE api_key_id = ? AND id = ?
+                )
+            ON CONFLICT(api_key_id, idempotency_key) DO NOTHING
+            "#,
+        )
+        .bind(&id)
+        .bind(&input.api_key_id)
+        .bind(&input.idempotency_key)
+        .bind(AUDIO_CONTENT_HASH_ALGORITHM_ID)
+        .bind(recorded_at)
+        .bind(&input.session_id)
+        .bind(&input.language)
+        .bind(&input.audio_format)
+        .bind(input.chunk_count)
+        .bind(&now)
+        .bind(&now)
+        .bind(input.max_retries)
+        .bind(&input.session_id)
+        .bind(&input.api_key_id)
+        .bind(&input.session_id)
+        .execute(&mut *tx)
+        .await?;
+
+        let job = if result.rows_affected() == 1 {
+            let row = sqlx::query(
+                r#"
+                SELECT * FROM transcription_jobs
+                WHERE api_key_id = ? AND id = ?
+                "#,
+            )
+            .bind(&input.api_key_id)
+            .bind(&id)
+            .fetch_one(&mut *tx)
+            .await?;
+            job_from_row(row)?
+        } else {
+            let row = sqlx::query(
+                r#"
+                SELECT * FROM transcription_jobs
+                WHERE api_key_id = ? AND idempotency_key = ?
+                "#,
+            )
+            .bind(&input.api_key_id)
+            .bind(&input.idempotency_key)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(job_from_row)
+            .transpose()?;
+            match row {
+                Some(job) => job,
+                None => {
+                    tx.commit().await?;
+                    return Ok(AcceptJobOutcome::SessionNotFound);
+                }
+            }
+        };
+        tx.commit().await?;
+
+        if result.rows_affected() == 1 {
+            Ok(AcceptJobOutcome::Created(job))
+        } else if job.matches_open_submission(&input) {
+            Ok(AcceptJobOutcome::Replayed(job))
+        } else {
+            Ok(AcceptJobOutcome::Conflict(SubmissionConflict {
+                job_id: job.id,
+            }))
+        }
+    }
+
+    pub async fn accept_chunk(
+        &self,
+        input: AcceptedChunk,
+    ) -> Result<PushChunkOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let Some(job) = sqlx::query(
+            r#"
+            SELECT * FROM transcription_jobs
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(&input.api_key_id)
+        .bind(&input.job_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(job_from_row)
+        .transpose()?
+        else {
+            tx.commit().await?;
+            return Ok(PushChunkOutcome::NotFound);
+        };
+
+        if job.status != "accepting_chunks" {
+            tx.commit().await?;
+            return Ok(PushChunkOutcome::Conflict);
+        }
+        if input.chunk_index < 0 || input.chunk_index >= job.chunk_count {
+            tx.commit().await?;
+            return Ok(PushChunkOutcome::InvalidIndex);
+        }
+
+        let existing = sqlx::query(
+            r#"
+            SELECT chunk_sha256
+            FROM transcription_job_chunks
+            WHERE api_key_id = ? AND job_id = ? AND chunk_index = ?
+            "#,
+        )
+        .bind(&input.api_key_id)
+        .bind(&input.job_id)
+        .bind(input.chunk_index)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some(row) = existing {
+            let existing_hash: String = row.try_get("chunk_sha256")?;
+            tx.commit().await?;
+            return if existing_hash == input.chunk_sha256 {
+                Ok(PushChunkOutcome::Replayed)
+            } else {
+                Ok(PushChunkOutcome::Conflict)
+            };
+        }
+
+        let path = input.path.to_string_lossy().into_owned();
+        let now = format_timestamp(input.now)?;
+        sqlx::query(
+            r#"
+            INSERT INTO transcription_job_chunks (
+                job_id, api_key_id, chunk_index, chunk_sha256, path, size_bytes, accepted_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&input.job_id)
+        .bind(&input.api_key_id)
+        .bind(input.chunk_index)
+        .bind(&input.chunk_sha256)
+        .bind(path)
+        .bind(input.size_bytes)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET chunks_received = chunks_received + 1, updated_at = ?
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(&now)
+        .bind(&input.api_key_id)
+        .bind(&input.job_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(PushChunkOutcome::Accepted)
+    }
+
+    pub async fn chunk_hashes_in_order(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT chunk_sha256
+            FROM transcription_job_chunks
+            WHERE api_key_id = ? AND job_id = ?
+            ORDER BY chunk_index ASC
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| row.try_get("chunk_sha256").map_err(StorageError::from))
+            .collect()
+    }
+
+    pub async fn chunk_paths_in_order(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+    ) -> Result<Vec<PathBuf>, StorageError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT path
+            FROM transcription_job_chunks
+            WHERE api_key_id = ? AND job_id = ?
+            ORDER BY chunk_index ASC
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                row.try_get::<String, _>("path")
+                    .map(PathBuf::from)
+                    .map_err(StorageError::from)
+            })
+            .collect()
+    }
+
+    pub async fn finalize_job(
+        &self,
+        input: FinalizedJob,
+    ) -> Result<FinalizeJobOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let Some(job) = sqlx::query(
+            r#"
+            SELECT * FROM transcription_jobs
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(&input.api_key_id)
+        .bind(&input.job_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(job_from_row)
+        .transpose()?
+        else {
+            tx.commit().await?;
+            return Ok(FinalizeJobOutcome::NotFound);
+        };
+
+        if job.status != "accepting_chunks" {
+            tx.commit().await?;
+            return if job.accepted_audio_path.as_os_str().is_empty() {
+                Ok(FinalizeJobOutcome::Conflict)
+            } else {
+                Ok(FinalizeJobOutcome::Replayed(job))
+            };
+        }
+        if job.chunks_received != job.chunk_count {
+            tx.commit().await?;
+            return Ok(FinalizeJobOutcome::MissingChunks);
+        }
+
+        let accepted_audio_path = input.accepted_audio_path.to_string_lossy().into_owned();
+        let now = format_timestamp(input.now)?;
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET audio_sha256_hex = ?,
+                accepted_audio_path = ?,
+                resolved_model = ?,
+                finalized_at = ?,
+                status = 'queued',
+                updated_at = ?
+            WHERE api_key_id = ? AND id = ? AND status = 'accepting_chunks'
+            "#,
+        )
+        .bind(&input.audio_sha256_hex)
+        .bind(accepted_audio_path)
+        .bind(&input.resolved_model)
+        .bind(&now)
+        .bind(&now)
+        .bind(&input.api_key_id)
+        .bind(&input.job_id)
+        .execute(&mut *tx)
+        .await?;
+        if result.rows_affected() != 1 {
+            tx.commit().await?;
+            return Ok(FinalizeJobOutcome::Conflict);
+        }
+
+        let row = sqlx::query(
+            r#"
+            SELECT * FROM transcription_jobs
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(&input.api_key_id)
+        .bind(&input.job_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let job = job_from_row(row)?;
+
+        tx.commit().await?;
+        Ok(FinalizeJobOutcome::Finalized(job))
+    }
+
     pub async fn find_job_by_idempotency_key(
         &self,
         api_key_id: &str,
@@ -487,6 +854,119 @@ impl Storage {
         .await?;
 
         row.map(job_from_row).transpose()
+    }
+
+    pub async fn claim_next_transcription_job(
+        &self,
+        now: OffsetDateTime,
+        lease_expires_at: OffsetDateTime,
+    ) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+        let now = format_timestamp(now)?;
+        let lease_expires_at = format_timestamp(lease_expires_at)?;
+        let row = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'processing',
+                processing_lease_expires_at = ?,
+                next_attempt_at = NULL,
+                updated_at = ?
+            WHERE id = (
+                SELECT id
+                FROM transcription_jobs
+                WHERE status = 'queued'
+                    OR (status = 'retry_waiting' AND next_attempt_at <= ?)
+                    OR (status = 'processing' AND processing_lease_expires_at <= ?)
+                ORDER BY created_at ASC, id ASC
+                LIMIT 1
+            )
+            RETURNING *
+            "#,
+        )
+        .bind(&lease_expires_at)
+        .bind(&now)
+        .bind(&now)
+        .bind(&now)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(job_from_row).transpose()
+    }
+
+    pub async fn record_transient_engine_failure(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        now: OffsetDateTime,
+        next_attempt_at: OffsetDateTime,
+    ) -> Result<(), StorageError> {
+        let now = format_timestamp(now)?;
+        let next_attempt_at = format_timestamp(next_attempt_at)?;
+        sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = CASE
+                    WHEN retry_count + 1 < max_retries THEN 'retry_waiting'
+                    ELSE 'failed'
+                END,
+                retry_count = retry_count + 1,
+                next_attempt_at = CASE
+                    WHEN retry_count + 1 < max_retries THEN ?
+                    ELSE NULL
+                END,
+                processing_lease_expires_at = NULL,
+                failure_code = CASE
+                    WHEN retry_count + 1 < max_retries THEN NULL
+                    ELSE 'engine_error'
+                END,
+                failure_message = CASE
+                    WHEN retry_count + 1 < max_retries THEN NULL
+                    ELSE 'Transcription engine failed after backend retries.'
+                END,
+                retryable_by_client = CASE
+                    WHEN retry_count + 1 < max_retries THEN NULL
+                    ELSE 1
+                END,
+                updated_at = ?
+            WHERE api_key_id = ? AND id = ? AND status = 'processing'
+            "#,
+        )
+        .bind(&next_attempt_at)
+        .bind(&now)
+        .bind(api_key_id)
+        .bind(job_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn record_terminal_engine_failure(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        now: OffsetDateTime,
+    ) -> Result<(), StorageError> {
+        let now = format_timestamp(now)?;
+        sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'failed',
+                next_attempt_at = NULL,
+                processing_lease_expires_at = NULL,
+                failure_code = 'audio_invalid',
+                failure_message = 'Transcription engine rejected the submitted audio.',
+                retryable_by_client = 0,
+                updated_at = ?
+            WHERE api_key_id = ? AND id = ? AND status = 'processing'
+            "#,
+        )
+        .bind(&now)
+        .bind(api_key_id)
+        .bind(job_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
     }
 
     pub async fn complete_job_with_transcript(
@@ -599,19 +1079,21 @@ impl Storage {
             .await?;
         }
 
-        sqlx::query(
-            r#"
-            INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
-            VALUES (?, ?, ?, ?, ?)
-            "#,
-        )
-        .bind(&transcript.id)
-        .bind(api_key_id)
-        .bind(&materialization.embedding.model)
-        .bind(&materialization.embedding.vector)
-        .bind(format_timestamp(materialization.embedding.created_at)?)
-        .execute(&mut *tx)
-        .await?;
+        if !materialization.embedding.vector.is_empty() {
+            sqlx::query(
+                r#"
+                INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(&transcript.id)
+            .bind(api_key_id)
+            .bind(&materialization.embedding.model)
+            .bind(&materialization.embedding.vector)
+            .bind(format_timestamp(materialization.embedding.created_at)?)
+            .execute(&mut *tx)
+            .await?;
+        }
 
         let result = sqlx::query(
             r#"
@@ -1454,6 +1936,14 @@ impl TranscriptionJobRecord {
             && self.session_id == input.session_id
             && self.language == input.language
     }
+
+    fn matches_open_submission(&self, input: &NewOpenTranscriptionJob) -> bool {
+        self.recorded_at == input.recorded_at
+            && self.session_id == input.session_id
+            && self.language == input.language
+            && self.audio_format == input.audio_format
+            && self.chunk_count == input.chunk_count
+    }
 }
 
 fn validate_database_path(database_path: &Path) -> Result<(), StorageError> {
@@ -1554,7 +2044,19 @@ fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, 
         recorded_at: parse_timestamp(row.try_get("recorded_at")?)?,
         session_id: row.try_get("session_id")?,
         language: row.try_get("language")?,
+        audio_format: row.try_get("audio_format")?,
+        chunk_count: row.try_get("chunk_count")?,
+        chunks_received: row.try_get("chunks_received")?,
         accepted_audio_path: PathBuf::from(row.try_get::<String, _>("accepted_audio_path")?),
+        resolved_model: row.try_get("resolved_model")?,
+        finalized_at: row
+            .try_get::<Option<String>, _>("finalized_at")?
+            .map(parse_timestamp)
+            .transpose()?,
+        processing_lease_expires_at: row
+            .try_get::<Option<String>, _>("processing_lease_expires_at")?
+            .map(parse_timestamp)
+            .transpose()?,
         status: row.try_get("status")?,
         created_at: parse_timestamp(row.try_get("created_at")?)?,
         updated_at: parse_timestamp(row.try_get("updated_at")?)?,

--- a/backend/src/transcription_jobs.rs
+++ b/backend/src/transcription_jobs.rs
@@ -1,0 +1,497 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use axum::Json;
+use axum::extract::{Multipart, Path as AxumPath, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+use ulid::Ulid;
+
+use crate::audio_hash::compose_audio_content_hash_hex;
+use crate::auth::AuthenticatedKey;
+use crate::collections::{parse_rfc3339_field, timestamp, validate_ulid_field};
+use crate::errors::{ApiError, ErrorDetail};
+use crate::json::JsonBody;
+use crate::state::AppState;
+use crate::storage::{
+    AcceptJobOutcome, AcceptedChunk, FinalizeJobOutcome, FinalizedJob, NewOpenTranscriptionJob,
+    PushChunkOutcome, TranscriptionJobRecord,
+};
+
+const MAX_CHUNK_BYTES: usize = 26_214_400;
+const MAX_RETRIES: i64 = 3;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TranscriptionJobResource {
+    id: String,
+    status: String,
+    created_at: String,
+    updated_at: String,
+    chunk_count: i64,
+    chunks_received: i64,
+    retry_count: i64,
+    max_retries: i64,
+    next_attempt_at: Option<String>,
+    failure_code: Option<String>,
+    failure_message: Option<String>,
+    retryable_by_client: Option<bool>,
+    voice_note_id: Option<String>,
+}
+
+pub async fn open_transcription_job(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    JsonBody(body): JsonBody<Value>,
+) -> Result<Response, ApiError> {
+    let idempotency_key = parse_idempotency_key(&headers)?;
+    let request = parse_open_body(body)?;
+    let outcome = state
+        .storage
+        .open_transcription_job(NewOpenTranscriptionJob {
+            api_key_id: authenticated_key.api_key_id.as_str().to_owned(),
+            idempotency_key,
+            recorded_at: request.recorded_at,
+            session_id: request.session_id,
+            language: request.language,
+            audio_format: request.audio_format,
+            chunk_count: request.chunk_count,
+            max_retries: MAX_RETRIES,
+            now: OffsetDateTime::now_utc(),
+        })
+        .await
+        .map_err(|_| ApiError::internal("Failed to open transcription job."))?;
+
+    match outcome {
+        AcceptJobOutcome::Created(job) => job_response(StatusCode::CREATED, job),
+        AcceptJobOutcome::Replayed(job) => {
+            let status = if job.status == "accepting_chunks" {
+                StatusCode::CREATED
+            } else {
+                StatusCode::OK
+            };
+            job_response(status, job)
+        }
+        AcceptJobOutcome::Conflict(_) => Err(ApiError::conflict(
+            "Idempotency key conflicts with an existing submission attempt.",
+            None,
+        )),
+        AcceptJobOutcome::SessionNotFound => Err(ApiError::not_found("Session not found.")),
+    }
+}
+
+pub async fn push_chunk(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    AxumPath(job_id): AxumPath<String>,
+    multipart: Multipart,
+) -> Result<StatusCode, ApiError> {
+    validate_ulid_field("job_id", &job_id)?;
+    let chunk = parse_chunk_multipart(multipart).await?;
+    if chunk.bytes.len() > MAX_CHUNK_BYTES {
+        return Err(ApiError::payload_too_large());
+    }
+    let actual_hash = sha256_hex(&chunk.bytes);
+    if actual_hash != chunk.chunk_sha256 {
+        return Err(validation_error(
+            "chunk_sha256",
+            "Must match the SHA-256 of the uploaded chunk bytes.",
+        ));
+    }
+    let Some(job) = state
+        .storage
+        .get_job(authenticated_key.api_key_id.as_str(), &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load transcription job."))?
+    else {
+        return Err(ApiError::not_found("Transcription job not found."));
+    };
+    if job.status != "accepting_chunks" {
+        return Err(ApiError::conflict(
+            "Chunk cannot be accepted for this transcription job.",
+            None,
+        ));
+    }
+    if chunk.chunk_index < 0 || chunk.chunk_index >= job.chunk_count {
+        return Err(validation_error(
+            "chunk_index",
+            "Must be within the declared chunk range.",
+        ));
+    }
+
+    let chunk_path = state
+        .accepted_audio_dir
+        .join(&job_id)
+        .join("chunks")
+        .join(format!("{:06}.chunk", chunk.chunk_index));
+    durable_write(&chunk_path, &chunk.bytes)
+        .map_err(|_| ApiError::internal("Failed to persist audio chunk."))?;
+
+    let outcome = state
+        .storage
+        .accept_chunk(AcceptedChunk {
+            api_key_id: authenticated_key.api_key_id.as_str().to_owned(),
+            job_id,
+            chunk_index: chunk.chunk_index,
+            chunk_sha256: chunk.chunk_sha256,
+            path: chunk_path,
+            size_bytes: chunk.bytes.len() as i64,
+            now: OffsetDateTime::now_utc(),
+        })
+        .await
+        .map_err(|_| ApiError::internal("Failed to accept audio chunk."))?;
+
+    match outcome {
+        PushChunkOutcome::Accepted | PushChunkOutcome::Replayed => Ok(StatusCode::NO_CONTENT),
+        PushChunkOutcome::NotFound => Err(ApiError::not_found("Transcription job not found.")),
+        PushChunkOutcome::Conflict => Err(ApiError::conflict(
+            "Chunk cannot be accepted for this transcription job.",
+            None,
+        )),
+        PushChunkOutcome::InvalidIndex => Err(validation_error(
+            "chunk_index",
+            "Must be within the declared chunk range.",
+        )),
+    }
+}
+
+pub async fn finalize_job(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    AxumPath(job_id): AxumPath<String>,
+) -> Result<Response, ApiError> {
+    validate_ulid_field("job_id", &job_id)?;
+    let Some(job) = state
+        .storage
+        .get_job(authenticated_key.api_key_id.as_str(), &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load transcription job."))?
+    else {
+        return Err(ApiError::not_found("Transcription job not found."));
+    };
+    if job.status != "accepting_chunks" {
+        if job.accepted_audio_path.as_os_str().is_empty() {
+            return Err(ApiError::conflict(
+                "Transcription job is not accepting chunks.",
+                None,
+            ));
+        }
+        return job_response(StatusCode::OK, job);
+    }
+    if job.chunks_received != job.chunk_count {
+        return Err(ApiError::conflict(
+            "Every declared chunk must be accepted before finalize.",
+            None,
+        ));
+    }
+
+    let chunk_hashes = state
+        .storage
+        .chunk_hashes_in_order(authenticated_key.api_key_id.as_str(), &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load accepted chunks."))?;
+    if chunk_hashes.len() != job.chunk_count as usize {
+        return Err(ApiError::conflict(
+            "Every declared chunk must be accepted before finalize.",
+            None,
+        ));
+    }
+    let audio_sha256_hex = compose_audio_content_hash_hex(chunk_hashes)
+        .map_err(|_| ApiError::internal("Failed to compose audio content hash."))?;
+
+    let chunk_paths = state
+        .storage
+        .chunk_paths_in_order(authenticated_key.api_key_id.as_str(), &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load accepted chunks."))?;
+    let composed_path = state
+        .accepted_audio_dir
+        .join(&job_id)
+        .join(format!("accepted.{}", job.audio_format));
+    compose_chunks(&composed_path, &chunk_paths)
+        .map_err(|_| ApiError::internal("Failed to persist accepted audio."))?;
+
+    let settings = state
+        .storage
+        .get_settings(authenticated_key.api_key_id.as_str())
+        .await
+        .map_err(|_| ApiError::internal("Failed to load settings."))?;
+
+    let outcome = state
+        .storage
+        .finalize_job(FinalizedJob {
+            api_key_id: authenticated_key.api_key_id.as_str().to_owned(),
+            job_id,
+            audio_sha256_hex,
+            accepted_audio_path: composed_path,
+            resolved_model: settings.transcription_model,
+            now: OffsetDateTime::now_utc(),
+        })
+        .await
+        .map_err(|_| ApiError::internal("Failed to finalize transcription job."))?;
+
+    match outcome {
+        FinalizeJobOutcome::Finalized(job) => job_response(StatusCode::ACCEPTED, job),
+        FinalizeJobOutcome::Replayed(job) => job_response(StatusCode::OK, job),
+        FinalizeJobOutcome::NotFound => Err(ApiError::not_found("Transcription job not found.")),
+        FinalizeJobOutcome::Conflict | FinalizeJobOutcome::MissingChunks => Err(
+            ApiError::conflict("Transcription job cannot be finalized.", None),
+        ),
+    }
+}
+
+pub async fn get_transcription_job(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    AxumPath(job_id): AxumPath<String>,
+) -> Result<Json<TranscriptionJobResource>, ApiError> {
+    validate_ulid_field("job_id", &job_id)?;
+    let Some(job) = state
+        .storage
+        .get_job(authenticated_key.api_key_id.as_str(), &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load transcription job."))?
+    else {
+        return Err(ApiError::not_found("Transcription job not found."));
+    };
+
+    Ok(Json(transcription_job_resource(job)?))
+}
+
+fn job_response(status: StatusCode, job: TranscriptionJobRecord) -> Result<Response, ApiError> {
+    Ok((status, Json(transcription_job_resource(job)?)).into_response())
+}
+
+fn transcription_job_resource(
+    job: TranscriptionJobRecord,
+) -> Result<TranscriptionJobResource, ApiError> {
+    Ok(TranscriptionJobResource {
+        id: job.id,
+        status: job.status,
+        created_at: timestamp(job.created_at)?,
+        updated_at: timestamp(job.updated_at)?,
+        chunk_count: job.chunk_count,
+        chunks_received: job.chunks_received,
+        retry_count: job.retry_count,
+        max_retries: job.max_retries,
+        next_attempt_at: job.next_attempt_at.map(timestamp).transpose()?,
+        failure_code: job.failure_code,
+        failure_message: job.failure_message,
+        retryable_by_client: job.retryable_by_client,
+        voice_note_id: job.transcript_id,
+    })
+}
+
+#[derive(Debug)]
+struct OpenJobRequest {
+    recorded_at: OffsetDateTime,
+    chunk_count: i64,
+    audio_format: String,
+    session_id: Option<String>,
+    language: Option<String>,
+}
+
+#[derive(Debug)]
+struct ParsedChunk {
+    chunk_index: i64,
+    chunk_sha256: String,
+    bytes: Vec<u8>,
+}
+
+fn parse_open_body(body: Value) -> Result<OpenJobRequest, ApiError> {
+    let Value::Object(mut fields) = body else {
+        return Err(validation_error("", "Request body must be a JSON object."));
+    };
+    let recorded_at = take_string(&mut fields, "recorded_at")
+        .and_then(|value| parse_rfc3339_field("recorded_at", &value))?;
+    let chunk_count = fields
+        .remove("chunk_count")
+        .and_then(|value| value.as_i64())
+        .ok_or_else(|| validation_error("chunk_count", "Must be an integer in 1..256."))?;
+    if !(1..=256).contains(&chunk_count) {
+        return Err(validation_error(
+            "chunk_count",
+            "Must be an integer in 1..256.",
+        ));
+    }
+    let audio_format = take_string(&mut fields, "audio_format")?;
+    if !["m4a", "mp3", "wav", "webm"].contains(&audio_format.as_str()) {
+        return Err(validation_error(
+            "audio_format",
+            "Must be a supported audio format.",
+        ));
+    }
+    let session_id = take_optional_string(&mut fields, "session_id")?;
+    if let Some(session_id) = &session_id {
+        validate_ulid_field("session_id", session_id)?;
+    }
+    let language = take_optional_string(&mut fields, "language")?;
+    if let Some(language) = &language {
+        if language.len() != 2 || !language.bytes().all(|byte| byte.is_ascii_lowercase()) {
+            return Err(validation_error(
+                "language",
+                "Must be a lowercase ISO 639-1 language code.",
+            ));
+        }
+    }
+
+    Ok(OpenJobRequest {
+        recorded_at,
+        chunk_count,
+        audio_format,
+        session_id,
+        language,
+    })
+}
+
+async fn parse_chunk_multipart(mut multipart: Multipart) -> Result<ParsedChunk, ApiError> {
+    let mut chunk_index = None;
+    let mut chunk_sha256 = None;
+    let mut bytes = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|_| validation_error("", "Malformed multipart body."))?
+    {
+        let Some(name) = field.name().map(str::to_owned) else {
+            continue;
+        };
+        match name.as_str() {
+            "chunk_index" => {
+                let value = field
+                    .text()
+                    .await
+                    .map_err(|_| validation_error("chunk_index", "Must be an integer."))?;
+                let parsed = value
+                    .parse::<i64>()
+                    .map_err(|_| validation_error("chunk_index", "Must be an integer."))?;
+                chunk_index = Some(parsed);
+            }
+            "chunk_sha256" => {
+                let value = field.text().await.map_err(|_| {
+                    validation_error("chunk_sha256", "Must be lowercase SHA-256 hex.")
+                })?;
+                if value.len() != 64
+                    || !value
+                        .bytes()
+                        .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+                {
+                    return Err(validation_error(
+                        "chunk_sha256",
+                        "Must be lowercase SHA-256 hex.",
+                    ));
+                }
+                chunk_sha256 = Some(value);
+            }
+            "file" => {
+                let value = field
+                    .bytes()
+                    .await
+                    .map_err(|_| validation_error("file", "Failed to read uploaded chunk."))?;
+                bytes = Some(value.to_vec());
+            }
+            _ => {}
+        }
+    }
+
+    Ok(ParsedChunk {
+        chunk_index: chunk_index
+            .ok_or_else(|| validation_error("chunk_index", "Field is required."))?,
+        chunk_sha256: chunk_sha256
+            .ok_or_else(|| validation_error("chunk_sha256", "Field is required."))?,
+        bytes: bytes.ok_or_else(|| validation_error("file", "Field is required."))?,
+    })
+}
+
+fn parse_idempotency_key(headers: &HeaderMap) -> Result<String, ApiError> {
+    let value = headers
+        .get("Idempotency-Key")
+        .ok_or_else(|| validation_error("Idempotency-Key", "Header is required."))?
+        .to_str()
+        .map_err(|_| validation_error("Idempotency-Key", "Header is malformed."))?;
+    if value.is_empty()
+        || value.len() > 256
+        || !value.bytes().all(|byte| matches!(byte, 0x21..=0x7e))
+    {
+        return Err(validation_error("Idempotency-Key", "Header is malformed."));
+    }
+
+    Ok(value.to_owned())
+}
+
+fn take_string(
+    fields: &mut serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<String, ApiError> {
+    fields
+        .remove(field)
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .ok_or_else(|| validation_error(field, "Field is required."))
+}
+
+fn take_optional_string(
+    fields: &mut serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<Option<String>, ApiError> {
+    fields
+        .remove(field)
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_owned)
+                .ok_or_else(|| validation_error(field, "Must be a string."))
+        })
+        .transpose()
+}
+
+fn validation_error(field: &str, message: &str) -> ApiError {
+    ApiError::validation(
+        "One or more request fields are invalid.",
+        Some(vec![ErrorDetail {
+            field: field.to_owned(),
+            message: message.to_owned(),
+        }]),
+    )
+}
+
+fn compose_chunks(target: &Path, chunk_paths: &[PathBuf]) -> std::io::Result<()> {
+    let mut bytes = Vec::new();
+    for chunk_path in chunk_paths {
+        bytes.extend_from_slice(&fs::read(chunk_path)?);
+    }
+    durable_write(target, &bytes)
+}
+
+fn durable_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = target
+        .parent()
+        .expect("durable write target should have parent");
+    fs::create_dir_all(parent)?;
+    let temp_path = parent.join(format!(".{}.tmp", Ulid::new()));
+    {
+        let mut file = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp_path)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+    fs::rename(&temp_path, target)?;
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        output.push_str(&format!("{byte:02x}"));
+    }
+    output
+}

--- a/backend/src/transcription_worker.rs
+++ b/backend/src/transcription_worker.rs
@@ -1,0 +1,289 @@
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::time::Duration as StdDuration;
+
+use serde::Deserialize;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+use thiserror::Error;
+use time::{Duration, OffsetDateTime};
+use ulid::Ulid;
+
+use crate::storage::{
+    NewEmbedding, NewSegment, NewTranscript, NewTranscriptVersion, Storage, StorageError,
+    TranscriptMaterialization,
+};
+
+const PROCESSING_LEASE: Duration = Duration::minutes(30);
+const FIRST_RETRY_DELAY: Duration = Duration::seconds(30);
+
+pub trait TranscriptionEngine {
+    fn transcribe(
+        &self,
+        input: TranscriptionInput<'_>,
+    ) -> Result<TranscriptionOutput, TranscriptionEngineError>;
+}
+
+pub struct TranscriptionInput<'a> {
+    pub audio_path: &'a Path,
+    pub model: &'a str,
+    pub language: Option<&'a str>,
+}
+
+pub struct TranscriptionOutput {
+    pub text: String,
+    pub model: String,
+    pub processing_time_ms: i64,
+    pub cost_cents: Option<i64>,
+}
+
+pub struct OpenAiTranscriptionEngine {
+    api_key: String,
+    client: reqwest::blocking::Client,
+}
+
+#[derive(Debug, Error)]
+pub enum TranscriptionEngineError {
+    #[error("transient transcription engine failure")]
+    Transient,
+    #[error("terminal transcription engine failure")]
+    Terminal,
+}
+
+impl OpenAiTranscriptionEngine {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            client: reqwest::blocking::Client::new(),
+        }
+    }
+}
+
+impl TranscriptionEngine for OpenAiTranscriptionEngine {
+    fn transcribe(
+        &self,
+        input: TranscriptionInput<'_>,
+    ) -> Result<TranscriptionOutput, TranscriptionEngineError> {
+        let file = std::fs::File::open(input.audio_path)
+            .map_err(|_| TranscriptionEngineError::Terminal)?;
+        let file_part = reqwest::blocking::multipart::Part::reader(file)
+            .file_name("audio")
+            .mime_str("application/octet-stream")
+            .map_err(|_| TranscriptionEngineError::Terminal)?;
+        let mut form = reqwest::blocking::multipart::Form::new()
+            .text("model", input.model.to_owned())
+            .text("response_format", "json")
+            .part("file", file_part);
+        if let Some(language) = input.language {
+            form = form.text("language", language.to_owned());
+        }
+
+        let response = self
+            .client
+            .post("https://api.openai.com/v1/audio/transcriptions")
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .map_err(|_| TranscriptionEngineError::Transient)?;
+        let status = response.status();
+        if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(TranscriptionEngineError::Transient);
+        }
+        if !status.is_success() {
+            return Err(TranscriptionEngineError::Terminal);
+        }
+        let body: OpenAiTranscriptionResponse = response
+            .json()
+            .map_err(|_| TranscriptionEngineError::Terminal)?;
+
+        Ok(TranscriptionOutput {
+            text: body.text,
+            model: input.model.to_owned(),
+            processing_time_ms: 0,
+            cost_cents: None,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiTranscriptionResponse {
+    text: String,
+}
+
+#[derive(Debug, Error)]
+pub enum TranscriptionWorkerError {
+    #[error("{0}")]
+    Storage(#[from] StorageError),
+    #[error("queued job has no resolved model: {0}")]
+    MissingResolvedModel(String),
+    #[error("queued job has no accepted audio path: {0}")]
+    MissingAcceptedAudioPath(String),
+    #[error("failed to inspect audio duration for {path}: {source}")]
+    AudioDuration {
+        path: PathBuf,
+        #[source]
+        source: AudioDurationError,
+    },
+    #[error("{0}")]
+    Engine(#[from] TranscriptionEngineError),
+}
+
+#[derive(Debug, Error)]
+pub enum AudioDurationError {
+    #[error("audio file could not be opened: {0}")]
+    Open(#[from] std::io::Error),
+    #[error("audio format could not be probed: {0}")]
+    Probe(#[from] symphonia::core::errors::Error),
+    #[error("audio track is missing duration metadata")]
+    MissingDuration,
+}
+
+pub async fn process_one_queued_job(
+    storage: &Storage,
+    engine: &impl TranscriptionEngine,
+    now: OffsetDateTime,
+) -> Result<bool, TranscriptionWorkerError> {
+    let Some(job) = storage
+        .claim_next_transcription_job(now, now + PROCESSING_LEASE)
+        .await?
+    else {
+        return Ok(false);
+    };
+
+    let model = job
+        .resolved_model
+        .as_deref()
+        .ok_or_else(|| TranscriptionWorkerError::MissingResolvedModel(job.id.clone()))?;
+    if job.accepted_audio_path.as_os_str().is_empty() {
+        return Err(TranscriptionWorkerError::MissingAcceptedAudioPath(job.id));
+    }
+
+    let duration = audio_duration_seconds(&job.accepted_audio_path).map_err(|source| {
+        TranscriptionWorkerError::AudioDuration {
+            path: job.accepted_audio_path.clone(),
+            source,
+        }
+    })?;
+    let audio_size_bytes = std::fs::metadata(&job.accepted_audio_path)
+        .map_err(AudioDurationError::Open)
+        .map_err(|source| TranscriptionWorkerError::AudioDuration {
+            path: job.accepted_audio_path.clone(),
+            source,
+        })?
+        .len() as i64;
+    let output = match engine.transcribe(TranscriptionInput {
+        audio_path: &job.accepted_audio_path,
+        model,
+        language: job.language.as_deref(),
+    }) {
+        Ok(output) => output,
+        Err(TranscriptionEngineError::Transient) => {
+            storage
+                .record_transient_engine_failure(
+                    job.api_key_id.as_str(),
+                    job.id.as_str(),
+                    now,
+                    now + FIRST_RETRY_DELAY,
+                )
+                .await?;
+            return Ok(true);
+        }
+        Err(TranscriptionEngineError::Terminal) => {
+            storage
+                .record_terminal_engine_failure(job.api_key_id.as_str(), job.id.as_str(), now)
+                .await?;
+            return Ok(true);
+        }
+    };
+
+    let voice_note_id = Ulid::new().to_string();
+    let version_id = Ulid::new().to_string();
+    let segment_id = Ulid::new().to_string();
+    let embedding_created_at = now;
+    storage
+        .complete_job_with_transcript(
+            job.api_key_id.as_str(),
+            job.id.as_str(),
+            TranscriptMaterialization {
+                transcript: NewTranscript {
+                    id: voice_note_id.clone(),
+                    audio_duration_seconds: duration,
+                    audio_format: job.audio_format,
+                    audio_size_bytes,
+                    transcript_language: job.language,
+                    model: output.model,
+                    processing_time_ms: output.processing_time_ms,
+                    cost_cents: output.cost_cents,
+                    created_at: now,
+                    recorded_at: job.recorded_at,
+                },
+                initial_version: NewTranscriptVersion {
+                    id: version_id,
+                    transcript: output.text.clone(),
+                    created_at: now,
+                },
+                segments: vec![NewSegment {
+                    id: segment_id,
+                    position: 0,
+                    start_ms: 0,
+                    end_ms: (duration * 1000.0).round() as i64,
+                    text: output.text,
+                }],
+                embedding: NewEmbedding {
+                    model: "deferred-until-27".to_owned(),
+                    vector: Vec::new(),
+                    created_at: embedding_created_at,
+                },
+            },
+        )
+        .await?;
+
+    Ok(true)
+}
+
+pub async fn run_transcription_worker(storage: Storage, engine: OpenAiTranscriptionEngine) {
+    let poll_interval = StdDuration::from_secs(5);
+    loop {
+        match process_one_queued_job(&storage, &engine, OffsetDateTime::now_utc()).await {
+            Ok(true) => {}
+            Ok(false) => tokio::time::sleep(poll_interval).await,
+            Err(error) => {
+                tracing::error!("transcription worker failed: {error}");
+                tokio::time::sleep(poll_interval).await;
+            }
+        }
+    }
+}
+
+pub fn audio_duration_seconds(path: &Path) -> Result<f64, AudioDurationError> {
+    let file = File::open(path)?;
+    let media_source = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(extension) = path.extension().and_then(|value| value.to_str()) {
+        hint.with_extension(extension);
+    }
+
+    let probed = symphonia::default::get_probe().format(
+        &hint,
+        media_source,
+        &FormatOptions::default(),
+        &MetadataOptions::default(),
+    )?;
+    let track = probed
+        .format
+        .default_track()
+        .ok_or(AudioDurationError::MissingDuration)?;
+    let time_base = track
+        .codec_params
+        .time_base
+        .ok_or(AudioDurationError::MissingDuration)?;
+    let frames = track
+        .codec_params
+        .n_frames
+        .ok_or(AudioDurationError::MissingDuration)?;
+    let duration = time_base.calc_time(frames);
+
+    Ok(duration.seconds as f64 + duration.frac)
+}

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -1,0 +1,473 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use oracy_backend::auth::AuthStore;
+use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::router::build_router;
+use oracy_backend::state::AppState;
+use oracy_backend::storage::Storage;
+use oracy_backend::transcription_worker::{
+    TranscriptionEngine, TranscriptionEngineError, TranscriptionInput, TranscriptionOutput,
+    process_one_queued_job,
+};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+use time::macros::datetime;
+use tower::util::ServiceExt;
+
+#[tokio::test]
+async fn chunked_submission_finalizes_durably_and_exposes_job_progress() {
+    let fixture = TranscriptionJobFixture::new().await;
+
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some(("Idempotency-Key", "attempt-one")),
+            json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav",
+                "language": "en"
+            }),
+        )
+        .await;
+
+    assert_eq!(opened.status, StatusCode::CREATED);
+    assert_eq!(opened.body["status"], "accepting_chunks");
+    assert_eq!(opened.body["chunk_count"], 1);
+    assert_eq!(opened.body["chunks_received"], 0);
+    assert_eq!(opened.body["retry_count"], 0);
+    assert_eq!(opened.body["voice_note_id"], Value::Null);
+    let job_id = opened.body["id"].as_str().expect("job id").to_owned();
+
+    let chunk = b"not actually wav yet";
+    let response = fixture
+        .multipart_chunk(&job_id, 0, &sha256_hex(chunk), chunk)
+        .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let progressed = fixture.get_job(&job_id).await;
+    assert_eq!(progressed.status, StatusCode::OK);
+    assert_eq!(progressed.body["status"], "accepting_chunks");
+    assert_eq!(progressed.body["chunks_received"], 1);
+
+    let finalized = fixture
+        .empty_request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+        )
+        .await;
+    assert_eq!(finalized.status, StatusCode::ACCEPTED);
+    assert_eq!(finalized.body["status"], "queued");
+    assert_eq!(finalized.body["chunks_received"], 1);
+    assert_eq!(finalized.body["voice_note_id"], Value::Null);
+
+    let fetched = fixture.get_job(&job_id).await;
+    assert_eq!(fetched.status, StatusCode::OK);
+    assert_eq!(fetched.body, finalized.body);
+}
+
+#[tokio::test]
+async fn queued_job_processing_materializes_voice_note_and_single_coarse_segment() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let job_id = fixture.open_single_chunk_wav("attempt-process").await;
+    let chunk = one_tenth_second_wav();
+    let response = fixture
+        .multipart_chunk(&job_id, 0, &sha256_hex(&chunk), &chunk)
+        .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        fixture
+            .empty_request(
+                "POST",
+                &format!("/api/v1/transcription-jobs/{job_id}/finalize")
+            )
+            .await
+            .status,
+        StatusCode::ACCEPTED
+    );
+
+    let processed = process_one_queued_job(
+        &fixture.app_state.storage,
+        &FakeTranscriptionEngine,
+        datetime!(2026-04-24 18:00:30 UTC),
+    )
+    .await
+    .expect("process queued job");
+    assert!(processed);
+
+    let job = fixture.get_job(&job_id).await;
+    assert_eq!(job.status, StatusCode::OK);
+    assert_eq!(job.body["status"], "succeeded");
+    let voice_note_id = job.body["voice_note_id"]
+        .as_str()
+        .expect("voice note id")
+        .to_owned();
+
+    let voice_note = fixture
+        .empty_request("GET", &format!("/api/v1/voice-notes/{voice_note_id}"))
+        .await;
+    assert_eq!(voice_note.status, StatusCode::OK);
+    assert_eq!(voice_note.body["text"], "hello from fake engine");
+    assert_eq!(voice_note.body["audio_duration_seconds"], 0.1);
+    assert_eq!(voice_note.body["model"], "gpt-4o-mini-transcribe");
+
+    let segments = fixture
+        .empty_request(
+            "GET",
+            &format!("/api/v1/voice-notes/{voice_note_id}/segments"),
+        )
+        .await;
+    assert_eq!(segments.status, StatusCode::OK);
+    assert_eq!(
+        segments.body["items"].as_array().expect("segments").len(),
+        1
+    );
+    assert_eq!(segments.body["items"][0]["position"], 0);
+    assert_eq!(segments.body["items"][0]["start_ms"], 0);
+    assert_eq!(segments.body["items"][0]["end_ms"], 100);
+    assert_eq!(segments.body["items"][0]["text"], "hello from fake engine");
+}
+
+#[tokio::test]
+async fn transient_engine_failure_moves_job_to_retry_waiting() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let job_id = fixture.open_single_chunk_wav("attempt-retry").await;
+    let chunk = one_tenth_second_wav();
+    let response = fixture
+        .multipart_chunk(&job_id, 0, &sha256_hex(&chunk), &chunk)
+        .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        fixture
+            .empty_request(
+                "POST",
+                &format!("/api/v1/transcription-jobs/{job_id}/finalize")
+            )
+            .await
+            .status,
+        StatusCode::ACCEPTED
+    );
+
+    let processed = process_one_queued_job(
+        &fixture.app_state.storage,
+        &TransientFailureEngine,
+        datetime!(2026-04-24 18:00:30 UTC),
+    )
+    .await
+    .expect("record retryable failure");
+    assert!(processed);
+
+    let job = fixture.get_job(&job_id).await;
+    assert_eq!(job.status, StatusCode::OK);
+    assert_eq!(job.body["status"], "retry_waiting");
+    assert_eq!(job.body["retry_count"], 1);
+    assert_eq!(job.body["next_attempt_at"], "2026-04-24T18:01:00Z");
+    assert_eq!(job.body["failure_code"], Value::Null);
+    assert_eq!(job.body["voice_note_id"], Value::Null);
+}
+
+#[tokio::test]
+async fn open_replay_matches_original_body_and_conflicts_on_mismatch() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let first = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some(("Idempotency-Key", "attempt-replay")),
+            json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav",
+                "language": "en"
+            }),
+        )
+        .await;
+    assert_eq!(first.status, StatusCode::CREATED);
+
+    let replay = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some(("Idempotency-Key", "attempt-replay")),
+            json!({
+                "recorded_at": "2026-04-24T17:59:00.000Z",
+                "chunk_count": 1,
+                "audio_format": "wav",
+                "language": "en"
+            }),
+        )
+        .await;
+    assert_eq!(replay.status, StatusCode::CREATED);
+    assert_eq!(replay.body["id"], first.body["id"]);
+
+    let conflict = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some(("Idempotency-Key", "attempt-replay")),
+            json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 2,
+                "audio_format": "wav",
+                "language": "en"
+            }),
+        )
+        .await;
+    assert_eq!(conflict.status, StatusCode::CONFLICT);
+    assert_eq!(conflict.body["error_code"], "conflict");
+}
+
+#[tokio::test]
+async fn malformed_job_ids_return_validation_before_not_found() {
+    let fixture = TranscriptionJobFixture::new().await;
+
+    for uri in [
+        "/api/v1/transcription-jobs/not-a-ulid",
+        "/api/v1/transcription-jobs/not-a-ulid/finalize",
+    ] {
+        let response = fixture.empty_request("GET", uri).await;
+        let response = if response.status == StatusCode::METHOD_NOT_ALLOWED {
+            fixture.empty_request("POST", uri).await
+        } else {
+            response
+        };
+        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        assert_eq!(response.body["error_code"], "validation_error");
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+struct TranscriptionJobFixture {
+    _tempdir: TempDir,
+    app_state: AppState,
+}
+
+impl TranscriptionJobFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let accepted_audio_dir = tempdir.path().join("accepted-audio");
+        std::fs::create_dir(&accepted_audio_dir).expect("accepted audio dir");
+        let database_path = tempdir.path().join("oracy.sqlite");
+        let storage = Storage::connect(&database_path).await.expect("storage");
+        let auth_store = AuthStore::try_from_configs(&[
+            ApiKeyConfig {
+                api_key_id: "alpha".to_owned(),
+                key: "alpha-secret".to_owned(),
+            },
+            ApiKeyConfig {
+                api_key_id: "beta".to_owned(),
+                key: "beta-secret".to_owned(),
+            },
+        ])
+        .expect("auth store");
+
+        let app_state = AppState {
+            accepted_audio_dir,
+            auth_store: Arc::new(auth_store),
+            storage,
+        };
+
+        Self {
+            _tempdir: tempdir,
+            app_state,
+        }
+    }
+
+    fn app(&self) -> axum::Router {
+        build_router(self.app_state.clone())
+    }
+
+    async fn json_request(
+        &self,
+        method: &str,
+        uri: &str,
+        extra_header: Option<(&str, &str)>,
+        body: Value,
+    ) -> JsonResponse {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("Authorization", "Bearer alpha-secret")
+            .header("Content-Type", "application/json");
+        if let Some((name, value)) = extra_header {
+            builder = builder.header(name, value);
+        }
+        let response = self
+            .app()
+            .oneshot(builder.body(Body::from(body.to_string())).unwrap())
+            .await
+            .expect("response");
+        json_response(response).await
+    }
+
+    async fn empty_request(&self, method: &str, uri: &str) -> JsonResponse {
+        let response = self
+            .app()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .header("Authorization", "Bearer alpha-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+        json_response(response).await
+    }
+
+    async fn get_job(&self, job_id: &str) -> JsonResponse {
+        self.empty_request("GET", &format!("/api/v1/transcription-jobs/{job_id}"))
+            .await
+    }
+
+    async fn open_single_chunk_wav(&self, idempotency_key: &str) -> String {
+        let opened = self
+            .json_request(
+                "POST",
+                "/api/v1/transcription-jobs",
+                Some(("Idempotency-Key", idempotency_key)),
+                json!({
+                    "recorded_at": "2026-04-24T17:59:00Z",
+                    "chunk_count": 1,
+                    "audio_format": "wav",
+                    "language": "en"
+                }),
+            )
+            .await;
+        assert_eq!(opened.status, StatusCode::CREATED);
+        opened.body["id"].as_str().expect("job id").to_owned()
+    }
+
+    async fn multipart_chunk(
+        &self,
+        job_id: &str,
+        chunk_index: i64,
+        chunk_sha256: &str,
+        chunk: &[u8],
+    ) -> axum::response::Response {
+        let boundary = "oracy-test-boundary";
+        let mut body = Vec::new();
+        push_part(
+            &mut body,
+            boundary,
+            "chunk_index",
+            chunk_index.to_string().as_bytes(),
+        );
+        push_part(&mut body, boundary, "chunk_sha256", chunk_sha256.as_bytes());
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"chunk.wav\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        body.extend_from_slice(chunk);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+        self.app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/transcription-jobs/{job_id}/chunks"))
+                    .header("Authorization", "Bearer alpha-secret")
+                    .header(
+                        "Content-Type",
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .expect("response")
+    }
+}
+
+async fn json_response(response: axum::response::Response) -> JsonResponse {
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("json")
+    };
+    JsonResponse { status, body }
+}
+
+fn push_part(body: &mut Vec<u8>, boundary: &str, name: &str, value: &[u8]) {
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+    );
+    body.extend_from_slice(value);
+    body.extend_from_slice(b"\r\n");
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        output.push_str(&format!("{byte:02x}"));
+    }
+    output
+}
+
+struct FakeTranscriptionEngine;
+
+impl TranscriptionEngine for FakeTranscriptionEngine {
+    fn transcribe(
+        &self,
+        input: TranscriptionInput<'_>,
+    ) -> Result<TranscriptionOutput, TranscriptionEngineError> {
+        assert_eq!(input.model, "gpt-4o-mini-transcribe");
+        assert_eq!(input.language, Some("en"));
+        assert!(input.audio_path.ends_with("accepted.wav"));
+        Ok(TranscriptionOutput {
+            text: "hello from fake engine".to_owned(),
+            model: input.model.to_owned(),
+            processing_time_ms: 42,
+            cost_cents: None,
+        })
+    }
+}
+
+struct TransientFailureEngine;
+
+impl TranscriptionEngine for TransientFailureEngine {
+    fn transcribe(
+        &self,
+        _input: TranscriptionInput<'_>,
+    ) -> Result<TranscriptionOutput, TranscriptionEngineError> {
+        Err(TranscriptionEngineError::Transient)
+    }
+}
+
+fn one_tenth_second_wav() -> Vec<u8> {
+    let sample_rate = 8_000_u32;
+    let samples = 800_u32;
+    let data_bytes = samples * 2;
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"RIFF");
+    bytes.extend_from_slice(&(36 + data_bytes).to_le_bytes());
+    bytes.extend_from_slice(b"WAVEfmt ");
+    bytes.extend_from_slice(&16_u32.to_le_bytes());
+    bytes.extend_from_slice(&1_u16.to_le_bytes());
+    bytes.extend_from_slice(&1_u16.to_le_bytes());
+    bytes.extend_from_slice(&sample_rate.to_le_bytes());
+    bytes.extend_from_slice(&(sample_rate * 2).to_le_bytes());
+    bytes.extend_from_slice(&2_u16.to_le_bytes());
+    bytes.extend_from_slice(&16_u16.to_le_bytes());
+    bytes.extend_from_slice(b"data");
+    bytes.extend_from_slice(&data_bytes.to_le_bytes());
+    bytes.resize(bytes.len() + data_bytes as usize, 0);
+    bytes
+}

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -968,6 +968,13 @@ Fields:
   start of the composed audio
 - `text`: segment text captured from the transcription result
 
+For `v0.1.0`, the supported OpenAI transcription engines do not
+produce per-utterance timing. Voice notes therefore carry one coarse
+segment with `position=0`, `start_ms=0`, and `end_ms` equal to the
+locally measured audio duration in milliseconds. The resource shape
+already supports richer per-utterance timing for future engines without
+a contract change.
+
 ### `Tag`
 
 ```json


### PR DESCRIPTION
## Summary

- Adds the core chunked transcription-job flow: open, chunk push, finalize, job read, and durable accepted-audio persistence.
- Adds leased worker processing with OpenAI transcription plumbing, fake-engine integration coverage, local duration extraction via Symphonia, and one coarse v0.1.0 segment per successful voice note.
- Documents the coarse-segment behavior and the temporary #27 embedding deviation while keeping this PR scoped as partial progress on #40.

## Changes

- Introduces transcription job HTTP handlers and storage support for `accepting_chunks`, accepted chunk rows, composed audio artifacts, Settings model capture, and retry-waiting state.
- Starts an in-process transcription worker in the backend binary and adds an OpenAI-backed transcription engine implementation.
- Adds integration tests for open/push/finalize/read, open idempotency conflict behavior, malformed job IDs, successful materialization, and transient retry handoff.
- Updates the API contract notes, backend README, and changelog for the behavior this slice makes visible.

## GitHub Issue(s)

Refs #40

Remaining #40 work intentionally not closed by this PR:
- Full internal `transcripts*` to `voice_notes*` persistence/Rust rename.
- Abandonment-window sweeper for stale `accepting_chunks` jobs.
- Broader retry-exhaustion and terminal failure coverage beyond the first transient retry handoff.

## Test plan

- `cargo test` from `backend/`
- `git diff --check`
