### PR TITLE
feat(persistence): rename transcripts substrate to voice notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@
 - Fix the foreground upload queue so pending recordings wait for a configured
   API key and resume after one is saved.
 - Add the durable backend SQLite substrate for accepted transcription jobs,
-  transcript versions, ordered segments, current embeddings, owner scoping, and
+  voice-note versions, ordered segments, current embeddings, owner scoping, and
   the required operator `database_path` setting.
 - Add the durable backend SQLite substrate for tags, sessions,
-  transcript-to-tag associations, transcript session membership, and metadata
+  voice-note-to-tag associations, voice-note session membership, and metadata
   deletion invariants.
 - Establish independent backend and frontend CI gates for v0.1.0 pull requests
   and pushes to `main`.
@@ -41,17 +41,17 @@
 - Import the Flutter client into `client/` with six inherited defects fixed
   in-place rather than deferred, and commit `client/pubspec.lock` for
   reproducible app builds.
-- Expand the v0.1.0 spec to define the full transcript substrate and HTTP
-  surface, including sessions, tags, transcript editing and version history,
-  segment retrieval, transcript deletion, unified history/search collection
+- Expand the v0.1.0 spec to define the full voice-note substrate and HTTP
+  surface, including sessions, tags, voice-note editing and version history,
+  segment retrieval, voice-note deletion, unified history/search collection
   semantics, required `recorded_at`, and the shared error envelope.
-- Rename the transcript schema field from `whisper_model` to `model` so the API
+- Rename the voice-note schema field from `whisper_model` to `model` so the API
   describes the transcription engine without binding the contract to Whisper.
-- Clarify that `cost_cents` is always present on transcript resources but may be
+- Clarify that `cost_cents` is always present on voice-note resources but may be
   `null` when the backend cannot derive a stable estimate from fixed-rate
   pricing inputs.
-- Rewrite the v0.1.0 spec around the durable voice-note artifact: rename the
-  `Transcript` family to `VoiceNote`, replace single-multipart audio upload with
-  the chunked open/push/finalize protocol (with `accepting_chunks` as a
+- Rewrite the v0.1.0 spec around the durable voice-note artifact: replace the
+  pre-pivot resource family with `VoiceNote`, replace single-multipart audio
+  upload with the chunked open/push/finalize protocol (with `accepting_chunks` as a
   contract-visible job status), and add the per-API-key `transcription_model`
   settings surface enumerating the OpenAI transcription engine identifiers.

--- a/backend/migrations/20260424000000_create_job_transcript_substrate.sql
+++ b/backend/migrations/20260424000000_create_job_transcript_substrate.sql
@@ -27,8 +27,8 @@ CREATE TABLE transcription_jobs (
     ),
     failure_message TEXT,
     retryable_by_client INTEGER CHECK (retryable_by_client IS NULL OR retryable_by_client IN (0, 1)),
-    transcript_id TEXT REFERENCES transcripts(id) ON DELETE SET NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id),
+    voice_note_id TEXT REFERENCES voice_notes(id) ON DELETE SET NULL,
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id),
     UNIQUE (api_key_id, idempotency_key)
 );
 
@@ -45,13 +45,13 @@ BEGIN
     SELECT RAISE(ABORT, 'accepted submission tuple is immutable');
 END;
 
-CREATE TABLE transcripts (
+CREATE TABLE voice_notes (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
     audio_duration_seconds REAL NOT NULL CHECK (audio_duration_seconds >= 0),
     audio_format TEXT NOT NULL,
     audio_size_bytes INTEGER NOT NULL CHECK (audio_size_bytes >= 0),
-    transcript_language TEXT,
+    language TEXT,
     model TEXT NOT NULL,
     processing_time_ms INTEGER NOT NULL CHECK (processing_time_ms >= 0),
     cost_cents INTEGER CHECK (cost_cents IS NULL OR cost_cents >= 0),
@@ -60,49 +60,49 @@ CREATE TABLE transcripts (
     session_id TEXT
 );
 
-CREATE UNIQUE INDEX transcripts_owner_id_idx
-    ON transcripts (api_key_id, id);
+CREATE UNIQUE INDEX voice_notes_owner_id_idx
+    ON voice_notes (api_key_id, id);
 
-CREATE INDEX transcripts_history_idx
-    ON transcripts (api_key_id, created_at DESC, id DESC);
+CREATE INDEX voice_notes_history_idx
+    ON voice_notes (api_key_id, created_at DESC, id DESC);
 
-CREATE TABLE transcript_versions (
+CREATE TABLE voice_note_versions (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL,
+    voice_note_id TEXT NOT NULL,
     version_number INTEGER NOT NULL CHECK (version_number >= 1),
-    transcript TEXT NOT NULL,
+    text TEXT NOT NULL,
     created_at TEXT NOT NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
-    UNIQUE (transcript_id, version_number)
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE,
+    UNIQUE (voice_note_id, version_number)
 );
 
-CREATE INDEX transcript_versions_current_idx
-    ON transcript_versions (transcript_id, version_number DESC);
+CREATE INDEX voice_note_versions_current_idx
+    ON voice_note_versions (voice_note_id, version_number DESC);
 
 CREATE TABLE segments (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL,
+    voice_note_id TEXT NOT NULL,
     position INTEGER NOT NULL CHECK (position >= 0),
     start_ms INTEGER NOT NULL CHECK (start_ms >= 0),
     end_ms INTEGER NOT NULL CHECK (end_ms >= start_ms),
     text TEXT NOT NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
-    UNIQUE (transcript_id, position)
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE,
+    UNIQUE (voice_note_id, position)
 );
 
 CREATE INDEX segments_order_idx
-    ON segments (transcript_id, position ASC);
+    ON segments (voice_note_id, position ASC);
 
 CREATE TABLE embeddings (
-    transcript_id TEXT PRIMARY KEY,
+    voice_note_id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
     model TEXT NOT NULL,
     vector BLOB NOT NULL,
     created_at TEXT NOT NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX embeddings_owner_idx
-    ON embeddings (api_key_id, transcript_id);
+    ON embeddings (api_key_id, voice_note_id);

--- a/backend/migrations/20260425010000_create_metadata_substrate.sql
+++ b/backend/migrations/20260425010000_create_metadata_substrate.sql
@@ -28,17 +28,17 @@ CREATE UNIQUE INDEX tags_owner_id_idx
 CREATE INDEX tags_list_idx
     ON tags (api_key_id, created_at DESC, id DESC);
 
-CREATE TABLE transcript_tags (
+CREATE TABLE voice_note_tags (
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL,
+    voice_note_id TEXT NOT NULL,
     tag_id TEXT NOT NULL,
-    PRIMARY KEY (api_key_id, transcript_id, tag_id),
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
+    PRIMARY KEY (api_key_id, voice_note_id, tag_id),
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE,
     FOREIGN KEY (api_key_id, tag_id) REFERENCES tags(api_key_id, id) ON DELETE CASCADE
 );
 
-CREATE INDEX transcript_tags_tag_idx
-    ON transcript_tags (api_key_id, tag_id, transcript_id);
+CREATE INDEX voice_note_tags_tag_idx
+    ON voice_note_tags (api_key_id, tag_id, voice_note_id);
 
 CREATE TRIGGER transcription_jobs_session_owner_insert
 BEFORE INSERT ON transcription_jobs
@@ -51,32 +51,32 @@ BEGIN
     );
 END;
 
-CREATE TRIGGER transcripts_session_owner_insert
-BEFORE INSERT ON transcripts
+CREATE TRIGGER voice_notes_session_owner_insert
+BEFORE INSERT ON voice_notes
 WHEN NEW.session_id IS NOT NULL
 BEGIN
-    SELECT RAISE(ABORT, 'transcript session must belong to same owner')
+    SELECT RAISE(ABORT, 'voice note session must belong to same owner')
     WHERE NOT EXISTS (
         SELECT 1 FROM sessions
         WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
     );
 END;
 
-CREATE TRIGGER transcripts_session_owner_update
-BEFORE UPDATE OF api_key_id, session_id ON transcripts
+CREATE TRIGGER voice_notes_session_owner_update
+BEFORE UPDATE OF api_key_id, session_id ON voice_notes
 WHEN NEW.session_id IS NOT NULL
 BEGIN
-    SELECT RAISE(ABORT, 'transcript session must belong to same owner')
+    SELECT RAISE(ABORT, 'voice note session must belong to same owner')
     WHERE NOT EXISTS (
         SELECT 1 FROM sessions
         WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
     );
 END;
 
-CREATE TRIGGER sessions_delete_null_transcripts
+CREATE TRIGGER sessions_delete_null_voice_notes
 AFTER DELETE ON sessions
 BEGIN
-    UPDATE transcripts
+    UPDATE voice_notes
     SET session_id = NULL
     WHERE api_key_id = OLD.api_key_id AND session_id = OLD.id;
 END;

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -59,7 +59,7 @@ pub enum StorageError {
     },
     #[error("storage query failed: {0}")]
     Query(#[from] sqlx::Error),
-    #[error("job is not eligible for transcript completion: {job_id}")]
+    #[error("job is not eligible for voice note completion: {job_id}")]
     JobNotCompletable { job_id: String },
     #[error("stored timestamp is invalid: {0}")]
     InvalidTimestamp(#[from] time::error::Parse),
@@ -89,7 +89,7 @@ pub enum RenameTagOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReplaceTranscriptTagsOutcome {
+pub enum ReplaceVoiceNoteTagsOutcome {
     Replaced,
     NotFound,
     DuplicateTagIds,
@@ -159,24 +159,24 @@ pub struct TranscriptionJobRecord {
     pub failure_code: Option<String>,
     pub failure_message: Option<String>,
     pub retryable_by_client: Option<bool>,
-    pub transcript_id: Option<String>,
+    pub voice_note_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-pub struct TranscriptMaterialization {
-    pub transcript: NewTranscript,
-    pub initial_version: NewTranscriptVersion,
+pub struct VoiceNoteMaterialization {
+    pub voice_note: NewVoiceNote,
+    pub initial_version: NewVoiceNoteVersion,
     pub segments: Vec<NewSegment>,
     pub embedding: NewEmbedding,
 }
 
 #[derive(Debug, Clone)]
-pub struct NewTranscript {
+pub struct NewVoiceNote {
     pub id: String,
     pub audio_duration_seconds: f64,
     pub audio_format: String,
     pub audio_size_bytes: i64,
-    pub transcript_language: Option<String>,
+    pub language: Option<String>,
     pub model: String,
     pub processing_time_ms: i64,
     pub cost_cents: Option<i64>,
@@ -185,9 +185,9 @@ pub struct NewTranscript {
 }
 
 #[derive(Debug, Clone)]
-pub struct NewTranscriptVersion {
+pub struct NewVoiceNoteVersion {
     pub id: String,
-    pub transcript: String,
+    pub text: String,
     pub created_at: OffsetDateTime,
 }
 
@@ -208,15 +208,15 @@ pub struct NewEmbedding {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct TranscriptRecord {
+pub struct VoiceNoteRecord {
     pub id: String,
     pub api_key_id: String,
     pub current_version_id: String,
-    pub transcript: String,
+    pub text: String,
     pub audio_duration_seconds: f64,
     pub audio_format: String,
     pub audio_size_bytes: i64,
-    pub transcript_language: Option<String>,
+    pub language: Option<String>,
     pub model: String,
     pub processing_time_ms: i64,
     pub cost_cents: Option<i64>,
@@ -226,15 +226,15 @@ pub struct TranscriptRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TranscriptVersionRecord {
+pub struct VoiceNoteVersionRecord {
     pub id: String,
-    pub transcript_id: String,
-    pub transcript: String,
+    pub voice_note_id: String,
+    pub text: String,
     pub created_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct TranscriptFilters {
+pub struct VoiceNoteFilters {
     pub tag_ids: Vec<String>,
     pub session_id: Option<String>,
     pub recorded_after: Option<OffsetDateTime>,
@@ -246,7 +246,7 @@ pub struct TranscriptFilters {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentRecord {
     pub id: String,
-    pub transcript_id: String,
+    pub voice_note_id: String,
     pub position: i64,
     pub start_ms: i64,
     pub end_ms: i64,
@@ -255,7 +255,7 @@ pub struct SegmentRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EmbeddingRecord {
-    pub transcript_id: String,
+    pub voice_note_id: String,
     pub model: String,
     pub vector: Vec<u8>,
     pub created_at: OffsetDateTime,
@@ -489,16 +489,16 @@ impl Storage {
         row.map(job_from_row).transpose()
     }
 
-    pub async fn complete_job_with_transcript(
+    pub async fn complete_job_with_voice_note(
         &self,
         api_key_id: &str,
         job_id: &str,
-        materialization: TranscriptMaterialization,
+        materialization: VoiceNoteMaterialization,
     ) -> Result<(), StorageError> {
         let mut tx = self.pool.begin().await?;
-        let transcript = materialization.transcript;
+        let voice_note = materialization.voice_note;
         let version = materialization.initial_version;
-        let now = format_timestamp(transcript.created_at)?;
+        let now = format_timestamp(voice_note.created_at)?;
 
         let result = sqlx::query(
             r#"
@@ -507,7 +507,7 @@ impl Storage {
             WHERE api_key_id = ?
                 AND id = ?
                 AND status = 'processing'
-                AND transcript_id IS NULL
+                AND voice_note_id IS NULL
             "#,
         )
         .bind(&now)
@@ -521,9 +521,9 @@ impl Storage {
             });
         }
 
-        let transcript_session_id: Option<String> = sqlx::query(
+        let voice_note_session_id: Option<String> = sqlx::query(
             r#"
-            SELECT sessions.id AS transcript_session_id
+            SELECT sessions.id AS voice_note_session_id
             FROM transcription_jobs
             LEFT JOIN sessions
                 ON sessions.api_key_id = transcription_jobs.api_key_id
@@ -536,45 +536,45 @@ impl Storage {
         .bind(job_id)
         .fetch_one(&mut *tx)
         .await?
-        .try_get("transcript_session_id")?;
+        .try_get("voice_note_session_id")?;
 
         sqlx::query(
             r#"
-            INSERT INTO transcripts (
+            INSERT INTO voice_notes (
                 id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-                transcript_language, model, processing_time_ms, cost_cents,
+                language, model, processing_time_ms, cost_cents,
                 created_at, recorded_at, session_id
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
-        .bind(&transcript.id)
+        .bind(&voice_note.id)
         .bind(api_key_id)
-        .bind(transcript.audio_duration_seconds)
-        .bind(&transcript.audio_format)
-        .bind(transcript.audio_size_bytes)
-        .bind(&transcript.transcript_language)
-        .bind(&transcript.model)
-        .bind(transcript.processing_time_ms)
-        .bind(transcript.cost_cents)
+        .bind(voice_note.audio_duration_seconds)
+        .bind(&voice_note.audio_format)
+        .bind(voice_note.audio_size_bytes)
+        .bind(&voice_note.language)
+        .bind(&voice_note.model)
+        .bind(voice_note.processing_time_ms)
+        .bind(voice_note.cost_cents)
         .bind(&now)
-        .bind(format_timestamp(transcript.recorded_at)?)
-        .bind(&transcript_session_id)
+        .bind(format_timestamp(voice_note.recorded_at)?)
+        .bind(&voice_note_session_id)
         .execute(&mut *tx)
         .await?;
 
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, 1, ?, ?)
             "#,
         )
         .bind(&version.id)
         .bind(api_key_id)
-        .bind(&transcript.id)
-        .bind(&version.transcript)
+        .bind(&voice_note.id)
+        .bind(&version.text)
         .bind(format_timestamp(version.created_at)?)
         .execute(&mut *tx)
         .await?;
@@ -583,14 +583,14 @@ impl Storage {
             sqlx::query(
                 r#"
                 INSERT INTO segments (
-                    id, api_key_id, transcript_id, position, start_ms, end_ms, text
+                    id, api_key_id, voice_note_id, position, start_ms, end_ms, text
                 )
                 VALUES (?, ?, ?, ?, ?, ?, ?)
                 "#,
             )
             .bind(&segment.id)
             .bind(api_key_id)
-            .bind(&transcript.id)
+            .bind(&voice_note.id)
             .bind(segment.position)
             .bind(segment.start_ms)
             .bind(segment.end_ms)
@@ -601,11 +601,11 @@ impl Storage {
 
         sqlx::query(
             r#"
-            INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
             VALUES (?, ?, ?, ?, ?)
             "#,
         )
-        .bind(&transcript.id)
+        .bind(&voice_note.id)
         .bind(api_key_id)
         .bind(&materialization.embedding.model)
         .bind(&materialization.embedding.vector)
@@ -616,14 +616,14 @@ impl Storage {
         let result = sqlx::query(
             r#"
             UPDATE transcription_jobs
-            SET status = 'succeeded', transcript_id = ?, updated_at = ?
+            SET status = 'succeeded', voice_note_id = ?, updated_at = ?
             WHERE api_key_id = ?
                 AND id = ?
                 AND status = 'processing'
-                AND transcript_id IS NULL
+                AND voice_note_id IS NULL
             "#,
         )
-        .bind(&transcript.id)
+        .bind(&voice_note.id)
         .bind(&now)
         .bind(api_key_id)
         .bind(job_id)
@@ -639,68 +639,68 @@ impl Storage {
         Ok(())
     }
 
-    pub async fn get_transcript(
+    pub async fn get_voice_note(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
-    ) -> Result<Option<TranscriptRecord>, StorageError> {
+        voice_note_id: &str,
+    ) -> Result<Option<VoiceNoteRecord>, StorageError> {
         let row = sqlx::query(
             r#"
             SELECT
-                transcripts.*,
-                transcript_versions.id AS current_version_id,
-                transcript_versions.transcript AS current_transcript
-            FROM transcripts
-            JOIN transcript_versions
-                ON transcript_versions.transcript_id = transcripts.id
-            WHERE transcripts.api_key_id = ?
-                AND transcripts.id = ?
-                AND transcript_versions.version_number = (
+                voice_notes.*,
+                voice_note_versions.id AS current_version_id,
+                voice_note_versions.text AS current_text
+            FROM voice_notes
+            JOIN voice_note_versions
+                ON voice_note_versions.voice_note_id = voice_notes.id
+            WHERE voice_notes.api_key_id = ?
+                AND voice_notes.id = ?
+                AND voice_note_versions.version_number = (
                     SELECT MAX(version_number)
-                    FROM transcript_versions
-                    WHERE transcript_id = transcripts.id
+                    FROM voice_note_versions
+                    WHERE voice_note_id = voice_notes.id
                 )
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_optional(&self.pool)
         .await?;
 
-        row.map(transcript_from_row).transpose()
+        row.map(voice_note_from_row).transpose()
     }
 
-    pub async fn list_transcripts(
+    pub async fn list_voice_notes(
         &self,
         api_key_id: &str,
-        filters: &TranscriptFilters,
+        filters: &VoiceNoteFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptRecord>, StorageError> {
-        self.list_transcripts_in_session(api_key_id, None, filters, cursor, limit)
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        self.list_voice_notes_in_session(api_key_id, None, filters, cursor, limit)
             .await
     }
 
-    pub async fn list_session_transcripts(
+    pub async fn list_session_voice_notes(
         &self,
         api_key_id: &str,
         session_id: &str,
-        filters: &TranscriptFilters,
+        filters: &VoiceNoteFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptRecord>, StorageError> {
-        self.list_transcripts_in_session(api_key_id, Some(session_id), filters, cursor, limit)
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        self.list_voice_notes_in_session(api_key_id, Some(session_id), filters, cursor, limit)
             .await
     }
 
-    async fn list_transcripts_in_session(
+    async fn list_voice_notes_in_session(
         &self,
         api_key_id: &str,
         session_id: Option<&str>,
-        filters: &TranscriptFilters,
+        filters: &VoiceNoteFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptRecord>, StorageError> {
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
         let cursor_created_at = cursor
             .as_ref()
             .map(|(created_at, _)| format_timestamp(*created_at))
@@ -714,34 +714,34 @@ impl Storage {
         let mut query = QueryBuilder::new(
             r#"
             SELECT
-                transcripts.*,
-                transcript_versions.id AS current_version_id,
-                transcript_versions.transcript AS current_transcript
-            FROM transcripts
-            JOIN transcript_versions
-                ON transcript_versions.transcript_id = transcripts.id
-            WHERE transcripts.api_key_id =
+                voice_notes.*,
+                voice_note_versions.id AS current_version_id,
+                voice_note_versions.text AS current_text
+            FROM voice_notes
+            JOIN voice_note_versions
+                ON voice_note_versions.voice_note_id = voice_notes.id
+            WHERE voice_notes.api_key_id =
             "#,
         );
         query.push_bind(api_key_id);
         if let Some(session_id) = effective_session_id {
-            query.push(" AND transcripts.session_id = ");
+            query.push(" AND voice_notes.session_id = ");
             query.push_bind(session_id);
         }
         if let Some(recorded_after) = recorded_after.as_deref() {
-            query.push(" AND transcripts.recorded_at > ");
+            query.push(" AND voice_notes.recorded_at > ");
             query.push_bind(recorded_after);
         }
         if let Some(recorded_before) = recorded_before.as_deref() {
-            query.push(" AND transcripts.recorded_at <= ");
+            query.push(" AND voice_notes.recorded_at <= ");
             query.push_bind(recorded_before);
         }
         if let Some(created_after) = created_after.as_deref() {
-            query.push(" AND transcripts.created_at > ");
+            query.push(" AND voice_notes.created_at > ");
             query.push_bind(created_after);
         }
         if let Some(created_before) = created_before.as_deref() {
-            query.push(" AND transcripts.created_at <= ");
+            query.push(" AND voice_notes.created_at <= ");
             query.push_bind(created_before);
         }
         for tag_id in &filters.tag_ids {
@@ -749,10 +749,10 @@ impl Storage {
                 r#"
                 AND EXISTS (
                     SELECT 1
-                    FROM transcript_tags
-                    WHERE transcript_tags.api_key_id = transcripts.api_key_id
-                        AND transcript_tags.transcript_id = transcripts.id
-                        AND transcript_tags.tag_id =
+                    FROM voice_note_tags
+                    WHERE voice_note_tags.api_key_id = voice_notes.api_key_id
+                        AND voice_note_tags.voice_note_id = voice_notes.id
+                        AND voice_note_tags.tag_id =
                 "#,
             );
             query.push_bind(tag_id);
@@ -760,10 +760,10 @@ impl Storage {
         }
         query.push(
             r#"
-                AND transcript_versions.version_number = (
+                AND voice_note_versions.version_number = (
                     SELECT MAX(version_number)
-                    FROM transcript_versions
-                    WHERE transcript_id = transcripts.id
+                    FROM voice_note_versions
+                    WHERE voice_note_id = voice_notes.id
                 )
             "#,
         );
@@ -771,30 +771,30 @@ impl Storage {
             query.push(
                 r#"
                 AND (
-                    transcripts.created_at <
+                    voice_notes.created_at <
                 "#,
             );
             query.push_bind(cursor_created_at);
-            query.push(" OR (transcripts.created_at = ");
+            query.push(" OR (voice_notes.created_at = ");
             query.push_bind(cursor_created_at);
-            query.push(" AND transcripts.id < ");
+            query.push(" AND voice_notes.id < ");
             query.push_bind(cursor_id.expect("cursor id is present with cursor timestamp"));
             query.push("))");
         }
-        query.push(" ORDER BY transcripts.created_at DESC, transcripts.id DESC LIMIT ");
+        query.push(" ORDER BY voice_notes.created_at DESC, voice_notes.id DESC LIMIT ");
         query.push_bind(limit);
         let rows = query.build().fetch_all(&self.pool).await?;
 
-        rows.into_iter().map(transcript_from_row).collect()
+        rows.into_iter().map(voice_note_from_row).collect()
     }
 
-    pub async fn list_transcript_versions(
+    pub async fn list_voice_note_versions(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptVersionRecord>, StorageError> {
+    ) -> Result<Vec<VoiceNoteVersionRecord>, StorageError> {
         let cursor_created_at = cursor
             .as_ref()
             .map(|(created_at, _)| format_timestamp(*created_at))
@@ -802,10 +802,10 @@ impl Storage {
         let cursor_id = cursor.as_ref().map(|(_, id)| id.as_str());
         let rows = sqlx::query(
             r#"
-            SELECT id, transcript_id, transcript, created_at
-            FROM transcript_versions
+            SELECT id, voice_note_id, text, created_at
+            FROM voice_note_versions
             WHERE api_key_id = ?
-                AND transcript_id = ?
+                AND voice_note_id = ?
                 AND (
                     ? IS NULL
                     OR created_at < ?
@@ -816,7 +816,7 @@ impl Storage {
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .bind(&cursor_created_at)
         .bind(&cursor_created_at)
         .bind(&cursor_created_at)
@@ -825,24 +825,24 @@ impl Storage {
         .fetch_all(&self.pool)
         .await?;
 
-        rows.into_iter().map(transcript_version_from_row).collect()
+        rows.into_iter().map(voice_note_version_from_row).collect()
     }
 
     pub async fn list_segments(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<Vec<SegmentRecord>, StorageError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, transcript_id, position, start_ms, end_ms, text
+            SELECT id, voice_note_id, position, start_ms, end_ms, text
             FROM segments
-            WHERE api_key_id = ? AND transcript_id = ?
+            WHERE api_key_id = ? AND voice_note_id = ?
             ORDER BY position ASC
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_all(&self.pool)
         .await?;
 
@@ -852,23 +852,23 @@ impl Storage {
     pub async fn list_segments_page(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         cursor: Option<i64>,
         limit: i64,
     ) -> Result<Vec<SegmentRecord>, StorageError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, transcript_id, position, start_ms, end_ms, text
+            SELECT id, voice_note_id, position, start_ms, end_ms, text
             FROM segments
             WHERE api_key_id = ?
-                AND transcript_id = ?
+                AND voice_note_id = ?
                 AND (? IS NULL OR position > ?)
             ORDER BY position ASC
             LIMIT ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .bind(cursor)
         .bind(cursor)
         .bind(limit)
@@ -975,30 +975,30 @@ impl Storage {
     pub async fn replace_current_embedding(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         embedding: NewEmbedding,
     ) -> Result<bool, StorageError> {
         let result = sqlx::query(
             r#"
-            INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
             SELECT ?, ?, ?, ?, ?
             WHERE EXISTS (
-                SELECT 1 FROM transcripts WHERE api_key_id = ? AND id = ?
+                SELECT 1 FROM voice_notes WHERE api_key_id = ? AND id = ?
             )
-            ON CONFLICT(transcript_id) DO UPDATE SET
+            ON CONFLICT(voice_note_id) DO UPDATE SET
                 model = excluded.model,
                 vector = excluded.vector,
                 created_at = excluded.created_at
             WHERE embeddings.api_key_id = excluded.api_key_id
             "#,
         )
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .bind(api_key_id)
         .bind(&embedding.model)
         .bind(&embedding.vector)
         .bind(format_timestamp(embedding.created_at)?)
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected() == 1)
@@ -1007,36 +1007,36 @@ impl Storage {
     pub async fn get_current_embedding(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<Option<EmbeddingRecord>, StorageError> {
         let row = sqlx::query(
             r#"
-            SELECT transcript_id, model, vector, created_at
+            SELECT voice_note_id, model, vector, created_at
             FROM embeddings
-            WHERE api_key_id = ? AND transcript_id = ?
+            WHERE api_key_id = ? AND voice_note_id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_optional(&self.pool)
         .await?;
 
         row.map(embedding_from_row).transpose()
     }
 
-    pub async fn delete_transcript(
+    pub async fn delete_voice_note(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<bool, StorageError> {
         let result = sqlx::query(
             r#"
-            DELETE FROM transcripts
+            DELETE FROM voice_notes
             WHERE api_key_id = ? AND id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .execute(&self.pool)
         .await?;
 
@@ -1292,34 +1292,34 @@ impl Storage {
         row.map(session_from_row).transpose()
     }
 
-    pub async fn replace_transcript_tags(
+    pub async fn replace_voice_note_tags(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         tag_ids: &[String],
-    ) -> Result<ReplaceTranscriptTagsOutcome, StorageError> {
+    ) -> Result<ReplaceVoiceNoteTagsOutcome, StorageError> {
         let mut seen = HashSet::with_capacity(tag_ids.len());
         for tag_id in tag_ids {
             if !seen.insert(tag_id) {
-                return Ok(ReplaceTranscriptTagsOutcome::DuplicateTagIds);
+                return Ok(ReplaceVoiceNoteTagsOutcome::DuplicateTagIds);
             }
         }
 
         let mut tx = self.pool.begin().await?;
-        let transcript_exists: Option<i64> = sqlx::query_scalar(
+        let voice_note_exists: Option<i64> = sqlx::query_scalar(
             r#"
             SELECT 1
-            FROM transcripts
+            FROM voice_notes
             WHERE api_key_id = ? AND id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_optional(&mut *tx)
         .await?;
-        if transcript_exists.is_none() {
+        if voice_note_exists.is_none() {
             tx.commit().await?;
-            return Ok(ReplaceTranscriptTagsOutcome::NotFound);
+            return Ok(ReplaceVoiceNoteTagsOutcome::NotFound);
         }
 
         for tag_id in tag_ids {
@@ -1336,114 +1336,114 @@ impl Storage {
             .await?;
             if tag_exists.is_none() {
                 tx.commit().await?;
-                return Ok(ReplaceTranscriptTagsOutcome::NotFound);
+                return Ok(ReplaceVoiceNoteTagsOutcome::NotFound);
             }
         }
 
         sqlx::query(
             r#"
-            DELETE FROM transcript_tags
-            WHERE api_key_id = ? AND transcript_id = ?
+            DELETE FROM voice_note_tags
+            WHERE api_key_id = ? AND voice_note_id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .execute(&mut *tx)
         .await?;
 
         for tag_id in tag_ids {
             sqlx::query(
                 r#"
-                INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+                INSERT INTO voice_note_tags (api_key_id, voice_note_id, tag_id)
                 VALUES (?, ?, ?)
                 "#,
             )
             .bind(api_key_id)
-            .bind(transcript_id)
+            .bind(voice_note_id)
             .bind(tag_id)
             .execute(&mut *tx)
             .await?;
         }
 
         tx.commit().await?;
-        Ok(ReplaceTranscriptTagsOutcome::Replaced)
+        Ok(ReplaceVoiceNoteTagsOutcome::Replaced)
     }
 
-    pub async fn list_transcript_tags(
+    pub async fn list_voice_note_tags(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<Vec<TagRecord>, StorageError> {
         let rows = sqlx::query(
             r#"
             SELECT tags.id, tags.api_key_id, tags.name, tags.created_at
             FROM tags
-            JOIN transcript_tags
-                ON transcript_tags.api_key_id = tags.api_key_id
-                AND transcript_tags.tag_id = tags.id
-            WHERE transcript_tags.api_key_id = ?
-                AND transcript_tags.transcript_id = ?
+            JOIN voice_note_tags
+                ON voice_note_tags.api_key_id = tags.api_key_id
+                AND voice_note_tags.tag_id = tags.id
+            WHERE voice_note_tags.api_key_id = ?
+                AND voice_note_tags.voice_note_id = ?
             ORDER BY tags.created_at DESC, tags.id DESC
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_all(&self.pool)
         .await?;
 
         rows.into_iter().map(tag_from_row).collect()
     }
 
-    pub async fn list_tags_for_transcripts(
+    pub async fn list_tags_for_voice_notes(
         &self,
         api_key_id: &str,
-        transcript_ids: &[String],
+        voice_note_ids: &[String],
     ) -> Result<HashMap<String, Vec<TagRecord>>, StorageError> {
-        if transcript_ids.is_empty() {
+        if voice_note_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
         let mut query = QueryBuilder::new(
             r#"
             SELECT
-                transcript_tags.transcript_id AS transcript_id,
+                voice_note_tags.voice_note_id AS voice_note_id,
                 tags.id AS tag_id,
                 tags.api_key_id AS api_key_id,
                 tags.name AS name,
                 tags.created_at AS created_at
-            FROM transcript_tags
+            FROM voice_note_tags
             JOIN tags
-                ON tags.api_key_id = transcript_tags.api_key_id
-                AND tags.id = transcript_tags.tag_id
-            WHERE transcript_tags.api_key_id =
+                ON tags.api_key_id = voice_note_tags.api_key_id
+                AND tags.id = voice_note_tags.tag_id
+            WHERE voice_note_tags.api_key_id =
             "#,
         );
         query.push_bind(api_key_id);
-        query.push(" AND transcript_tags.transcript_id IN (");
+        query.push(" AND voice_note_tags.voice_note_id IN (");
         let mut separated = query.separated(", ");
-        for transcript_id in transcript_ids {
-            separated.push_bind(transcript_id);
+        for voice_note_id in voice_note_ids {
+            separated.push_bind(voice_note_id);
         }
         separated.push_unseparated(")");
         query.push(
-            " ORDER BY transcript_tags.transcript_id ASC, tags.created_at DESC, tags.id DESC",
+            " ORDER BY voice_note_tags.voice_note_id ASC, tags.created_at DESC, tags.id DESC",
         );
 
         let rows = query.build().fetch_all(&self.pool).await?;
-        let mut tags_by_transcript = HashMap::new();
-        for transcript_id in transcript_ids {
-            tags_by_transcript.insert(transcript_id.clone(), Vec::new());
+        let mut tags_by_voice_note = HashMap::new();
+        for voice_note_id in voice_note_ids {
+            tags_by_voice_note.insert(voice_note_id.clone(), Vec::new());
         }
         for row in rows {
-            let transcript_id: String = row.try_get("transcript_id")?;
+            let voice_note_id: String = row.try_get("voice_note_id")?;
             let tag = tag_from_prefixed_row(row)?;
-            tags_by_transcript
-                .entry(transcript_id)
+            tags_by_voice_note
+                .entry(voice_note_id)
                 .or_default()
                 .push(tag);
         }
 
-        Ok(tags_by_transcript)
+        Ok(tags_by_voice_note)
     }
 }
 
@@ -1567,7 +1567,7 @@ fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, 
         failure_code: row.try_get("failure_code")?,
         failure_message: row.try_get("failure_message")?,
         retryable_by_client,
-        transcript_id: row.try_get("transcript_id")?,
+        voice_note_id: row.try_get("voice_note_id")?,
     })
 }
 
@@ -1577,16 +1577,16 @@ fn settings_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SettingsRecord, Sto
     })
 }
 
-fn transcript_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptRecord, StorageError> {
-    Ok(TranscriptRecord {
+fn voice_note_from_row(row: sqlx::sqlite::SqliteRow) -> Result<VoiceNoteRecord, StorageError> {
+    Ok(VoiceNoteRecord {
         id: row.try_get("id")?,
         api_key_id: row.try_get("api_key_id")?,
         current_version_id: row.try_get("current_version_id")?,
-        transcript: row.try_get("current_transcript")?,
+        text: row.try_get("current_text")?,
         audio_duration_seconds: row.try_get("audio_duration_seconds")?,
         audio_format: row.try_get("audio_format")?,
         audio_size_bytes: row.try_get("audio_size_bytes")?,
-        transcript_language: row.try_get("transcript_language")?,
+        language: row.try_get("language")?,
         model: row.try_get("model")?,
         processing_time_ms: row.try_get("processing_time_ms")?,
         cost_cents: row.try_get("cost_cents")?,
@@ -1596,13 +1596,13 @@ fn transcript_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptRecord,
     })
 }
 
-fn transcript_version_from_row(
+fn voice_note_version_from_row(
     row: sqlx::sqlite::SqliteRow,
-) -> Result<TranscriptVersionRecord, StorageError> {
-    Ok(TranscriptVersionRecord {
+) -> Result<VoiceNoteVersionRecord, StorageError> {
+    Ok(VoiceNoteVersionRecord {
         id: row.try_get("id")?,
-        transcript_id: row.try_get("transcript_id")?,
-        transcript: row.try_get("transcript")?,
+        voice_note_id: row.try_get("voice_note_id")?,
+        text: row.try_get("text")?,
         created_at: parse_timestamp(row.try_get("created_at")?)?,
     })
 }
@@ -1610,7 +1610,7 @@ fn transcript_version_from_row(
 fn segment_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SegmentRecord, StorageError> {
     Ok(SegmentRecord {
         id: row.try_get("id")?,
-        transcript_id: row.try_get("transcript_id")?,
+        voice_note_id: row.try_get("voice_note_id")?,
         position: row.try_get("position")?,
         start_ms: row.try_get("start_ms")?,
         end_ms: row.try_get("end_ms")?,
@@ -1620,7 +1620,7 @@ fn segment_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SegmentRecord, Stora
 
 fn embedding_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EmbeddingRecord, StorageError> {
     Ok(EmbeddingRecord {
-        transcript_id: row.try_get("transcript_id")?,
+        voice_note_id: row.try_get("voice_note_id")?,
         model: row.try_get("model")?,
         vector: row.try_get("vector")?,
         created_at: parse_timestamp(row.try_get("created_at")?)?,

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -12,7 +12,7 @@ use crate::collections::{
 use crate::errors::{ApiError, CollectionEnvelope};
 use crate::state::AppState;
 use crate::storage::{
-    SegmentRecord, TagRecord, TranscriptFilters, TranscriptRecord, TranscriptVersionRecord,
+    SegmentRecord, TagRecord, VoiceNoteFilters, VoiceNoteRecord, VoiceNoteVersionRecord,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,7 +32,7 @@ struct PageQuery<T> {
 #[derive(Debug, Clone)]
 struct VoiceNoteCollectionQuery {
     page: PageQuery<(OffsetDateTime, String)>,
-    filters: TranscriptFilters,
+    filters: VoiceNoteFilters,
     search_requested: bool,
 }
 
@@ -92,7 +92,7 @@ pub async fn list_voice_notes(
 
     let rows = state
         .storage
-        .list_transcripts(
+        .list_voice_notes(
             authenticated_key.api_key_id.as_str(),
             &query.filters,
             query.page.cursor,
@@ -119,7 +119,7 @@ pub async fn get_voice_note(
     validate_ulid_field("voice_note_id", &voice_note_id)?;
     let Some(record) = state
         .storage
-        .get_transcript(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .get_voice_note(authenticated_key.api_key_id.as_str(), &voice_note_id)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note."))?
     else {
@@ -127,7 +127,7 @@ pub async fn get_voice_note(
     };
     let tags = state
         .storage
-        .list_transcript_tags(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .list_voice_note_tags(authenticated_key.api_key_id.as_str(), &voice_note_id)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
 
@@ -151,7 +151,7 @@ pub async fn list_voice_note_versions(
     .await?;
     let mut rows = state
         .storage
-        .list_transcript_versions(
+        .list_voice_note_versions(
             authenticated_key.api_key_id.as_str(),
             &voice_note_id,
             page.cursor,
@@ -251,7 +251,7 @@ pub async fn list_session_voice_notes(
 
     let rows = state
         .storage
-        .list_session_transcripts(
+        .list_session_voice_notes(
             authenticated_key.api_key_id.as_str(),
             &session_id,
             &query.filters,
@@ -278,7 +278,7 @@ async fn ensure_voice_note_exists(
 ) -> Result<(), ApiError> {
     if state
         .storage
-        .get_transcript(api_key_id, voice_note_id)
+        .get_voice_note(api_key_id, voice_note_id)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note."))?
         .is_none()
@@ -292,7 +292,7 @@ async fn ensure_voice_note_exists(
 async fn render_voice_note_page(
     api_key_id: &str,
     state: &AppState,
-    mut rows: Vec<TranscriptRecord>,
+    mut rows: Vec<VoiceNoteRecord>,
     limit: i64,
     cursor_kind: CursorKind,
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
@@ -309,16 +309,16 @@ async fn render_voice_note_page(
     } else {
         None
     };
-    let transcript_ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
-    let mut tags_by_transcript = state
+    let voice_note_ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+    let mut tags_by_voice_note = state
         .storage
-        .list_tags_for_transcripts(api_key_id, &transcript_ids)
+        .list_tags_for_voice_notes(api_key_id, &voice_note_ids)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
     let items = rows
         .into_iter()
         .map(|row| {
-            let tags = tags_by_transcript.remove(&row.id).unwrap_or_default();
+            let tags = tags_by_voice_note.remove(&row.id).unwrap_or_default();
             voice_note_resource(row, tags)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -346,7 +346,7 @@ fn parse_voice_note_collection_query(
                 .map(|cursor| parse_time_cursor(cursor, cursor_kind.as_str()))
                 .transpose()?,
         },
-        filters: parse_transcript_filters(params, cursor_kind)?,
+        filters: parse_voice_note_filters(params, cursor_kind)?,
         search_requested: query_any(params, "q"),
     })
 }
@@ -451,11 +451,11 @@ fn validate_collection_query_values(
     Ok(())
 }
 
-fn parse_transcript_filters(
+fn parse_voice_note_filters(
     params: &[(String, String)],
     cursor_kind: CursorKind,
-) -> Result<TranscriptFilters, ApiError> {
-    let mut filters = TranscriptFilters::default();
+) -> Result<VoiceNoteFilters, ApiError> {
+    let mut filters = VoiceNoteFilters::default();
     for tag_id in query_values(params, "tag_id") {
         let tag_id = tag_id.to_owned();
         if !filters.tag_ids.contains(&tag_id) {
@@ -483,17 +483,17 @@ fn parse_optional_rfc3339_filter(
 }
 
 fn voice_note_resource(
-    record: TranscriptRecord,
+    record: VoiceNoteRecord,
     tags: Vec<TagRecord>,
 ) -> Result<VoiceNoteResource, ApiError> {
     Ok(VoiceNoteResource {
         id: record.id,
         current_version_id: record.current_version_id,
-        text: record.transcript,
+        text: record.text,
         audio_duration_seconds: record.audio_duration_seconds,
         audio_format: record.audio_format,
         audio_size_bytes: record.audio_size_bytes,
-        language: record.transcript_language,
+        language: record.language,
         model: record.model,
         processing_time_ms: record.processing_time_ms,
         cost_cents: record.cost_cents,
@@ -508,12 +508,12 @@ fn voice_note_resource(
 }
 
 fn voice_note_version_resource(
-    record: TranscriptVersionRecord,
+    record: VoiceNoteVersionRecord,
 ) -> Result<VoiceNoteVersionResource, ApiError> {
     Ok(VoiceNoteVersionResource {
         id: record.id,
-        voice_note_id: record.transcript_id,
-        text: record.transcript,
+        voice_note_id: record.voice_note_id,
+        text: record.text,
         created_at: timestamp(record.created_at)?,
     })
 }
@@ -521,7 +521,7 @@ fn voice_note_version_resource(
 fn segment_resource(record: SegmentRecord) -> SegmentResource {
     SegmentResource {
         id: record.id,
-        voice_note_id: record.transcript_id,
+        voice_note_id: record.voice_note_id,
         position: record.position,
         start_ms: record.start_ms,
         end_ms: record.end_ms,

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -571,10 +571,10 @@ impl MetadataFixture {
     }
 
     async fn insert_voice_note_with_tag(&self, owner: &str, tag_id: &str) {
-        self.insert_transcript(owner, None).await;
+        self.insert_voice_note(owner, None).await;
         sqlx::query(
             r#"
-            INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+            INSERT INTO voice_note_tags (api_key_id, voice_note_id, tag_id)
             VALUES (?, ?, ?)
             "#,
         )
@@ -583,18 +583,18 @@ impl MetadataFixture {
         .bind(tag_id)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript tag");
+        .expect("insert voice note tag");
     }
 
     async fn insert_job_and_voice_note_in_session(&self) {
-        self.insert_transcript("alpha", Some(SESSION_ALPHA)).await;
+        self.insert_voice_note("alpha", Some(SESSION_ALPHA)).await;
         sqlx::query(
             r#"
             INSERT INTO transcription_jobs (
                 id, api_key_id, idempotency_key, audio_sha256_hex,
                 audio_content_hash_algorithm, recorded_at, session_id,
                 accepted_audio_path, status, created_at, updated_at,
-                retry_count, max_retries, transcript_id
+                retry_count, max_retries, voice_note_id
             )
             VALUES (
                 ?, 'alpha', 'attempt-a', 'hash', 'sha256:chunk-sha256-v1',
@@ -612,12 +612,12 @@ impl MetadataFixture {
         .expect("insert job");
     }
 
-    async fn insert_transcript(&self, owner: &str, session_id: Option<&str>) {
+    async fn insert_voice_note(&self, owner: &str, session_id: Option<&str>) {
         sqlx::query(
             r#"
-            INSERT INTO transcripts (
+            INSERT INTO voice_notes (
                 id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-                transcript_language, model, processing_time_ms, cost_cents,
+                language, model, processing_time_ms, cost_cents,
                 created_at, recorded_at, session_id
             )
             VALUES (?, ?, 12.5, 'wav', 401280, 'en', 'gpt-4o-mini-transcribe', 1843, NULL, ?, ?, ?)
@@ -630,12 +630,12 @@ impl MetadataFixture {
         .bind(session_id)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript");
+        .expect("insert voice note");
 
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, 1, 'note text', '2026-04-24T18:00:00.000000000Z')
             "#,
@@ -645,7 +645,7 @@ impl MetadataFixture {
         .bind(NOTE_ALPHA)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript version");
+        .expect("insert voice note version");
     }
 }
 

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -614,13 +614,15 @@ key = "key-one"
         .expect("valid runtime");
 
     assert!(database_path.exists());
-    let table_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'transcription_jobs'",
-    )
-    .fetch_one(state.storage.pool())
-    .await
-    .expect("query migrated schema");
-    assert_eq!(table_count, 1);
+    let table_names: Vec<String> =
+        sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name ASC")
+            .fetch_all(state.storage.pool())
+            .await
+            .expect("query migrated schema");
+    let legacy_table = ["trans", "cripts"].concat();
+    assert!(table_names.iter().any(|name| name == "transcription_jobs"));
+    assert!(table_names.iter().any(|name| name == "voice_notes"));
+    assert!(!table_names.iter().any(|name| name == &legacy_table));
 }
 
 #[tokio::test]

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use oracy_backend::audio_hash::{AUDIO_CONTENT_HASH_ALGORITHM_ID, compose_audio_content_hash_hex};
 use oracy_backend::storage::{
     AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewSegment, NewSession, NewTag,
-    NewTranscript, NewTranscriptVersion, NewTranscriptionJob, RenameTagOutcome,
-    ReplaceTranscriptTagsOutcome, Storage, StorageError, TranscriptMaterialization,
+    NewTranscriptionJob, NewVoiceNote, NewVoiceNoteVersion, RenameTagOutcome,
+    ReplaceVoiceNoteTagsOutcome, Storage, StorageError, VoiceNoteMaterialization,
 };
 use sqlx::Row;
 use tempfile::TempDir;
@@ -320,23 +320,23 @@ async fn accepted_submission_tuple_is_immutable_in_storage() {
 }
 
 #[tokio::test]
-async fn transcript_materialization_is_transactional() {
+async fn voice_note_materialization_is_transactional() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_processing(&storage, &job.id).await;
-    let mut materialization = materialization("transcript-a");
+    let mut materialization = materialization("voice-note-a");
     materialization.segments[1].position = materialization.segments[0].position;
 
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization)
+        .complete_job_with_voice_note("owner-a", &job.id, materialization)
         .await
         .expect_err("duplicate segment position should fail");
 
     assert!(
         storage
-            .get_transcript("owner-a", "transcript-a")
+            .get_voice_note("owner-a", "voice-note-a")
             .await
-            .expect("transcript lookup")
+            .expect("voice note lookup")
             .is_none()
     );
     let job = storage
@@ -345,41 +345,41 @@ async fn transcript_materialization_is_transactional() {
         .expect("job lookup")
         .expect("job exists");
     assert_eq!(job.status, "processing");
-    assert_eq!(job.transcript_id, None);
+    assert_eq!(job.voice_note_id, None);
 }
 
 #[tokio::test]
-async fn completed_transcripts_expose_current_version_ordered_segments_and_current_embedding() {
+async fn completed_voice_notes_expose_current_version_ordered_segments_and_current_embedding() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_processing(&storage, &job.id).await;
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
-        .expect("materialize transcript");
+        .expect("materialize voice note");
 
     sqlx::query(
         r#"
-        INSERT INTO transcript_versions (
-            id, api_key_id, transcript_id, version_number, transcript, created_at
+        INSERT INTO voice_note_versions (
+            id, api_key_id, voice_note_id, version_number, text, created_at
         )
-        VALUES ('version-2', 'owner-a', 'transcript-a', 2, 'edited text', '2026-04-24T18:01:00Z')
+        VALUES ('version-2', 'owner-a', 'voice-note-a', 2, 'edited text', '2026-04-24T18:01:00Z')
         "#,
     )
     .execute(storage.pool())
     .await
     .expect("insert edited version");
 
-    let transcript = storage
-        .get_transcript("owner-a", "transcript-a")
+    let voice_note = storage
+        .get_voice_note("owner-a", "voice-note-a")
         .await
-        .expect("transcript lookup")
-        .expect("transcript exists");
-    assert_eq!(transcript.current_version_id, "version-2");
-    assert_eq!(transcript.transcript, "edited text");
+        .expect("voice note lookup")
+        .expect("voice note exists");
+    assert_eq!(voice_note.current_version_id, "version-2");
+    assert_eq!(voice_note.text, "edited text");
 
     let segments = storage
-        .list_segments("owner-a", "transcript-a")
+        .list_segments("owner-a", "voice-note-a")
         .await
         .expect("segments");
     assert_eq!(
@@ -391,7 +391,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
     );
 
     let initial_embedding = storage
-        .get_current_embedding("owner-a", "transcript-a")
+        .get_current_embedding("owner-a", "voice-note-a")
         .await
         .expect("embedding lookup")
         .expect("embedding exists");
@@ -401,7 +401,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
         storage
             .replace_current_embedding(
                 "owner-a",
-                "transcript-a",
+                "voice-note-a",
                 NewEmbedding {
                     model: "embedding-v2".to_owned(),
                     vector: vec![4, 5, 6],
@@ -415,7 +415,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
         !storage
             .replace_current_embedding(
                 "owner-b",
-                "transcript-a",
+                "voice-note-a",
                 NewEmbedding {
                     model: "wrong-owner".to_owned(),
                     vector: vec![9],
@@ -427,7 +427,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
     );
 
     let replaced = storage
-        .get_current_embedding("owner-a", "transcript-a")
+        .get_current_embedding("owner-a", "voice-note-a")
         .await
         .expect("embedding lookup")
         .expect("embedding exists");
@@ -442,12 +442,12 @@ async fn duplicate_completion_fails_without_orphaning_materialized_rows() {
     mark_job_processing(&storage, &job.id).await;
 
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
         .expect("first materialization succeeds");
 
     let error = storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-b"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-b"))
         .await
         .expect_err("duplicate materialization should fail");
     assert!(matches!(
@@ -461,30 +461,30 @@ async fn duplicate_completion_fails_without_orphaning_materialized_rows() {
         .expect("job lookup")
         .expect("job exists");
     assert_eq!(job.status, "succeeded");
-    assert_eq!(job.transcript_id.as_deref(), Some("transcript-a"));
-    assert_eq!(row_count(&storage, "transcripts", "transcript-b").await, 0);
+    assert_eq!(job.voice_note_id.as_deref(), Some("voice-note-a"));
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-b").await, 0);
     assert_eq!(
-        child_row_count(&storage, "transcript_versions", "transcript-b").await,
+        child_row_count(&storage, "voice_note_versions", "voice-note-b").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "segments", "transcript-b").await,
+        child_row_count(&storage, "segments", "voice-note-b").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "embeddings", "transcript-b").await,
+        child_row_count(&storage, "embeddings", "voice-note-b").await,
         0
     );
 }
 
 #[tokio::test]
-async fn retry_waiting_jobs_are_not_eligible_for_transcript_completion() {
+async fn retry_waiting_jobs_are_not_eligible_for_voice_note_completion() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_retry_waiting(&storage, &job.id).await;
 
     let error = storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
         .expect_err("retry-waiting completion should fail");
     assert!(matches!(
@@ -498,18 +498,18 @@ async fn retry_waiting_jobs_are_not_eligible_for_transcript_completion() {
         .expect("job lookup")
         .expect("job exists");
     assert_eq!(job.status, "retry_waiting");
-    assert_eq!(job.transcript_id, None);
-    assert_eq!(row_count(&storage, "transcripts", "transcript-a").await, 0);
+    assert_eq!(job.voice_note_id, None);
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-a").await, 0);
     assert_eq!(
-        child_row_count(&storage, "transcript_versions", "transcript-a").await,
+        child_row_count(&storage, "voice_note_versions", "voice-note-a").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "segments", "transcript-a").await,
+        child_row_count(&storage, "segments", "voice-note-a").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "embeddings", "transcript-a").await,
+        child_row_count(&storage, "embeddings", "voice-note-a").await,
         0
     );
 }
@@ -607,38 +607,38 @@ async fn persisted_timestamps_order_and_filter_chronologically_under_sql_text_co
 }
 
 #[tokio::test]
-async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
+async fn deleting_a_voice_note_cascades_children_and_nulls_the_succeeded_job() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_processing(&storage, &job.id).await;
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
-        .expect("materialize transcript");
+        .expect("materialize voice note");
 
     assert!(
         storage
-            .delete_transcript("owner-a", "transcript-a")
+            .delete_voice_note("owner-a", "voice-note-a")
             .await
-            .expect("delete transcript")
+            .expect("delete voice note")
     );
     assert!(
         storage
-            .get_transcript("owner-a", "transcript-a")
+            .get_voice_note("owner-a", "voice-note-a")
             .await
-            .expect("transcript lookup")
+            .expect("voice note lookup")
             .is_none()
     );
     assert!(
         storage
-            .list_segments("owner-a", "transcript-a")
+            .list_segments("owner-a", "voice-note-a")
             .await
             .expect("segments")
             .is_empty()
     );
     assert!(
         storage
-            .get_current_embedding("owner-a", "transcript-a")
+            .get_current_embedding("owner-a", "voice-note-a")
             .await
             .expect("embedding lookup")
             .is_none()
@@ -650,36 +650,36 @@ async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
         .expect("job lookup")
         .expect("job survives");
     assert_eq!(job.status, "succeeded");
-    assert_eq!(job.transcript_id, None);
+    assert_eq!(job.voice_note_id, None);
 }
 
 #[tokio::test]
-async fn transcript_child_rows_must_match_the_parent_transcript_owner() {
+async fn voice_note_child_rows_must_match_the_parent_voice_note_owner() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
 
     sqlx::query(
         r#"
-        INSERT INTO transcript_versions (
-            id, api_key_id, transcript_id, version_number, transcript, created_at
+        INSERT INTO voice_note_versions (
+            id, api_key_id, voice_note_id, version_number, text, created_at
         )
         VALUES (
-            'owner-mismatched-version', 'owner-b', 'transcript-a', 1,
+            'owner-mismatched-version', 'owner-b', 'voice-note-a', 1,
             'cross-owner version', '2026-04-24T18:00:30.000000000Z'
         )
         "#,
     )
     .execute(storage.pool())
     .await
-    .expect_err("mismatched transcript version owner should fail");
+    .expect_err("mismatched voice note version owner should fail");
 
     sqlx::query(
         r#"
         INSERT INTO segments (
-            id, api_key_id, transcript_id, position, start_ms, end_ms, text
+            id, api_key_id, voice_note_id, position, start_ms, end_ms, text
         )
         VALUES (
-            'owner-mismatched-segment', 'owner-b', 'transcript-a', 0, 0, 1000,
+            'owner-mismatched-segment', 'owner-b', 'voice-note-a', 0, 0, 1000,
             'cross-owner segment'
         )
         "#,
@@ -690,9 +690,9 @@ async fn transcript_child_rows_must_match_the_parent_transcript_owner() {
 
     sqlx::query(
         r#"
-        INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+        INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
         VALUES (
-            'transcript-a', 'owner-b', 'embedding-v1', x'010203',
+            'voice-note-a', 'owner-b', 'embedding-v1', x'010203',
             '2026-04-24T18:00:31.000000000Z'
         )
         "#,
@@ -703,31 +703,31 @@ async fn transcript_child_rows_must_match_the_parent_transcript_owner() {
 }
 
 #[tokio::test]
-async fn completed_job_transcript_link_must_match_the_job_owner() {
+async fn completed_job_voice_note_link_must_match_the_job_owner() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let job = created_job(&storage, "owner-b", "attempt-1").await;
 
     sqlx::query(
         r#"
         UPDATE transcription_jobs
-        SET transcript_id = 'transcript-a'
+        SET voice_note_id = 'voice-note-a'
         WHERE id = ?
         "#,
     )
     .bind(&job.id)
     .execute(storage.pool())
     .await
-    .expect_err("mismatched job transcript owner should fail");
+    .expect_err("mismatched job voice note owner should fail");
 }
 
 #[tokio::test]
-async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many_with_transcripts()
+async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many_with_voice_notes()
 {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
-    insert_transcript_only(&storage, "owner-a", "transcript-b").await;
-    insert_transcript_only(&storage, "owner-b", "transcript-c").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-b").await;
+    insert_voice_note_only(&storage, "owner-b", "voice-note-c").await;
 
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
@@ -760,31 +760,31 @@ async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many
 
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&meeting.id))
+            .replace_voice_note_tags("owner-a", "voice-note-a", std::slice::from_ref(&meeting.id))
             .await
-            .expect("tag transcript"),
-        ReplaceTranscriptTagsOutcome::Replaced
+            .expect("tag voice note"),
+        ReplaceVoiceNoteTagsOutcome::Replaced
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-b", std::slice::from_ref(&meeting.id))
+            .replace_voice_note_tags("owner-a", "voice-note-b", std::slice::from_ref(&meeting.id))
             .await
-            .expect("tag second transcript"),
-        ReplaceTranscriptTagsOutcome::Replaced
+            .expect("tag second voice note"),
+        ReplaceVoiceNoteTagsOutcome::Replaced
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-b", "transcript-c", std::slice::from_ref(&meeting.id))
+            .replace_voice_note_tags("owner-b", "voice-note-c", std::slice::from_ref(&meeting.id))
             .await
             .expect("wrong-owner tag is rejected"),
-        ReplaceTranscriptTagsOutcome::NotFound
+        ReplaceVoiceNoteTagsOutcome::NotFound
     );
 
     assert_eq!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
-            .expect("list transcript tags"),
+            .expect("list voice note tags"),
         vec![replayed.clone()]
     );
 
@@ -796,13 +796,13 @@ async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many
     );
     assert!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
             .expect("tag associations removed")
             .is_empty()
     );
-    assert_eq!(row_count(&storage, "transcripts", "transcript-a").await, 1);
-    assert_eq!(row_count(&storage, "transcripts", "transcript-b").await, 1);
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-a").await, 1);
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-b").await, 1);
 }
 
 #[tokio::test]
@@ -837,9 +837,9 @@ async fn unicode_case_equivalent_tag_names_share_one_owner_scoped_identity() {
 }
 
 #[tokio::test]
-async fn duplicate_transcript_tag_ids_are_rejected_without_mutating_prior_tags() {
+async fn duplicate_voice_note_tag_ids_are_rejected_without_mutating_prior_tags() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
         .await
@@ -858,35 +858,35 @@ async fn duplicate_transcript_tag_ids_are_rejected_without_mutating_prior_tags()
     };
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&notes.id))
+            .replace_voice_note_tags("owner-a", "voice-note-a", std::slice::from_ref(&notes.id))
             .await
             .expect("set prior tag"),
-        ReplaceTranscriptTagsOutcome::Replaced
+        ReplaceVoiceNoteTagsOutcome::Replaced
     );
 
     let outcome = storage
-        .replace_transcript_tags(
+        .replace_voice_note_tags(
             "owner-a",
-            "transcript-a",
+            "voice-note-a",
             &[meeting.id.clone(), meeting.id.clone()],
         )
         .await
         .expect("duplicate-input outcome");
 
-    assert_eq!(outcome, ReplaceTranscriptTagsOutcome::DuplicateTagIds);
+    assert_eq!(outcome, ReplaceVoiceNoteTagsOutcome::DuplicateTagIds);
     assert_eq!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
-            .expect("list transcript tags"),
+            .expect("list voice note tags"),
         vec![notes]
     );
 }
 
 #[tokio::test]
-async fn transcript_tag_replacement_collapses_missing_transcript_and_tag_to_not_found() {
+async fn voice_note_tag_replacement_collapses_missing_voice_note_and_tag_to_not_found() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
         .await
@@ -898,22 +898,22 @@ async fn transcript_tag_replacement_collapses_missing_transcript_and_tag_to_not_
 
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-missing", &[meeting.id])
+            .replace_voice_note_tags("owner-a", "voice-note-missing", &[meeting.id])
             .await
-            .expect("missing transcript outcome"),
-        ReplaceTranscriptTagsOutcome::NotFound
+            .expect("missing voice note outcome"),
+        ReplaceVoiceNoteTagsOutcome::NotFound
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", &["tag-missing".to_owned()])
+            .replace_voice_note_tags("owner-a", "voice-note-a", &["tag-missing".to_owned()])
             .await
             .expect("missing tag outcome"),
-        ReplaceTranscriptTagsOutcome::NotFound
+        ReplaceVoiceNoteTagsOutcome::NotFound
     );
 }
 
 #[tokio::test]
-async fn complete_job_with_transcript_nulls_deleted_accepted_session_without_mutating_job_tuple() {
+async fn complete_job_with_voice_note_nulls_deleted_accepted_session_without_mutating_job_tuple() {
     let (_tempdir, storage) = storage().await;
     let input = new_job("owner-a", "attempt-deleted-session", "hash-a");
     let job = created_job(&storage, "owner-a", "attempt-deleted-session").await;
@@ -927,20 +927,20 @@ async fn complete_job_with_transcript_nulls_deleted_accepted_session_without_mut
     );
 
     storage
-        .complete_job_with_transcript(
+        .complete_job_with_voice_note(
             "owner-a",
             &job.id,
-            materialization("transcript-deleted-session"),
+            materialization("voice-note-deleted-session"),
         )
         .await
-        .expect("materialize transcript after session deletion");
+        .expect("materialize voice note after session deletion");
 
     assert_eq!(
         storage
-            .get_transcript("owner-a", "transcript-deleted-session")
+            .get_voice_note("owner-a", "voice-note-deleted-session")
             .await
-            .expect("transcript lookup")
-            .expect("transcript exists")
+            .expect("voice note lookup")
+            .expect("voice note exists")
             .session_id,
         None
     );
@@ -961,7 +961,7 @@ async fn complete_job_with_transcript_nulls_deleted_accepted_session_without_mut
 }
 
 #[tokio::test]
-async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_tuples() {
+async fn sessions_are_identities_that_null_voice_notes_without_mutating_replay_tuples() {
     let (_tempdir, storage) = storage().await;
     let session = storage
         .create_session(new_session("owner-a", "session-a", "Planning"))
@@ -981,16 +981,16 @@ async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_t
     };
     mark_job_processing(&storage, &job.id).await;
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-session"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-session"))
         .await
-        .expect("materialize transcript");
+        .expect("materialize voice note");
 
     assert_eq!(
         storage
-            .get_transcript("owner-a", "transcript-session")
+            .get_voice_note("owner-a", "voice-note-session")
             .await
-            .expect("transcript lookup")
-            .expect("transcript exists")
+            .expect("voice note lookup")
+            .expect("voice note exists")
             .session_id
             .as_deref(),
         Some("session-a")
@@ -1004,10 +1004,10 @@ async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_t
     );
     assert_eq!(
         storage
-            .get_transcript("owner-a", "transcript-session")
+            .get_voice_note("owner-a", "voice-note-session")
             .await
-            .expect("transcript lookup")
-            .expect("transcript exists")
+            .expect("voice note lookup")
+            .expect("voice note exists")
             .session_id,
         None
     );
@@ -1030,7 +1030,7 @@ async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_t
 #[tokio::test]
 async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collisions() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
         .await
@@ -1048,9 +1048,9 @@ async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collis
         other => panic!("expected created tag, got {other:?}"),
     };
     storage
-        .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&meeting.id))
+        .replace_voice_note_tags("owner-a", "voice-note-a", std::slice::from_ref(&meeting.id))
         .await
-        .expect("tag transcript");
+        .expect("tag voice note");
 
     let renamed = match storage
         .rename_tag("owner-a", &meeting.id, "MEETING")
@@ -1064,9 +1064,9 @@ async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collis
     assert_eq!(renamed.name, "MEETING");
     assert_eq!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
-            .expect("list transcript tags")
+            .expect("list voice note tags")
             .first()
             .expect("tag exists")
             .name,
@@ -1311,12 +1311,12 @@ async fn accept_while_uncommitted_row_exists(
     handle.await.expect("accept task should not panic")
 }
 
-async fn insert_transcript_only(storage: &Storage, owner: &str, transcript_id: &str) {
+async fn insert_voice_note_only(storage: &Storage, owner: &str, voice_note_id: &str) {
     sqlx::query(
         r#"
-        INSERT INTO transcripts (
+        INSERT INTO voice_notes (
             id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-            transcript_language, model, processing_time_ms, cost_cents,
+            language, model, processing_time_ms, cost_cents,
             created_at, recorded_at, session_id
         )
         VALUES (
@@ -1327,11 +1327,11 @@ async fn insert_transcript_only(storage: &Storage, owner: &str, transcript_id: &
         )
         "#,
     )
-    .bind(transcript_id)
+    .bind(voice_note_id)
     .bind(owner)
     .execute(storage.pool())
     .await
-    .expect("insert transcript");
+    .expect("insert voice note");
 }
 
 async fn insert_session_row(storage: &Storage, owner: &str, session_id: &str) {
@@ -1405,10 +1405,10 @@ async fn row_count(storage: &Storage, table: &str, id: &str) -> i64 {
         .get("count")
 }
 
-async fn child_row_count(storage: &Storage, table: &str, transcript_id: &str) -> i64 {
-    let sql = format!("SELECT COUNT(*) AS count FROM {table} WHERE transcript_id = ?");
+async fn child_row_count(storage: &Storage, table: &str, voice_note_id: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) AS count FROM {table} WHERE voice_note_id = ?");
     sqlx::query(&sql)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_one(storage.pool())
         .await
         .expect("count child rows")
@@ -1447,35 +1447,35 @@ fn new_session(owner: &str, id: &str, name: &str) -> NewSession {
     }
 }
 
-fn materialization(transcript_id: &str) -> TranscriptMaterialization {
-    TranscriptMaterialization {
-        transcript: NewTranscript {
-            id: transcript_id.to_owned(),
+fn materialization(voice_note_id: &str) -> VoiceNoteMaterialization {
+    VoiceNoteMaterialization {
+        voice_note: NewVoiceNote {
+            id: voice_note_id.to_owned(),
             audio_duration_seconds: 12.5,
             audio_format: "wav".to_owned(),
             audio_size_bytes: 401_280,
-            transcript_language: Some("en".to_owned()),
+            language: Some("en".to_owned()),
             model: "general-transcription-v1".to_owned(),
             processing_time_ms: 1_843,
             cost_cents: Some(1),
             created_at: datetime!(2026-04-24 18:00:30 UTC),
             recorded_at: datetime!(2026-04-24 17:59:00 UTC),
         },
-        initial_version: NewTranscriptVersion {
-            id: format!("{transcript_id}-version-1"),
-            transcript: "initial text".to_owned(),
+        initial_version: NewVoiceNoteVersion {
+            id: format!("{voice_note_id}-version-1"),
+            text: "initial text".to_owned(),
             created_at: datetime!(2026-04-24 18:00:30 UTC),
         },
         segments: vec![
             NewSegment {
-                id: format!("{transcript_id}-segment-1"),
+                id: format!("{voice_note_id}-segment-1"),
                 position: 0,
                 start_ms: 0,
                 end_ms: 1_000,
                 text: "first segment".to_owned(),
             },
             NewSegment {
-                id: format!("{transcript_id}-segment-2"),
+                id: format!("{voice_note_id}-segment-2"),
                 position: 1,
                 start_ms: 1_000,
                 end_ms: 2_000,

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -972,9 +972,9 @@ impl VoiceNoteFixture {
 
         sqlx::query(
             r#"
-            INSERT INTO transcripts (
+            INSERT INTO voice_notes (
                 id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-                transcript_language, model, processing_time_ms, cost_cents,
+                language, model, processing_time_ms, cost_cents,
                 created_at, recorded_at, session_id
             )
             VALUES (?, ?, 12.5, 'wav', 401280, 'en', 'gpt-4o-mini-transcribe', 1843, NULL, ?, ?, ?)
@@ -987,12 +987,12 @@ impl VoiceNoteFixture {
         .bind(seed.session_id)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript");
+        .expect("insert voice note");
 
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, 1, ?, ?)
             "#,
@@ -1004,7 +1004,7 @@ impl VoiceNoteFixture {
         .bind(seed.created_at)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript version");
+        .expect("insert voice note version");
 
         for tag in seed.tags {
             sqlx::query(
@@ -1024,7 +1024,7 @@ impl VoiceNoteFixture {
 
             sqlx::query(
                 r#"
-                INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+                INSERT INTO voice_note_tags (api_key_id, voice_note_id, tag_id)
                 VALUES (?, ?, ?)
                 "#,
             )
@@ -1033,7 +1033,7 @@ impl VoiceNoteFixture {
             .bind(tag.id)
             .execute(self.storage.pool())
             .await
-            .expect("insert transcript tag");
+            .expect("insert voice note tag");
         }
     }
 
@@ -1048,8 +1048,8 @@ impl VoiceNoteFixture {
     ) {
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, ?, ?, ?)
             "#,
@@ -1062,7 +1062,7 @@ impl VoiceNoteFixture {
         .bind(created_at)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript version");
+        .expect("insert voice note version");
     }
 
     async fn insert_segment(
@@ -1076,7 +1076,7 @@ impl VoiceNoteFixture {
         sqlx::query(
             r#"
             INSERT INTO segments (
-                id, api_key_id, transcript_id, position, start_ms, end_ms, text
+                id, api_key_id, voice_note_id, position, start_ms, end_ms, text
             )
             VALUES (?, ?, ?, ?, ?, ?, ?)
             "#,

--- a/client/lib/app.dart
+++ b/client/lib/app.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/screens/history_screen.dart';
 import 'package:oracy/screens/settings_screen.dart';
-import 'package:oracy/screens/transcript_result_screen.dart';
+import 'package:oracy/screens/voice_note_result_screen.dart';
 import 'package:oracy/services/home_widget_service.dart';
 import 'package:oracy/services/preferences_service.dart';
 import 'package:oracy/services/recording_service.dart';
@@ -109,7 +109,7 @@ class _HomePageState extends ConsumerState<HomePage>
         // Auto-copy to clipboard if enabled
         final autoCopyEnabled = ref.read(autoCopyEnabledProvider);
         if (autoCopyEnabled) {
-          Clipboard.setData(ClipboardData(text: next.transcript.transcript));
+          Clipboard.setData(ClipboardData(text: next.voiceNote.text));
           // Haptic feedback to indicate copy
           HapticFeedback.mediumImpact();
         }
@@ -118,8 +118,8 @@ class _HomePageState extends ConsumerState<HomePage>
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => TranscriptResultScreen(
-              transcript: next.transcript,
+            builder: (_) => VoiceNoteResultScreen(
+              voiceNote: next.voiceNote,
               wasAutoCopied: autoCopyEnabled,
             ),
           ),

--- a/client/lib/screens/history_screen.dart
+++ b/client/lib/screens/history_screen.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:oracy/screens/transcript_result_screen.dart';
+import 'package:oracy/screens/voice_note_result_screen.dart';
 import 'package:oracy/services/history_service.dart';
 import 'package:oracy/services/transcription_service.dart';
 
@@ -26,30 +26,28 @@ final searchQueryProvider = NotifierProvider<SearchQueryNotifier, String>(
   SearchQueryNotifier.new,
 );
 
-/// Groups a list of transcripts by date category.
-class _DateGroupedTranscripts {
-  final List<TranscriptResponse> today;
-  final List<TranscriptResponse> yesterday;
-  final Map<String, List<TranscriptResponse>> older;
+/// Groups a list of voice notes by date category.
+class _DateGroupedVoiceNotes {
+  final List<VoiceNoteResponse> today;
+  final List<VoiceNoteResponse> yesterday;
+  final Map<String, List<VoiceNoteResponse>> older;
 
-  _DateGroupedTranscripts({
+  _DateGroupedVoiceNotes({
     required this.today,
     required this.yesterday,
     required this.older,
   });
 
-  factory _DateGroupedTranscripts.fromList(
-    List<TranscriptResponse> transcripts,
-  ) {
+  factory _DateGroupedVoiceNotes.fromList(List<VoiceNoteResponse> voiceNotes) {
     final now = DateTime.now();
     final todayStart = DateTime(now.year, now.month, now.day);
     final yesterdayStart = todayStart.subtract(const Duration(days: 1));
 
-    final today = <TranscriptResponse>[];
-    final yesterday = <TranscriptResponse>[];
-    final older = <String, List<TranscriptResponse>>{};
+    final today = <VoiceNoteResponse>[];
+    final yesterday = <VoiceNoteResponse>[];
+    final older = <String, List<VoiceNoteResponse>>{};
 
-    for (final t in transcripts) {
+    for (final t in voiceNotes) {
       if (t.createdAt.isAfter(todayStart)) {
         today.add(t);
       } else if (t.createdAt.isAfter(yesterdayStart)) {
@@ -61,7 +59,7 @@ class _DateGroupedTranscripts {
       }
     }
 
-    return _DateGroupedTranscripts(
+    return _DateGroupedVoiceNotes(
       today: today,
       yesterday: yesterday,
       older: older,
@@ -89,7 +87,7 @@ class _DateGroupedTranscripts {
   bool get isEmpty => today.isEmpty && yesterday.isEmpty && older.isEmpty;
 }
 
-/// Screen displaying transcript history with search and pagination.
+/// Screen displaying voice-note history with search and pagination.
 class HistoryScreen extends ConsumerStatefulWidget {
   const HistoryScreen({super.key});
 
@@ -107,7 +105,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     super.initState();
     // Load initial data
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(transcriptHistoryProvider.notifier).loadInitial();
+      ref.read(voiceNoteHistoryProvider.notifier).loadInitial();
     });
 
     // Listen for scroll to load more
@@ -129,7 +127,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     // Load more when near the bottom.
     if (_scrollController.position.pixels >=
         _scrollController.position.maxScrollExtent - 200) {
-      ref.read(transcriptHistoryProvider.notifier).loadMore();
+      ref.read(voiceNoteHistoryProvider.notifier).loadMore();
     }
   }
 
@@ -139,19 +137,19 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     _debounceTimer = Timer(const Duration(milliseconds: 300), () {
       final query = _searchController.text;
       ref.read(searchQueryProvider.notifier).update(query);
-      unawaited(ref.read(transcriptHistoryProvider.notifier).search(query));
+      unawaited(ref.read(voiceNoteHistoryProvider.notifier).search(query));
     });
   }
 
   void _clearSearch() {
     _searchController.clear();
     ref.read(searchQueryProvider.notifier).clear();
-    unawaited(ref.read(transcriptHistoryProvider.notifier).search(''));
+    unawaited(ref.read(voiceNoteHistoryProvider.notifier).search(''));
   }
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(transcriptHistoryProvider);
+    final state = ref.watch(voiceNoteHistoryProvider);
     final searchQuery = ref.watch(searchQueryProvider);
     final theme = Theme.of(context);
 
@@ -165,7 +163,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
             tooltip: 'Refresh',
             onPressed: state.isLoading
                 ? null
-                : () => ref.read(transcriptHistoryProvider.notifier).refresh(),
+                : () => ref.read(voiceNoteHistoryProvider.notifier).refresh(),
           ),
         ],
       ),
@@ -177,7 +175,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
             child: TextField(
               controller: _searchController,
               decoration: InputDecoration(
-                hintText: 'Search transcripts...',
+                hintText: 'Search voice notes...',
                 prefixIcon: const Icon(Icons.search),
                 suffixIcon: searchQuery.isNotEmpty
                     ? IconButton(
@@ -202,7 +200,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
 
           // Results
           Expanded(
-            child: _buildBody(state, state.transcripts, searchQuery, theme),
+            child: _buildBody(state, state.voiceNotes, searchQuery, theme),
           ),
         ],
       ),
@@ -210,25 +208,25 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
   }
 
   Widget _buildBody(
-    TranscriptHistoryState state,
-    List<TranscriptResponse> filteredTranscripts,
+    VoiceNoteHistoryState state,
+    List<VoiceNoteResponse> filteredVoiceNotes,
     String searchQuery,
     ThemeData theme,
   ) {
-    if (state.isLoading && state.transcripts.isEmpty) {
+    if (state.isLoading && state.voiceNotes.isEmpty) {
       return const Center(child: CircularProgressIndicator());
     }
 
-    if (state.error != null && state.transcripts.isEmpty) {
+    if (state.error != null && state.voiceNotes.isEmpty) {
       return _ErrorView(
         message: state.error!,
         onRetry: () =>
-            ref.read(transcriptHistoryProvider.notifier).loadInitial(),
+            ref.read(voiceNoteHistoryProvider.notifier).loadInitial(),
       );
     }
 
     // Show no results message for search
-    if (state.query.isNotEmpty && filteredTranscripts.isEmpty) {
+    if (state.query.isNotEmpty && filteredVoiceNotes.isEmpty) {
       return _NoSearchResults(query: state.query);
     }
 
@@ -236,11 +234,11 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
       return const _EmptyView();
     }
 
-    // Group transcripts by date
-    final grouped = _DateGroupedTranscripts.fromList(filteredTranscripts);
+    // Group voice notes by date
+    final grouped = _DateGroupedVoiceNotes.fromList(filteredVoiceNotes);
 
     return RefreshIndicator(
-      onRefresh: () => ref.read(transcriptHistoryProvider.notifier).refresh(),
+      onRefresh: () => ref.read(voiceNoteHistoryProvider.notifier).refresh(),
       child: ListView(
         controller: _scrollController,
         padding: const EdgeInsets.only(bottom: 16),
@@ -249,9 +247,9 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
           if (grouped.today.isNotEmpty) ...[
             _DateHeader(label: 'Today'),
             ...grouped.today.map(
-              (t) => _TranscriptTile(
-                transcript: t,
-                onTap: () => _openTranscript(t),
+              (t) => _VoiceNoteTile(
+                voiceNote: t,
+                onTap: () => _openVoiceNote(t),
                 searchQuery: searchQuery,
               ),
             ),
@@ -261,9 +259,9 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
           if (grouped.yesterday.isNotEmpty) ...[
             _DateHeader(label: 'Yesterday'),
             ...grouped.yesterday.map(
-              (t) => _TranscriptTile(
-                transcript: t,
-                onTap: () => _openTranscript(t),
+              (t) => _VoiceNoteTile(
+                voiceNote: t,
+                onTap: () => _openVoiceNote(t),
                 searchQuery: searchQuery,
               ),
             ),
@@ -273,9 +271,9 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
           for (final entry in grouped.older.entries) ...[
             _DateHeader(label: entry.key),
             ...entry.value.map(
-              (t) => _TranscriptTile(
-                transcript: t,
-                onTap: () => _openTranscript(t),
+              (t) => _VoiceNoteTile(
+                voiceNote: t,
+                onTap: () => _openVoiceNote(t),
                 searchQuery: searchQuery,
               ),
             ),
@@ -292,17 +290,17 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     );
   }
 
-  void _openTranscript(TranscriptResponse transcript) {
+  void _openVoiceNote(VoiceNoteResponse voiceNote) {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => TranscriptResultScreen(transcript: transcript),
+        builder: (_) => VoiceNoteResultScreen(voiceNote: voiceNote),
       ),
     );
   }
 }
 
-/// Date header for grouping transcripts.
+/// Date header for grouping voice notes.
 class _DateHeader extends StatelessWidget {
   final String label;
 
@@ -325,30 +323,30 @@ class _DateHeader extends StatelessWidget {
   }
 }
 
-/// A tile displaying a transcript summary with expand/collapse.
-class _TranscriptTile extends StatefulWidget {
-  final TranscriptResponse transcript;
+/// A tile displaying a voice note summary with expand/collapse.
+class _VoiceNoteTile extends StatefulWidget {
+  final VoiceNoteResponse voiceNote;
   final VoidCallback onTap;
   final String searchQuery;
 
-  const _TranscriptTile({
-    required this.transcript,
+  const _VoiceNoteTile({
+    required this.voiceNote,
     required this.onTap,
     this.searchQuery = '',
   });
 
   @override
-  State<_TranscriptTile> createState() => _TranscriptTileState();
+  State<_VoiceNoteTile> createState() => _VoiceNoteTileState();
 }
 
-class _TranscriptTileState extends State<_TranscriptTile> {
+class _VoiceNoteTileState extends State<_VoiceNoteTile> {
   bool _isExpanded = false;
 
-  void _copyTranscript() {
-    Clipboard.setData(ClipboardData(text: widget.transcript.transcript));
+  void _copyVoiceNote() {
+    Clipboard.setData(ClipboardData(text: widget.voiceNote.text));
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(
-        content: Text('Transcript copied to clipboard'),
+        content: Text('Voice note copied to clipboard'),
         duration: Duration(seconds: 2),
       ),
     );
@@ -357,10 +355,10 @@ class _TranscriptTileState extends State<_TranscriptTile> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final transcript = widget.transcript;
+    final voiceNote = widget.voiceNote;
 
     // Get text to display
-    final fullText = transcript.transcript;
+    final fullText = voiceNote.text;
     final previewText = fullText.length > 100
         ? '${fullText.substring(0, 100)}...'
         : fullText;
@@ -377,9 +375,9 @@ class _TranscriptTileState extends State<_TranscriptTile> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Transcript text
+              // Voice note text
               Text(
-                displayText.isEmpty ? '(No transcript text)' : displayText,
+                displayText.isEmpty ? '(No voice note text)' : displayText,
                 style: theme.textTheme.bodyMedium,
               ),
 
@@ -407,14 +405,14 @@ class _TranscriptTileState extends State<_TranscriptTile> {
                   // Duration
                   _MetadataChip(
                     icon: Icons.timer_outlined,
-                    label: _formatDuration(transcript.audioDurationSeconds),
+                    label: _formatDuration(voiceNote.audioDurationSeconds),
                   ),
                   const SizedBox(width: 12),
 
                   // Timestamp
                   _MetadataChip(
                     icon: Icons.schedule,
-                    label: _formatTime(transcript.createdAt),
+                    label: _formatTime(voiceNote.createdAt),
                   ),
 
                   const Spacer(),
@@ -422,8 +420,8 @@ class _TranscriptTileState extends State<_TranscriptTile> {
                   // Copy button
                   IconButton(
                     icon: const Icon(Icons.copy, size: 20),
-                    onPressed: _copyTranscript,
-                    tooltip: 'Copy transcript',
+                    onPressed: _copyVoiceNote,
+                    tooltip: 'Copy voice note',
                     visualDensity: VisualDensity.compact,
                     style: IconButton.styleFrom(
                       foregroundColor: theme.colorScheme.onSurfaceVariant,
@@ -431,7 +429,7 @@ class _TranscriptTileState extends State<_TranscriptTile> {
                   ),
 
                   // Language badge
-                  if (transcript.transcriptLanguage != null)
+                  if (voiceNote.language != null)
                     Container(
                       padding: const EdgeInsets.symmetric(
                         horizontal: 8,
@@ -442,7 +440,7 @@ class _TranscriptTileState extends State<_TranscriptTile> {
                         borderRadius: BorderRadius.circular(4),
                       ),
                       child: Text(
-                        transcript.transcriptLanguage!.toUpperCase(),
+                        voiceNote.language!.toUpperCase(),
                         style: theme.textTheme.labelSmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
@@ -504,7 +502,7 @@ class _MetadataChip extends StatelessWidget {
   }
 }
 
-/// Empty state when no transcripts exist.
+/// Empty state when no voice notes exist.
 class _EmptyView extends StatelessWidget {
   const _EmptyView();
 
@@ -524,7 +522,7 @@ class _EmptyView extends StatelessWidget {
               color: theme.colorScheme.onSurfaceVariant,
             ),
             const SizedBox(height: 16),
-            Text('No transcripts yet', style: theme.textTheme.titleLarge),
+            Text('No voice notes yet', style: theme.textTheme.titleLarge),
             const SizedBox(height: 8),
             Text(
               'Your transcription history will appear here.',
@@ -606,7 +604,7 @@ class _NoSearchResults extends StatelessWidget {
             Text('No results found', style: theme.textTheme.titleLarge),
             const SizedBox(height: 8),
             Text(
-              'No transcripts match "$query"',
+              'No voice notes match "$query"',
               textAlign: TextAlign.center,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,

--- a/client/lib/screens/settings_screen.dart
+++ b/client/lib/screens/settings_screen.dart
@@ -332,7 +332,7 @@ class _AutoCopyToggle extends ConsumerWidget {
     return SwitchListTile(
       secondary: const Icon(Icons.content_copy),
       title: const Text('Auto-copy to clipboard'),
-      subtitle: const Text('Copy transcript automatically when complete'),
+      subtitle: const Text('Copy voice note automatically when complete'),
       value: autoCopyEnabled,
       onChanged: (value) {
         ref.read(autoCopyEnabledProvider.notifier).toggle(value);

--- a/client/lib/screens/voice_note_result_screen.dart
+++ b/client/lib/screens/voice_note_result_screen.dart
@@ -5,32 +5,31 @@ import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/widgets/permission_dialog.dart';
 
 /// Screen that displays the result of a transcription.
-class TranscriptResultScreen extends ConsumerStatefulWidget {
-  final TranscriptResponse transcript;
+class VoiceNoteResultScreen extends ConsumerStatefulWidget {
+  final VoiceNoteResponse voiceNote;
   final bool wasAutoCopied;
 
-  const TranscriptResultScreen({
+  const VoiceNoteResultScreen({
     super.key,
-    required this.transcript,
+    required this.voiceNote,
     this.wasAutoCopied = false,
   });
 
   @override
-  ConsumerState<TranscriptResultScreen> createState() =>
-      _TranscriptResultScreenState();
+  ConsumerState<VoiceNoteResultScreen> createState() =>
+      _VoiceNoteResultScreenState();
 }
 
-class _TranscriptResultScreenState
-    extends ConsumerState<TranscriptResultScreen> {
+class _VoiceNoteResultScreenState extends ConsumerState<VoiceNoteResultScreen> {
   @override
   void initState() {
     super.initState();
-    // Show snackbar after build if transcript was auto-copied
+    // Show snackbar after build if voiceNote was auto-copied
     if (widget.wasAutoCopied) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text('Transcript copied to clipboard'),
+            content: Text('Voice note copied to clipboard'),
             duration: Duration(seconds: 2),
             behavior: SnackBarBehavior.floating,
           ),
@@ -45,13 +44,13 @@ class _TranscriptResultScreenState
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Transcript'),
+        title: const Text('Voice note'),
         centerTitle: true,
         actions: [
           IconButton(
             icon: const Icon(Icons.copy),
-            tooltip: 'Copy transcript',
-            onPressed: () => _copyTranscript(context),
+            tooltip: 'Copy voice note',
+            onPressed: () => _copyVoiceNote(context),
           ),
         ],
       ),
@@ -68,33 +67,32 @@ class _TranscriptResultScreenState
                   _MetadataItem(
                     icon: Icons.timer_outlined,
                     label: _formatDuration(
-                      widget.transcript.audioDurationSeconds,
+                      widget.voiceNote.audioDurationSeconds,
                     ),
                     tooltip: 'Audio duration',
                   ),
-                  if (widget.transcript.transcriptLanguage != null)
+                  if (widget.voiceNote.language != null)
                     _MetadataItem(
                       icon: Icons.language,
-                      label: widget.transcript.transcriptLanguage!
-                          .toUpperCase(),
+                      label: widget.voiceNote.language!.toUpperCase(),
                       tooltip: 'Language',
                     ),
                   _MetadataItem(
                     icon: Icons.attach_money,
                     label:
-                        '\$${(widget.transcript.costCents / 100).toStringAsFixed(3)}',
+                        '\$${(widget.voiceNote.costCents / 100).toStringAsFixed(3)}',
                     tooltip: 'Cost',
                   ),
                 ],
               ),
             ),
 
-            // Transcript text
+            // Voice note text
             Expanded(
               child: SingleChildScrollView(
                 padding: const EdgeInsets.all(16),
                 child: SelectableText(
-                  widget.transcript.transcript,
+                  widget.voiceNote.text,
                   style: theme.textTheme.bodyLarge?.copyWith(height: 1.6),
                 ),
               ),
@@ -107,7 +105,7 @@ class _TranscriptResultScreenState
                 children: [
                   Expanded(
                     child: OutlinedButton.icon(
-                      onPressed: () => _copyTranscript(context),
+                      onPressed: () => _copyVoiceNote(context),
                       icon: const Icon(Icons.copy),
                       label: const Text('Copy'),
                     ),
@@ -129,11 +127,11 @@ class _TranscriptResultScreenState
     );
   }
 
-  void _copyTranscript(BuildContext context) {
-    Clipboard.setData(ClipboardData(text: widget.transcript.transcript));
+  void _copyVoiceNote(BuildContext context) {
+    Clipboard.setData(ClipboardData(text: widget.voiceNote.text));
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(
-        content: Text('Transcript copied to clipboard'),
+        content: Text('Voice note copied to clipboard'),
         duration: Duration(seconds: 2),
       ),
     );

--- a/client/lib/services/history_service.dart
+++ b/client/lib/services/history_service.dart
@@ -3,67 +3,58 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/services/api_client.dart';
 import 'package:oracy/services/transcription_service.dart';
 
-/// Response from the transcripts list endpoint.
-class TranscriptListResponse {
-  final List<TranscriptResponse> transcripts;
-  final int total;
-  final int offset;
-  final int limit;
+/// Response from the voice notes list endpoint.
+class VoiceNoteListResponse {
+  final List<VoiceNoteResponse> voiceNotes;
+  final String? nextCursor;
 
-  const TranscriptListResponse({
-    required this.transcripts,
-    required this.total,
-    required this.offset,
-    required this.limit,
-  });
+  const VoiceNoteListResponse({required this.voiceNotes, this.nextCursor});
 
-  factory TranscriptListResponse.fromJson(Map<String, dynamic> json) {
-    return TranscriptListResponse(
-      transcripts: (json['transcripts'] as List)
-          .map((e) => TranscriptResponse.fromJson(e as Map<String, dynamic>))
+  factory VoiceNoteListResponse.fromJson(Map<String, dynamic> json) {
+    final items = json['items'] as List;
+    return VoiceNoteListResponse(
+      voiceNotes: items
+          .map((e) => VoiceNoteResponse.fromJson(e as Map<String, dynamic>))
           .toList(),
-      total: json['total'] as int,
-      offset: json['offset'] as int,
-      limit: json['limit'] as int,
+      nextCursor: json['next_cursor'] as String?,
     );
   }
 
-  bool get hasMore => offset + transcripts.length < total;
+  bool get hasMore => nextCursor != null;
 }
 
-/// Service for fetching transcript history from the API.
+/// Service for fetching voice-note history from the API.
 class HistoryService {
   final Dio _dio;
 
   HistoryService(this._dio);
 
-  /// Fetch a page of transcripts.
+  /// Fetch a page of voice notes.
   ///
-  /// [offset] - Number of items to skip (for pagination)
   /// [limit] - Maximum items per page (default 20, max 100)
-  Future<TranscriptListResponse> getTranscripts({
-    int offset = 0,
+  Future<VoiceNoteListResponse> getVoiceNotes({
+    String? cursor,
     int limit = 20,
     String? query,
   }) async {
     final response = await _dio.get(
-      '/api/v1/transcripts',
+      '/api/v1/voice-notes',
       queryParameters: {
-        'offset': offset,
         'limit': limit,
+        'cursor': ?cursor,
         if (query != null && query.isNotEmpty) 'q': query,
       },
     );
 
-    return TranscriptListResponse.fromJson(
+    return VoiceNoteListResponse.fromJson(
       response.data as Map<String, dynamic>,
     );
   }
 
-  /// Get a single transcript by ID.
-  Future<TranscriptResponse> getTranscript(String id) async {
-    final response = await _dio.get('/api/v1/transcripts/$id');
-    return TranscriptResponse.fromJson(response.data as Map<String, dynamic>);
+  /// Get a single voice note by ID.
+  Future<VoiceNoteResponse> getVoiceNote(String id) async {
+    final response = await _dio.get('/api/v1/voice-notes/$id');
+    return VoiceNoteResponse.fromJson(response.data as Map<String, dynamic>);
   }
 }
 
@@ -73,62 +64,62 @@ final historyServiceProvider = Provider<HistoryService>((ref) {
   return HistoryService(dio);
 });
 
-/// State for the paginated transcript list.
-class TranscriptHistoryState {
-  final List<TranscriptResponse> transcripts;
-  final int total;
+/// State for the paginated voice-note list.
+class VoiceNoteHistoryState {
+  final List<VoiceNoteResponse> voiceNotes;
   final bool isLoading;
   final bool isLoadingMore;
   final String? error;
   final bool hasMore;
+  final String? nextCursor;
   final String query;
 
-  const TranscriptHistoryState({
-    this.transcripts = const [],
-    this.total = 0,
+  const VoiceNoteHistoryState({
+    this.voiceNotes = const [],
     this.isLoading = false,
     this.isLoadingMore = false,
     this.error,
     this.hasMore = true,
+    this.nextCursor,
     this.query = '',
   });
 
-  TranscriptHistoryState copyWith({
-    List<TranscriptResponse>? transcripts,
-    int? total,
+  VoiceNoteHistoryState copyWith({
+    List<VoiceNoteResponse>? voiceNotes,
     bool? isLoading,
     bool? isLoadingMore,
     String? error,
     bool? hasMore,
+    String? nextCursor,
     String? query,
   }) {
-    return TranscriptHistoryState(
-      transcripts: transcripts ?? this.transcripts,
-      total: total ?? this.total,
+    return VoiceNoteHistoryState(
+      voiceNotes: voiceNotes ?? this.voiceNotes,
       isLoading: isLoading ?? this.isLoading,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       error: error,
       hasMore: hasMore ?? this.hasMore,
+      nextCursor: nextCursor ?? this.nextCursor,
       query: query ?? this.query,
     );
   }
 
-  bool get isEmpty => transcripts.isEmpty && !isLoading;
+  bool get isEmpty => voiceNotes.isEmpty && !isLoading;
 }
 
-/// Notifier for managing transcript history with pagination.
-class TranscriptHistoryNotifier extends Notifier<TranscriptHistoryState> {
+/// Notifier for managing voice-note history with pagination.
+class VoiceNoteHistoryNotifier extends Notifier<VoiceNoteHistoryState> {
   static const int _pageSize = 20;
   int _requestVersion = 0;
 
   HistoryService get _service => ref.read(historyServiceProvider);
 
   @override
-  TranscriptHistoryState build() {
-    return const TranscriptHistoryState();
+  VoiceNoteHistoryState build() {
+    return const VoiceNoteHistoryState();
   }
 
-  /// Load the initial page of transcripts.
+  /// Load the initial page of voice notes.
   Future<void> loadInitial() async {
     if (state.isLoading) return;
 
@@ -137,18 +128,17 @@ class TranscriptHistoryNotifier extends Notifier<TranscriptHistoryState> {
     state = state.copyWith(isLoading: true, error: null);
 
     try {
-      final response = await _service.getTranscripts(
-        offset: 0,
+      final response = await _service.getVoiceNotes(
         limit: _pageSize,
         query: query,
       );
       if (!_isCurrentRequest(requestVersion, query)) return;
 
-      state = TranscriptHistoryState(
-        transcripts: response.transcripts,
-        total: response.total,
+      state = VoiceNoteHistoryState(
+        voiceNotes: response.voiceNotes,
         isLoading: false,
         hasMore: response.hasMore,
+        nextCursor: response.nextCursor,
         query: query,
       );
     } on DioException catch (e) {
@@ -158,36 +148,37 @@ class TranscriptHistoryNotifier extends Notifier<TranscriptHistoryState> {
       if (!_isCurrentRequest(requestVersion, query)) return;
       state = state.copyWith(
         isLoading: false,
-        error: 'Failed to load transcripts: $e',
+        error: 'Failed to load voice notes: $e',
       );
     }
   }
 
-  /// Load more transcripts (append to existing list).
+  /// Load more voice notes (append to existing list).
   Future<void> loadMore() async {
     if (state.isLoading || state.isLoadingMore || !state.hasMore) return;
 
     final query = state.query;
-    final offset = state.transcripts.length;
+    final cursor = state.nextCursor;
     final requestVersion = ++_requestVersion;
+    final previousCount = state.voiceNotes.length;
     state = state.copyWith(isLoadingMore: true);
 
     try {
-      final response = await _service.getTranscripts(
-        offset: offset,
+      final response = await _service.getVoiceNotes(
+        cursor: cursor,
         limit: _pageSize,
         query: query,
       );
       if (!_isCurrentRequest(requestVersion, query) ||
-          state.transcripts.length != offset) {
+          state.voiceNotes.length != previousCount) {
         return;
       }
 
       state = state.copyWith(
-        transcripts: [...state.transcripts, ...response.transcripts],
-        total: response.total,
+        voiceNotes: [...state.voiceNotes, ...response.voiceNotes],
         isLoadingMore: false,
         hasMore: response.hasMore,
+        nextCursor: response.nextCursor,
       );
     } on DioException catch (e) {
       if (!_isCurrentRequest(requestVersion, query)) return;
@@ -196,25 +187,25 @@ class TranscriptHistoryNotifier extends Notifier<TranscriptHistoryState> {
       if (!_isCurrentRequest(requestVersion, query)) return;
       state = state.copyWith(
         isLoadingMore: false,
-        error: 'Failed to load more transcripts: $e',
+        error: 'Failed to load more voice notes: $e',
       );
     }
   }
 
   /// Refresh the list (reload from beginning).
   Future<void> refresh() async {
-    state = TranscriptHistoryState(query: state.query);
+    state = VoiceNoteHistoryState(query: state.query);
     await loadInitial();
   }
 
-  /// Search transcripts using the same paginated collection contract as history.
+  /// Search voice notes using the same paginated collection contract as history.
   Future<void> search(String query) async {
     final normalizedQuery = query.trim();
     if (normalizedQuery == state.query && !state.isLoading) {
       return;
     }
 
-    state = TranscriptHistoryState(query: normalizedQuery);
+    state = VoiceNoteHistoryState(query: normalizedQuery);
     await loadInitial();
   }
 
@@ -231,12 +222,12 @@ class TranscriptHistoryNotifier extends Notifier<TranscriptHistoryState> {
         e.type == DioExceptionType.receiveTimeout) {
       return 'Request timed out. Please try again.';
     }
-    return 'Failed to load transcripts. Please try again.';
+    return 'Failed to load voice notes. Please try again.';
   }
 }
 
-/// Provider for transcript history state.
-final transcriptHistoryProvider =
-    NotifierProvider<TranscriptHistoryNotifier, TranscriptHistoryState>(
-      TranscriptHistoryNotifier.new,
+/// Provider for voice-note history state.
+final voiceNoteHistoryProvider =
+    NotifierProvider<VoiceNoteHistoryNotifier, VoiceNoteHistoryState>(
+      VoiceNoteHistoryNotifier.new,
     );

--- a/client/lib/services/preferences_service.dart
+++ b/client/lib/services/preferences_service.dart
@@ -12,7 +12,7 @@ class PreferencesService {
 
   PreferencesService(this._prefs);
 
-  /// Whether to automatically copy transcripts to clipboard.
+  /// Whether to automatically copy voice notes to clipboard.
   /// Default: true (enabled)
   bool get autoCopyToClipboard =>
       _prefs.getBool(PreferenceKeys.autoCopyToClipboard) ?? true;

--- a/client/lib/services/transcription_service.dart
+++ b/client/lib/services/transcription_service.dart
@@ -12,40 +12,40 @@ import 'transcription_service_stub.dart'
     as platform;
 
 /// Response from the transcription API.
-class TranscriptResponse {
+class VoiceNoteResponse {
   final String id;
-  final String transcript;
+  final String text;
   final double audioDurationSeconds;
   final String? audioFormat;
   final int? audioSizeBytes;
-  final String? transcriptLanguage;
-  final String? whisperModel;
+  final String? language;
+  final String? model;
   final int? processingTimeMs;
   final int costCents;
   final DateTime createdAt;
 
-  const TranscriptResponse({
+  const VoiceNoteResponse({
     required this.id,
-    required this.transcript,
+    required this.text,
     required this.audioDurationSeconds,
     this.audioFormat,
     this.audioSizeBytes,
-    this.transcriptLanguage,
-    this.whisperModel,
+    this.language,
+    this.model,
     this.processingTimeMs,
     required this.costCents,
     required this.createdAt,
   });
 
-  factory TranscriptResponse.fromJson(Map<String, dynamic> json) {
-    return TranscriptResponse(
+  factory VoiceNoteResponse.fromJson(Map<String, dynamic> json) {
+    return VoiceNoteResponse(
       id: json['id'] as String,
-      transcript: json['transcript'] as String,
+      text: json['text'] as String,
       audioDurationSeconds: (json['audio_duration_seconds'] as num).toDouble(),
       audioFormat: json['audio_format'] as String?,
       audioSizeBytes: json['audio_size_bytes'] as int?,
-      transcriptLanguage: json['transcript_language'] as String?,
-      whisperModel: json['whisper_model'] as String?,
+      language: json['language'] as String?,
+      model: json['model'] as String?,
       processingTimeMs: json['processing_time_ms'] as int?,
       costCents: json['cost_cents'] as int,
       createdAt: DateTime.parse(json['created_at'] as String),
@@ -72,8 +72,8 @@ class TranscriptionProcessing extends TranscriptionState {
 }
 
 class TranscriptionSuccess extends TranscriptionState {
-  final TranscriptResponse transcript;
-  const TranscriptionSuccess(this.transcript);
+  final VoiceNoteResponse voiceNote;
+  const TranscriptionSuccess(this.voiceNote);
 }
 
 /// Types of transcription errors for better UI differentiation.
@@ -321,7 +321,7 @@ class TranscriptionService {
   /// Upload an audio file for transcription.
   /// On native platforms, filePath is a file system path.
   /// On web, filePath is a blob URL (blob:https://...).
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -371,7 +371,7 @@ class TranscriptionService {
       },
     );
 
-    return TranscriptResponse.fromJson(response.data as Map<String, dynamic>);
+    return VoiceNoteResponse.fromJson(response.data as Map<String, dynamic>);
   }
 }
 
@@ -458,7 +458,7 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
 
       state = const TranscriptionUploading(progress: 0.0);
 
-      final transcript = await service.transcribe(
+      final voiceNote = await service.transcribe(
         filePath,
         language: language,
         idempotencyKey: queuedUpload?.idempotencyKey,
@@ -483,7 +483,7 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
         );
       }
 
-      state = TranscriptionSuccess(transcript);
+      state = TranscriptionSuccess(voiceNote);
     } on DioException catch (e) {
       final classification = classifyUploadFailure(e);
       await _markQueuedUploadFailed(

--- a/client/test/background_sync_service_test.dart
+++ b/client/test/background_sync_service_test.dart
@@ -16,13 +16,13 @@ class _SuccessfulTranscriptionService extends TranscriptionService {
   _SuccessfulTranscriptionService() : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
     void Function(double progress)? onProgress,
   }) async {
-    return createMockTranscript();
+    return createMockVoiceNote();
   }
 }
 
@@ -32,14 +32,14 @@ class _CountingTranscriptionService extends TranscriptionService {
   int callCount = 0;
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
     void Function(double progress)? onProgress,
   }) async {
     callCount++;
-    return createMockTranscript();
+    return createMockVoiceNote();
   }
 }
 

--- a/client/test/helpers/test_utils.dart
+++ b/client/test/helpers/test_utils.dart
@@ -172,7 +172,7 @@ class MockTranscriptionNotifier extends TranscriptionNotifier {
     await Future.delayed(const Duration(milliseconds: 10));
     state = const TranscriptionProcessing();
     await Future.delayed(const Duration(milliseconds: 10));
-    state = TranscriptionSuccess(createMockTranscript());
+    state = TranscriptionSuccess(createMockVoiceNote());
   }
 
   @override
@@ -188,31 +188,31 @@ class MockTranscriptionNotifier extends TranscriptionNotifier {
 }
 
 /// Mock history notifier for testing.
-class MockHistoryNotifier extends TranscriptHistoryNotifier {
-  final List<TranscriptResponse> _mockTranscripts;
+class MockHistoryNotifier extends VoiceNoteHistoryNotifier {
+  final List<VoiceNoteResponse> _mockVoiceNotes;
   final bool _hasMore;
 
   MockHistoryNotifier({
-    List<TranscriptResponse>? transcripts,
+    List<VoiceNoteResponse>? voiceNotes,
     bool hasMore = false,
-  }) : _mockTranscripts = transcripts ?? [],
+  }) : _mockVoiceNotes = voiceNotes ?? [],
        _hasMore = hasMore;
 
   @override
-  TranscriptHistoryState build() => TranscriptHistoryState(
-    transcripts: _mockTranscripts,
-    total: _mockTranscripts.length,
+  VoiceNoteHistoryState build() => VoiceNoteHistoryState(
+    voiceNotes: _mockVoiceNotes,
     hasMore: _hasMore,
+    nextCursor: _hasMore ? 'mock-next-page' : null,
   );
 
   @override
   Future<void> loadInitial() async {
     state = state.copyWith(isLoading: true);
     await Future.delayed(const Duration(milliseconds: 10));
-    state = TranscriptHistoryState(
-      transcripts: _mockTranscripts,
-      total: _mockTranscripts.length,
+    state = VoiceNoteHistoryState(
+      voiceNotes: _mockVoiceNotes,
       hasMore: _hasMore,
+      nextCursor: _hasMore ? 'mock-next-page' : null,
     );
   }
 
@@ -227,36 +227,36 @@ class MockHistoryNotifier extends TranscriptHistoryNotifier {
   }
 }
 
-/// Creates a mock TranscriptResponse for testing.
-TranscriptResponse createMockTranscript({
+/// Creates a mock VoiceNoteResponse for testing.
+VoiceNoteResponse createMockVoiceNote({
   String? id,
-  String? transcript,
+  String? text,
   double? audioDurationSeconds,
   int? costCents,
   DateTime? createdAt,
   String? language,
 }) {
-  return TranscriptResponse(
+  return VoiceNoteResponse(
     id: id ?? 'mock-id-123',
-    transcript: transcript ?? 'This is a mock transcript for testing purposes.',
+    text: text ?? 'This is a mock voice note for testing purposes.',
     audioDurationSeconds: audioDurationSeconds ?? 30.0,
     audioFormat: 'm4a',
     audioSizeBytes: 50000,
-    transcriptLanguage: language ?? 'en',
-    whisperModel: 'whisper-1',
+    language: language ?? 'en',
+    model: 'whisper-1',
     processingTimeMs: 1500,
     costCents: costCents ?? 1,
     createdAt: createdAt ?? DateTime.now(),
   );
 }
 
-/// Creates a list of mock transcripts for testing.
-List<TranscriptResponse> createMockTranscriptList({int count = 5}) {
+/// Creates a list of mock voice notes for testing.
+List<VoiceNoteResponse> createMockVoiceNoteList({int count = 5}) {
   return List.generate(
     count,
-    (index) => createMockTranscript(
+    (index) => createMockVoiceNote(
       id: 'mock-id-$index',
-      transcript: 'Mock transcript number ${index + 1}.',
+      text: 'Mock voice note number ${index + 1}.',
       createdAt: DateTime.now().subtract(Duration(days: index)),
     ),
   );
@@ -313,11 +313,11 @@ dynamic transcriptionOverride([TranscriptionState? initialState]) {
 
 /// Override for mock history state.
 dynamic historyOverride({
-  List<TranscriptResponse>? transcripts,
+  List<VoiceNoteResponse>? voiceNotes,
   bool hasMore = false,
 }) {
-  return transcriptHistoryProvider.overrideWith(
-    () => MockHistoryNotifier(transcripts: transcripts, hasMore: hasMore),
+  return voiceNoteHistoryProvider.overrideWith(
+    () => MockHistoryNotifier(voiceNotes: voiceNotes, hasMore: hasMore),
   );
 }
 

--- a/client/test/history_screen_test.dart
+++ b/client/test/history_screen_test.dart
@@ -16,44 +16,34 @@ class _FakeHistoryService extends HistoryService {
   final queries = <String?>[];
 
   @override
-  Future<TranscriptListResponse> getTranscripts({
-    int offset = 0,
+  Future<VoiceNoteListResponse> getVoiceNotes({
+    String? cursor,
     int limit = 20,
     String? query,
   }) async {
     queries.add(query);
-    final transcripts = query == null || query.isEmpty
-        ? [createMockTranscript(id: 'visible', transcript: 'Visible page')]
-        : [createMockTranscript(id: 'remote', transcript: 'Remote needle hit')];
-    return TranscriptListResponse(
-      transcripts: transcripts,
-      total: transcripts.length,
-      offset: offset,
-      limit: limit,
-    );
+    final voiceNotes = query == null || query.isEmpty
+        ? [createMockVoiceNote(id: 'visible', text: 'Visible page')]
+        : [createMockVoiceNote(id: 'remote', text: 'Remote needle hit')];
+    return VoiceNoteListResponse(voiceNotes: voiceNotes);
   }
 }
 
 class _PendingHistoryRequest {
-  final int offset;
+  final String? cursor;
   final int limit;
   final String? query;
-  final Completer<TranscriptListResponse> completer = Completer();
+  final Completer<VoiceNoteListResponse> completer = Completer();
 
   _PendingHistoryRequest({
-    required this.offset,
+    required this.cursor,
     required this.limit,
     required this.query,
   });
 
-  void complete(List<TranscriptResponse> transcripts, {int? total}) {
+  void complete(List<VoiceNoteResponse> voiceNotes, {String? nextCursor}) {
     completer.complete(
-      TranscriptListResponse(
-        transcripts: transcripts,
-        total: total ?? transcripts.length,
-        offset: offset,
-        limit: limit,
-      ),
+      VoiceNoteListResponse(voiceNotes: voiceNotes, nextCursor: nextCursor),
     );
   }
 }
@@ -64,13 +54,13 @@ class _ControlledHistoryService extends HistoryService {
   final requests = <_PendingHistoryRequest>[];
 
   @override
-  Future<TranscriptListResponse> getTranscripts({
-    int offset = 0,
+  Future<VoiceNoteListResponse> getVoiceNotes({
+    String? cursor,
     int limit = 20,
     String? query,
   }) {
     final request = _PendingHistoryRequest(
-      offset: offset,
+      cursor: cursor,
       limit: limit,
       query: query,
     );
@@ -89,7 +79,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final notifier = container.read(transcriptHistoryProvider.notifier);
+      final notifier = container.read(voiceNoteHistoryProvider.notifier);
       final oldSearch = notifier.search('old');
       expect(service.requests.single.query, 'old');
 
@@ -97,23 +87,23 @@ void main() {
       expect(service.requests.last.query, 'new');
 
       service.requests.last.complete([
-        createMockTranscript(id: 'new-result', transcript: 'new result'),
+        createMockVoiceNote(id: 'new-result', text: 'new result'),
       ]);
       await newSearch;
 
       service.requests.first.complete([
-        createMockTranscript(id: 'old-result', transcript: 'old result'),
+        createMockVoiceNote(id: 'old-result', text: 'old result'),
       ]);
       await oldSearch;
 
-      final state = container.read(transcriptHistoryProvider);
+      final state = container.read(voiceNoteHistoryProvider);
       expect(state.query, 'new');
-      expect(state.transcripts.map((t) => t.id), ['new-result']);
+      expect(state.voiceNotes.map((t) => t.id), ['new-result']);
     },
   );
 
   testWidgets(
-    'Given a match exists outside the loaded page, When history search changes, Then the transcript collection is queried and remote results are shown',
+    'Given a match exists outside the loaded page, When history search changes, Then the voice note collection is queried and remote results are shown',
     (tester) async {
       final service = _FakeHistoryService();
 
@@ -141,10 +131,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            historyOverride(
-              transcripts: [createMockTranscript()],
-              hasMore: true,
-            ),
+            historyOverride(voiceNotes: [createMockVoiceNote()], hasMore: true),
           ],
           child: const MaterialApp(home: HistoryScreen()),
         ),
@@ -178,13 +165,13 @@ void main() {
       service.requests.last.complete(
         List.generate(
           20,
-          (index) => createMockTranscript(
+          (index) => createMockVoiceNote(
             id: 'needle-$index',
-            transcript: 'Remote needle hit ${index + 1}',
+            text: 'Remote needle hit ${index + 1}',
             createdAt: DateTime.now().subtract(Duration(minutes: index)),
           ),
         ),
-        total: 25,
+        nextCursor: 'needle-page-2',
       );
       await tester.pumpAndSettle();
 
@@ -193,7 +180,7 @@ void main() {
 
       expect(service.requests.length, 3);
       expect(service.requests.last.query, 'needle');
-      expect(service.requests.last.offset, 20);
+      expect(service.requests.last.cursor, 'needle-page-2');
       expect(
         find.byType(CircularProgressIndicator, skipOffstage: false),
         findsOneWidget,
@@ -215,7 +202,7 @@ void main() {
       await tester.pump();
 
       service.requests.single.complete([
-        createMockTranscript(id: 'visible', transcript: 'Visible history'),
+        createMockVoiceNote(id: 'visible', text: 'Visible history'),
       ]);
       await tester.pumpAndSettle();
 
@@ -226,8 +213,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('No results found'), findsOneWidget);
-      expect(find.text('No transcripts yet'), findsNothing);
-      expect(find.text('No transcripts match "missing"'), findsOneWidget);
+      expect(find.text('No voice notes yet'), findsNothing);
+      expect(find.text('No voice notes match "missing"'), findsOneWidget);
     },
   );
 }

--- a/client/test/recording_entrypoints_test.dart
+++ b/client/test/recording_entrypoints_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oracy/app.dart';
-import 'package:oracy/screens/transcript_result_screen.dart';
+import 'package:oracy/screens/voice_note_result_screen.dart';
 import 'package:oracy/services/home_widget_service.dart';
 import 'package:oracy/services/permission_service.dart';
 import 'package:oracy/services/recording_service.dart';
@@ -231,7 +231,7 @@ void main() {
   );
 
   testWidgets(
-    'Given microphone permission is denied, When New Recording is tapped from a transcript, Then the result screen remains and recording does not start',
+    'Given microphone permission is denied, When New Recording is tapped from a voice note, Then the result screen remains and recording does not start',
     (tester) async {
       final permissions = MockPermissionService(
         status: MicrophonePermissionStatus.denied,
@@ -241,7 +241,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            transcriptionOverride(TranscriptionSuccess(createMockTranscript())),
+            transcriptionOverride(TranscriptionSuccess(createMockVoiceNote())),
             permissionOverride(permissions),
             recordingProvider.overrideWith(() => recordingNotifier),
           ],
@@ -250,10 +250,8 @@ void main() {
               builder: (context) => TextButton(
                 onPressed: () => Navigator.of(context).push(
                   MaterialPageRoute<void>(
-                    builder: (_) => TranscriptResultScreen(
-                      transcript: createMockTranscript(
-                        transcript: 'Saved result',
-                      ),
+                    builder: (_) => VoiceNoteResultScreen(
+                      voiceNote: createMockVoiceNote(text: 'Saved result'),
                     ),
                   ),
                 ),
@@ -272,18 +270,18 @@ void main() {
 
       expect(permissions.checkCount, greaterThanOrEqualTo(1));
       expect(recordingNotifier.startCount, 0);
-      expect(find.text('Transcript'), findsOneWidget);
+      expect(find.text('Voice note'), findsOneWidget);
       expect(find.text('Microphone Access Required'), findsOneWidget);
     },
   );
 
   testWidgets(
-    'Given microphone permission is granted but recorder startup fails, When New Recording is tapped from a transcript, Then the result screen remains and transcript state is preserved',
+    'Given microphone permission is granted but recorder startup fails, When New Recording is tapped from a voice note, Then the result screen remains and voice note state is preserved',
     (tester) async {
       final permissions = MockPermissionService();
       final recordingNotifier = _StartupFailingRecordingNotifier();
       final transcriptionNotifier = _ResetCountingTranscriptionNotifier(
-        TranscriptionSuccess(createMockTranscript()),
+        TranscriptionSuccess(createMockVoiceNote()),
       );
 
       await tester.pumpWidget(
@@ -298,10 +296,8 @@ void main() {
               builder: (context) => TextButton(
                 onPressed: () => Navigator.of(context).push(
                   MaterialPageRoute<void>(
-                    builder: (_) => TranscriptResultScreen(
-                      transcript: createMockTranscript(
-                        transcript: 'Saved result',
-                      ),
+                    builder: (_) => VoiceNoteResultScreen(
+                      voiceNote: createMockVoiceNote(text: 'Saved result'),
                     ),
                   ),
                 ),
@@ -320,13 +316,13 @@ void main() {
       expect(permissions.checkCount, greaterThanOrEqualTo(1));
       expect(recordingNotifier.startCount, 1);
       expect(transcriptionNotifier.resetCount, 0);
-      expect(find.text('Transcript'), findsOneWidget);
+      expect(find.text('Voice note'), findsOneWidget);
       expect(find.text('Open result'), findsNothing);
     },
   );
 
   testWidgets(
-    'Given microphone permission is granted after a completed recording, When New Recording is tapped from a transcript, Then recording starts and returns home',
+    'Given microphone permission is granted after a completed recording, When New Recording is tapped from a voice note, Then recording starts and returns home',
     (tester) async {
       final permissions = MockPermissionService();
       final recordingNotifier = MockRecordingNotifier(
@@ -339,7 +335,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            transcriptionOverride(TranscriptionSuccess(createMockTranscript())),
+            transcriptionOverride(TranscriptionSuccess(createMockVoiceNote())),
             permissionOverride(permissions),
             recordingProvider.overrideWith(() => recordingNotifier),
           ],
@@ -348,10 +344,8 @@ void main() {
               builder: (context) => TextButton(
                 onPressed: () => Navigator.of(context).push(
                   MaterialPageRoute<void>(
-                    builder: (_) => TranscriptResultScreen(
-                      transcript: createMockTranscript(
-                        transcript: 'Saved result',
-                      ),
+                    builder: (_) => VoiceNoteResultScreen(
+                      voiceNote: createMockVoiceNote(text: 'Saved result'),
                     ),
                   ),
                 ),
@@ -370,7 +364,7 @@ void main() {
       expect(permissions.checkCount, greaterThanOrEqualTo(1));
       expect(recordingNotifier.startCount, 1);
       expect(find.text('Open result'), findsOneWidget);
-      expect(find.text('Transcript'), findsNothing);
+      expect(find.text('Voice note'), findsNothing);
     },
   );
 }

--- a/client/test/transcription_persistence_test.dart
+++ b/client/test/transcription_persistence_test.dart
@@ -17,7 +17,7 @@ class _FailingTranscriptionService extends TranscriptionService {
   _FailingTranscriptionService() : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -34,13 +34,13 @@ class _SuccessfulTranscriptionService extends TranscriptionService {
   _SuccessfulTranscriptionService() : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
     void Function(double progress)? onProgress,
   }) async {
-    return createMockTranscript();
+    return createMockVoiceNote();
   }
 }
 
@@ -54,7 +54,7 @@ class _ApiKeySensitiveTranscriptionService extends TranscriptionService {
   }) : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -73,7 +73,7 @@ class _ApiKeySensitiveTranscriptionService extends TranscriptionService {
       );
     }
 
-    return createMockTranscript();
+    return createMockVoiceNote();
   }
 }
 
@@ -85,7 +85,7 @@ class _StatusCodeFailingTranscriptionService extends TranscriptionService {
     : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -114,7 +114,7 @@ class _PlainTextResponseFailingTranscriptionService
   }) : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -136,7 +136,7 @@ class _TimeoutTranscriptionService extends TranscriptionService {
   _TimeoutTranscriptionService() : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -153,7 +153,7 @@ class _ThrowingTranscriptionService extends TranscriptionService {
   _ThrowingTranscriptionService() : super(Dio());
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,

--- a/client/test/upload_queue_service_test.dart
+++ b/client/test/upload_queue_service_test.dart
@@ -50,7 +50,7 @@ class _CountingTranscriptionService extends TranscriptionService {
   final List<String?> idempotencyKeys = [];
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -58,7 +58,7 @@ class _CountingTranscriptionService extends TranscriptionService {
   }) async {
     callCount++;
     idempotencyKeys.add(idempotencyKey);
-    return createMockTranscript();
+    return createMockVoiceNote();
   }
 }
 
@@ -69,7 +69,7 @@ class _RetryingTranscriptionService extends TranscriptionService {
   final List<String?> idempotencyKeys = [];
 
   @override
-  Future<TranscriptResponse> transcribe(
+  Future<VoiceNoteResponse> transcribe(
     String filePath, {
     String? language,
     String? idempotencyKey,
@@ -85,7 +85,7 @@ class _RetryingTranscriptionService extends TranscriptionService {
       );
     }
 
-    return createMockTranscript();
+    return createMockVoiceNote();
   }
 }
 


### PR DESCRIPTION
## Summary

- Renames the unreleased SQLite voice-note substrate from the old transcript vocabulary to `voice_note*` tables, columns, indexes, and storage types.
- Aligns backend handlers, fixtures, and tests so the wire-boundary module no longer translates between voice-note contract names and transcript substrate names.
- Updates the Flutter client resource vocabulary to `VoiceNote*` and points history reads at the existing `/api/v1/voice-notes` cursor contract.

## Changes

- Rewrites the unreleased migrations in place for `voice_notes`, `voice_note_versions`, `voice_note_tags`, `voice_note_id`, `text`, and `language`.
- Renames backend storage records, builders, materialization, filters, tag replacement outcomes, and voice-note access methods.
- Updates client history/result naming, result screen filename, mock helpers, and affected tests from transcript resource vocabulary to voice-note resource vocabulary.
- Updates CHANGELOG entries so documented v0.1.0 vocabulary matches the current contract.

## GitHub Issue(s)

Closes #56

## Test plan

- `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- `flutter analyze`
- `flutter test`
- `git grep -n -i 'transcript' | grep -vi 'transcription'`
