### PR TITLE
feat(persistence): rename transcripts* to voice_notes* across substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@
 - Fix the foreground upload queue so pending recordings wait for a configured
   API key and resume after one is saved.
 - Add the durable backend SQLite substrate for accepted transcription jobs,
-  transcript versions, ordered segments, current embeddings, owner scoping, and
+  voice-note versions, ordered segments, current embeddings, owner scoping, and
   the required operator `database_path` setting.
 - Add the durable backend SQLite substrate for tags, sessions,
-  transcript-to-tag associations, transcript session membership, and metadata
+  voice-note-to-tag associations, voice-note session membership, and metadata
   deletion invariants.
 - Establish independent backend and frontend CI gates for v0.1.0 pull requests
   and pushes to `main`.
@@ -41,17 +41,17 @@
 - Import the Flutter client into `client/` with six inherited defects fixed
   in-place rather than deferred, and commit `client/pubspec.lock` for
   reproducible app builds.
-- Expand the v0.1.0 spec to define the full transcript substrate and HTTP
-  surface, including sessions, tags, transcript editing and version history,
-  segment retrieval, transcript deletion, unified history/search collection
+- Expand the v0.1.0 spec to define the full voice-note substrate and HTTP
+  surface, including sessions, tags, voice-note editing and version history,
+  segment retrieval, voice-note deletion, unified history/search collection
   semantics, required `recorded_at`, and the shared error envelope.
-- Rename the transcript schema field from `whisper_model` to `model` so the API
+- Rename the voice-note schema field from `whisper_model` to `model` so the API
   describes the transcription engine without binding the contract to Whisper.
-- Clarify that `cost_cents` is always present on transcript resources but may be
+- Clarify that `cost_cents` is always present on voice-note resources but may be
   `null` when the backend cannot derive a stable estimate from fixed-rate
   pricing inputs.
 - Rewrite the v0.1.0 spec around the durable voice-note artifact: rename the
-  `Transcript` family to `VoiceNote`, replace single-multipart audio upload with
-  the chunked open/push/finalize protocol (with `accepting_chunks` as a
-  contract-visible job status), and add the per-API-key `transcription_model`
-  settings surface enumerating the OpenAI transcription engine identifiers.
+  resource family, replace single-multipart audio upload with the chunked
+  open/push/finalize protocol (with `accepting_chunks` as a contract-visible job
+  status), and add the per-API-key `transcription_model` settings surface
+  enumerating the OpenAI transcription engine identifiers.

--- a/backend/migrations/20260424000000_create_job_voice_note_substrate.sql
+++ b/backend/migrations/20260424000000_create_job_voice_note_substrate.sql
@@ -27,8 +27,8 @@ CREATE TABLE transcription_jobs (
     ),
     failure_message TEXT,
     retryable_by_client INTEGER CHECK (retryable_by_client IS NULL OR retryable_by_client IN (0, 1)),
-    transcript_id TEXT REFERENCES transcripts(id) ON DELETE SET NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id),
+    voice_note_id TEXT REFERENCES voice_notes(id) ON DELETE SET NULL,
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id),
     UNIQUE (api_key_id, idempotency_key)
 );
 
@@ -45,13 +45,13 @@ BEGIN
     SELECT RAISE(ABORT, 'accepted submission tuple is immutable');
 END;
 
-CREATE TABLE transcripts (
+CREATE TABLE voice_notes (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
     audio_duration_seconds REAL NOT NULL CHECK (audio_duration_seconds >= 0),
     audio_format TEXT NOT NULL,
     audio_size_bytes INTEGER NOT NULL CHECK (audio_size_bytes >= 0),
-    transcript_language TEXT,
+    language TEXT,
     model TEXT NOT NULL,
     processing_time_ms INTEGER NOT NULL CHECK (processing_time_ms >= 0),
     cost_cents INTEGER CHECK (cost_cents IS NULL OR cost_cents >= 0),
@@ -60,49 +60,49 @@ CREATE TABLE transcripts (
     session_id TEXT
 );
 
-CREATE UNIQUE INDEX transcripts_owner_id_idx
-    ON transcripts (api_key_id, id);
+CREATE UNIQUE INDEX voice_notes_owner_id_idx
+    ON voice_notes (api_key_id, id);
 
-CREATE INDEX transcripts_history_idx
-    ON transcripts (api_key_id, created_at DESC, id DESC);
+CREATE INDEX voice_notes_history_idx
+    ON voice_notes (api_key_id, created_at DESC, id DESC);
 
-CREATE TABLE transcript_versions (
+CREATE TABLE voice_note_versions (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL,
+    voice_note_id TEXT NOT NULL,
     version_number INTEGER NOT NULL CHECK (version_number >= 1),
-    transcript TEXT NOT NULL,
+    text TEXT NOT NULL,
     created_at TEXT NOT NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
-    UNIQUE (transcript_id, version_number)
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE,
+    UNIQUE (voice_note_id, version_number)
 );
 
-CREATE INDEX transcript_versions_current_idx
-    ON transcript_versions (transcript_id, version_number DESC);
+CREATE INDEX voice_note_versions_current_idx
+    ON voice_note_versions (voice_note_id, version_number DESC);
 
 CREATE TABLE segments (
     id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL,
+    voice_note_id TEXT NOT NULL,
     position INTEGER NOT NULL CHECK (position >= 0),
     start_ms INTEGER NOT NULL CHECK (start_ms >= 0),
     end_ms INTEGER NOT NULL CHECK (end_ms >= start_ms),
     text TEXT NOT NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
-    UNIQUE (transcript_id, position)
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE,
+    UNIQUE (voice_note_id, position)
 );
 
 CREATE INDEX segments_order_idx
-    ON segments (transcript_id, position ASC);
+    ON segments (voice_note_id, position ASC);
 
 CREATE TABLE embeddings (
-    transcript_id TEXT PRIMARY KEY,
+    voice_note_id TEXT PRIMARY KEY,
     api_key_id TEXT NOT NULL,
     model TEXT NOT NULL,
     vector BLOB NOT NULL,
     created_at TEXT NOT NULL,
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX embeddings_owner_idx
-    ON embeddings (api_key_id, transcript_id);
+    ON embeddings (api_key_id, voice_note_id);

--- a/backend/migrations/20260425010000_create_metadata_substrate.sql
+++ b/backend/migrations/20260425010000_create_metadata_substrate.sql
@@ -28,17 +28,17 @@ CREATE UNIQUE INDEX tags_owner_id_idx
 CREATE INDEX tags_list_idx
     ON tags (api_key_id, created_at DESC, id DESC);
 
-CREATE TABLE transcript_tags (
+CREATE TABLE voice_note_tags (
     api_key_id TEXT NOT NULL,
-    transcript_id TEXT NOT NULL,
+    voice_note_id TEXT NOT NULL,
     tag_id TEXT NOT NULL,
-    PRIMARY KEY (api_key_id, transcript_id, tag_id),
-    FOREIGN KEY (api_key_id, transcript_id) REFERENCES transcripts(api_key_id, id) ON DELETE CASCADE,
+    PRIMARY KEY (api_key_id, voice_note_id, tag_id),
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE,
     FOREIGN KEY (api_key_id, tag_id) REFERENCES tags(api_key_id, id) ON DELETE CASCADE
 );
 
-CREATE INDEX transcript_tags_tag_idx
-    ON transcript_tags (api_key_id, tag_id, transcript_id);
+CREATE INDEX voice_note_tags_tag_idx
+    ON voice_note_tags (api_key_id, tag_id, voice_note_id);
 
 CREATE TRIGGER transcription_jobs_session_owner_insert
 BEFORE INSERT ON transcription_jobs
@@ -51,32 +51,32 @@ BEGIN
     );
 END;
 
-CREATE TRIGGER transcripts_session_owner_insert
-BEFORE INSERT ON transcripts
+CREATE TRIGGER voice_notes_session_owner_insert
+BEFORE INSERT ON voice_notes
 WHEN NEW.session_id IS NOT NULL
 BEGIN
-    SELECT RAISE(ABORT, 'transcript session must belong to same owner')
+    SELECT RAISE(ABORT, 'voice note session must belong to same owner')
     WHERE NOT EXISTS (
         SELECT 1 FROM sessions
         WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
     );
 END;
 
-CREATE TRIGGER transcripts_session_owner_update
-BEFORE UPDATE OF api_key_id, session_id ON transcripts
+CREATE TRIGGER voice_notes_session_owner_update
+BEFORE UPDATE OF api_key_id, session_id ON voice_notes
 WHEN NEW.session_id IS NOT NULL
 BEGIN
-    SELECT RAISE(ABORT, 'transcript session must belong to same owner')
+    SELECT RAISE(ABORT, 'voice note session must belong to same owner')
     WHERE NOT EXISTS (
         SELECT 1 FROM sessions
         WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
     );
 END;
 
-CREATE TRIGGER sessions_delete_null_transcripts
+CREATE TRIGGER sessions_delete_null_voice_notes
 AFTER DELETE ON sessions
 BEGIN
-    UPDATE transcripts
+    UPDATE voice_notes
     SET session_id = NULL
     WHERE api_key_id = OLD.api_key_id AND session_id = OLD.id;
 END;

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -59,7 +59,7 @@ pub enum StorageError {
     },
     #[error("storage query failed: {0}")]
     Query(#[from] sqlx::Error),
-    #[error("job is not eligible for transcript completion: {job_id}")]
+    #[error("job is not eligible for voice note completion: {job_id}")]
     JobNotCompletable { job_id: String },
     #[error("stored timestamp is invalid: {0}")]
     InvalidTimestamp(#[from] time::error::Parse),
@@ -89,7 +89,7 @@ pub enum RenameTagOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReplaceTranscriptTagsOutcome {
+pub enum ReplaceVoiceNoteTagsOutcome {
     Replaced,
     NotFound,
     DuplicateTagIds,
@@ -159,24 +159,24 @@ pub struct TranscriptionJobRecord {
     pub failure_code: Option<String>,
     pub failure_message: Option<String>,
     pub retryable_by_client: Option<bool>,
-    pub transcript_id: Option<String>,
+    pub voice_note_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-pub struct TranscriptMaterialization {
-    pub transcript: NewTranscript,
-    pub initial_version: NewTranscriptVersion,
+pub struct VoiceNoteMaterialization {
+    pub voice_note: NewVoiceNote,
+    pub initial_version: NewVoiceNoteVersion,
     pub segments: Vec<NewSegment>,
     pub embedding: NewEmbedding,
 }
 
 #[derive(Debug, Clone)]
-pub struct NewTranscript {
+pub struct NewVoiceNote {
     pub id: String,
     pub audio_duration_seconds: f64,
     pub audio_format: String,
     pub audio_size_bytes: i64,
-    pub transcript_language: Option<String>,
+    pub language: Option<String>,
     pub model: String,
     pub processing_time_ms: i64,
     pub cost_cents: Option<i64>,
@@ -185,9 +185,9 @@ pub struct NewTranscript {
 }
 
 #[derive(Debug, Clone)]
-pub struct NewTranscriptVersion {
+pub struct NewVoiceNoteVersion {
     pub id: String,
-    pub transcript: String,
+    pub text: String,
     pub created_at: OffsetDateTime,
 }
 
@@ -208,15 +208,15 @@ pub struct NewEmbedding {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct TranscriptRecord {
+pub struct VoiceNoteRecord {
     pub id: String,
     pub api_key_id: String,
     pub current_version_id: String,
-    pub transcript: String,
+    pub text: String,
     pub audio_duration_seconds: f64,
     pub audio_format: String,
     pub audio_size_bytes: i64,
-    pub transcript_language: Option<String>,
+    pub language: Option<String>,
     pub model: String,
     pub processing_time_ms: i64,
     pub cost_cents: Option<i64>,
@@ -226,15 +226,15 @@ pub struct TranscriptRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TranscriptVersionRecord {
+pub struct VoiceNoteVersionRecord {
     pub id: String,
-    pub transcript_id: String,
-    pub transcript: String,
+    pub voice_note_id: String,
+    pub text: String,
     pub created_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct TranscriptFilters {
+pub struct VoiceNoteFilters {
     pub tag_ids: Vec<String>,
     pub session_id: Option<String>,
     pub recorded_after: Option<OffsetDateTime>,
@@ -246,7 +246,7 @@ pub struct TranscriptFilters {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentRecord {
     pub id: String,
-    pub transcript_id: String,
+    pub voice_note_id: String,
     pub position: i64,
     pub start_ms: i64,
     pub end_ms: i64,
@@ -255,7 +255,7 @@ pub struct SegmentRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EmbeddingRecord {
-    pub transcript_id: String,
+    pub voice_note_id: String,
     pub model: String,
     pub vector: Vec<u8>,
     pub created_at: OffsetDateTime,
@@ -489,16 +489,16 @@ impl Storage {
         row.map(job_from_row).transpose()
     }
 
-    pub async fn complete_job_with_transcript(
+    pub async fn complete_job_with_voice_note(
         &self,
         api_key_id: &str,
         job_id: &str,
-        materialization: TranscriptMaterialization,
+        materialization: VoiceNoteMaterialization,
     ) -> Result<(), StorageError> {
         let mut tx = self.pool.begin().await?;
-        let transcript = materialization.transcript;
+        let voice_note = materialization.voice_note;
         let version = materialization.initial_version;
-        let now = format_timestamp(transcript.created_at)?;
+        let now = format_timestamp(voice_note.created_at)?;
 
         let result = sqlx::query(
             r#"
@@ -507,7 +507,7 @@ impl Storage {
             WHERE api_key_id = ?
                 AND id = ?
                 AND status = 'processing'
-                AND transcript_id IS NULL
+                AND voice_note_id IS NULL
             "#,
         )
         .bind(&now)
@@ -521,9 +521,9 @@ impl Storage {
             });
         }
 
-        let transcript_session_id: Option<String> = sqlx::query(
+        let voice_note_session_id: Option<String> = sqlx::query(
             r#"
-            SELECT sessions.id AS transcript_session_id
+            SELECT sessions.id AS voice_note_session_id
             FROM transcription_jobs
             LEFT JOIN sessions
                 ON sessions.api_key_id = transcription_jobs.api_key_id
@@ -536,45 +536,45 @@ impl Storage {
         .bind(job_id)
         .fetch_one(&mut *tx)
         .await?
-        .try_get("transcript_session_id")?;
+        .try_get("voice_note_session_id")?;
 
         sqlx::query(
             r#"
-            INSERT INTO transcripts (
+            INSERT INTO voice_notes (
                 id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-                transcript_language, model, processing_time_ms, cost_cents,
+                language, model, processing_time_ms, cost_cents,
                 created_at, recorded_at, session_id
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
-        .bind(&transcript.id)
+        .bind(&voice_note.id)
         .bind(api_key_id)
-        .bind(transcript.audio_duration_seconds)
-        .bind(&transcript.audio_format)
-        .bind(transcript.audio_size_bytes)
-        .bind(&transcript.transcript_language)
-        .bind(&transcript.model)
-        .bind(transcript.processing_time_ms)
-        .bind(transcript.cost_cents)
+        .bind(voice_note.audio_duration_seconds)
+        .bind(&voice_note.audio_format)
+        .bind(voice_note.audio_size_bytes)
+        .bind(&voice_note.language)
+        .bind(&voice_note.model)
+        .bind(voice_note.processing_time_ms)
+        .bind(voice_note.cost_cents)
         .bind(&now)
-        .bind(format_timestamp(transcript.recorded_at)?)
-        .bind(&transcript_session_id)
+        .bind(format_timestamp(voice_note.recorded_at)?)
+        .bind(&voice_note_session_id)
         .execute(&mut *tx)
         .await?;
 
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, 1, ?, ?)
             "#,
         )
         .bind(&version.id)
         .bind(api_key_id)
-        .bind(&transcript.id)
-        .bind(&version.transcript)
+        .bind(&voice_note.id)
+        .bind(&version.text)
         .bind(format_timestamp(version.created_at)?)
         .execute(&mut *tx)
         .await?;
@@ -583,14 +583,14 @@ impl Storage {
             sqlx::query(
                 r#"
                 INSERT INTO segments (
-                    id, api_key_id, transcript_id, position, start_ms, end_ms, text
+                    id, api_key_id, voice_note_id, position, start_ms, end_ms, text
                 )
                 VALUES (?, ?, ?, ?, ?, ?, ?)
                 "#,
             )
             .bind(&segment.id)
             .bind(api_key_id)
-            .bind(&transcript.id)
+            .bind(&voice_note.id)
             .bind(segment.position)
             .bind(segment.start_ms)
             .bind(segment.end_ms)
@@ -601,11 +601,11 @@ impl Storage {
 
         sqlx::query(
             r#"
-            INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
             VALUES (?, ?, ?, ?, ?)
             "#,
         )
-        .bind(&transcript.id)
+        .bind(&voice_note.id)
         .bind(api_key_id)
         .bind(&materialization.embedding.model)
         .bind(&materialization.embedding.vector)
@@ -616,14 +616,14 @@ impl Storage {
         let result = sqlx::query(
             r#"
             UPDATE transcription_jobs
-            SET status = 'succeeded', transcript_id = ?, updated_at = ?
+            SET status = 'succeeded', voice_note_id = ?, updated_at = ?
             WHERE api_key_id = ?
                 AND id = ?
                 AND status = 'processing'
-                AND transcript_id IS NULL
+                AND voice_note_id IS NULL
             "#,
         )
-        .bind(&transcript.id)
+        .bind(&voice_note.id)
         .bind(&now)
         .bind(api_key_id)
         .bind(job_id)
@@ -639,68 +639,68 @@ impl Storage {
         Ok(())
     }
 
-    pub async fn get_transcript(
+    pub async fn get_voice_note(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
-    ) -> Result<Option<TranscriptRecord>, StorageError> {
+        voice_note_id: &str,
+    ) -> Result<Option<VoiceNoteRecord>, StorageError> {
         let row = sqlx::query(
             r#"
             SELECT
-                transcripts.*,
-                transcript_versions.id AS current_version_id,
-                transcript_versions.transcript AS current_transcript
-            FROM transcripts
-            JOIN transcript_versions
-                ON transcript_versions.transcript_id = transcripts.id
-            WHERE transcripts.api_key_id = ?
-                AND transcripts.id = ?
-                AND transcript_versions.version_number = (
+                voice_notes.*,
+                voice_note_versions.id AS current_version_id,
+                voice_note_versions.text AS current_text
+            FROM voice_notes
+            JOIN voice_note_versions
+                ON voice_note_versions.voice_note_id = voice_notes.id
+            WHERE voice_notes.api_key_id = ?
+                AND voice_notes.id = ?
+                AND voice_note_versions.version_number = (
                     SELECT MAX(version_number)
-                    FROM transcript_versions
-                    WHERE transcript_id = transcripts.id
+                    FROM voice_note_versions
+                    WHERE voice_note_id = voice_notes.id
                 )
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_optional(&self.pool)
         .await?;
 
-        row.map(transcript_from_row).transpose()
+        row.map(voice_note_from_row).transpose()
     }
 
-    pub async fn list_transcripts(
+    pub async fn list_voice_notes(
         &self,
         api_key_id: &str,
-        filters: &TranscriptFilters,
+        filters: &VoiceNoteFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptRecord>, StorageError> {
-        self.list_transcripts_in_session(api_key_id, None, filters, cursor, limit)
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        self.list_voice_notes_in_session(api_key_id, None, filters, cursor, limit)
             .await
     }
 
-    pub async fn list_session_transcripts(
+    pub async fn list_session_voice_notes(
         &self,
         api_key_id: &str,
         session_id: &str,
-        filters: &TranscriptFilters,
+        filters: &VoiceNoteFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptRecord>, StorageError> {
-        self.list_transcripts_in_session(api_key_id, Some(session_id), filters, cursor, limit)
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        self.list_voice_notes_in_session(api_key_id, Some(session_id), filters, cursor, limit)
             .await
     }
 
-    async fn list_transcripts_in_session(
+    async fn list_voice_notes_in_session(
         &self,
         api_key_id: &str,
         session_id: Option<&str>,
-        filters: &TranscriptFilters,
+        filters: &VoiceNoteFilters,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptRecord>, StorageError> {
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
         let cursor_created_at = cursor
             .as_ref()
             .map(|(created_at, _)| format_timestamp(*created_at))
@@ -714,34 +714,34 @@ impl Storage {
         let mut query = QueryBuilder::new(
             r#"
             SELECT
-                transcripts.*,
-                transcript_versions.id AS current_version_id,
-                transcript_versions.transcript AS current_transcript
-            FROM transcripts
-            JOIN transcript_versions
-                ON transcript_versions.transcript_id = transcripts.id
-            WHERE transcripts.api_key_id =
+                voice_notes.*,
+                voice_note_versions.id AS current_version_id,
+                voice_note_versions.text AS current_text
+            FROM voice_notes
+            JOIN voice_note_versions
+                ON voice_note_versions.voice_note_id = voice_notes.id
+            WHERE voice_notes.api_key_id =
             "#,
         );
         query.push_bind(api_key_id);
         if let Some(session_id) = effective_session_id {
-            query.push(" AND transcripts.session_id = ");
+            query.push(" AND voice_notes.session_id = ");
             query.push_bind(session_id);
         }
         if let Some(recorded_after) = recorded_after.as_deref() {
-            query.push(" AND transcripts.recorded_at > ");
+            query.push(" AND voice_notes.recorded_at > ");
             query.push_bind(recorded_after);
         }
         if let Some(recorded_before) = recorded_before.as_deref() {
-            query.push(" AND transcripts.recorded_at <= ");
+            query.push(" AND voice_notes.recorded_at <= ");
             query.push_bind(recorded_before);
         }
         if let Some(created_after) = created_after.as_deref() {
-            query.push(" AND transcripts.created_at > ");
+            query.push(" AND voice_notes.created_at > ");
             query.push_bind(created_after);
         }
         if let Some(created_before) = created_before.as_deref() {
-            query.push(" AND transcripts.created_at <= ");
+            query.push(" AND voice_notes.created_at <= ");
             query.push_bind(created_before);
         }
         for tag_id in &filters.tag_ids {
@@ -749,10 +749,10 @@ impl Storage {
                 r#"
                 AND EXISTS (
                     SELECT 1
-                    FROM transcript_tags
-                    WHERE transcript_tags.api_key_id = transcripts.api_key_id
-                        AND transcript_tags.transcript_id = transcripts.id
-                        AND transcript_tags.tag_id =
+                    FROM voice_note_tags
+                    WHERE voice_note_tags.api_key_id = voice_notes.api_key_id
+                        AND voice_note_tags.voice_note_id = voice_notes.id
+                        AND voice_note_tags.tag_id =
                 "#,
             );
             query.push_bind(tag_id);
@@ -760,10 +760,10 @@ impl Storage {
         }
         query.push(
             r#"
-                AND transcript_versions.version_number = (
+                AND voice_note_versions.version_number = (
                     SELECT MAX(version_number)
-                    FROM transcript_versions
-                    WHERE transcript_id = transcripts.id
+                    FROM voice_note_versions
+                    WHERE voice_note_id = voice_notes.id
                 )
             "#,
         );
@@ -771,30 +771,30 @@ impl Storage {
             query.push(
                 r#"
                 AND (
-                    transcripts.created_at <
+                    voice_notes.created_at <
                 "#,
             );
             query.push_bind(cursor_created_at);
-            query.push(" OR (transcripts.created_at = ");
+            query.push(" OR (voice_notes.created_at = ");
             query.push_bind(cursor_created_at);
-            query.push(" AND transcripts.id < ");
+            query.push(" AND voice_notes.id < ");
             query.push_bind(cursor_id.expect("cursor id is present with cursor timestamp"));
             query.push("))");
         }
-        query.push(" ORDER BY transcripts.created_at DESC, transcripts.id DESC LIMIT ");
+        query.push(" ORDER BY voice_notes.created_at DESC, voice_notes.id DESC LIMIT ");
         query.push_bind(limit);
         let rows = query.build().fetch_all(&self.pool).await?;
 
-        rows.into_iter().map(transcript_from_row).collect()
+        rows.into_iter().map(voice_note_from_row).collect()
     }
 
-    pub async fn list_transcript_versions(
+    pub async fn list_voice_note_versions(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         cursor: Option<(OffsetDateTime, String)>,
         limit: i64,
-    ) -> Result<Vec<TranscriptVersionRecord>, StorageError> {
+    ) -> Result<Vec<VoiceNoteVersionRecord>, StorageError> {
         let cursor_created_at = cursor
             .as_ref()
             .map(|(created_at, _)| format_timestamp(*created_at))
@@ -802,10 +802,10 @@ impl Storage {
         let cursor_id = cursor.as_ref().map(|(_, id)| id.as_str());
         let rows = sqlx::query(
             r#"
-            SELECT id, transcript_id, transcript, created_at
-            FROM transcript_versions
+            SELECT id, voice_note_id, text, created_at
+            FROM voice_note_versions
             WHERE api_key_id = ?
-                AND transcript_id = ?
+                AND voice_note_id = ?
                 AND (
                     ? IS NULL
                     OR created_at < ?
@@ -816,7 +816,7 @@ impl Storage {
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .bind(&cursor_created_at)
         .bind(&cursor_created_at)
         .bind(&cursor_created_at)
@@ -825,24 +825,24 @@ impl Storage {
         .fetch_all(&self.pool)
         .await?;
 
-        rows.into_iter().map(transcript_version_from_row).collect()
+        rows.into_iter().map(voice_note_version_from_row).collect()
     }
 
     pub async fn list_segments(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<Vec<SegmentRecord>, StorageError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, transcript_id, position, start_ms, end_ms, text
+            SELECT id, voice_note_id, position, start_ms, end_ms, text
             FROM segments
-            WHERE api_key_id = ? AND transcript_id = ?
+            WHERE api_key_id = ? AND voice_note_id = ?
             ORDER BY position ASC
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_all(&self.pool)
         .await?;
 
@@ -852,23 +852,23 @@ impl Storage {
     pub async fn list_segments_page(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         cursor: Option<i64>,
         limit: i64,
     ) -> Result<Vec<SegmentRecord>, StorageError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, transcript_id, position, start_ms, end_ms, text
+            SELECT id, voice_note_id, position, start_ms, end_ms, text
             FROM segments
             WHERE api_key_id = ?
-                AND transcript_id = ?
+                AND voice_note_id = ?
                 AND (? IS NULL OR position > ?)
             ORDER BY position ASC
             LIMIT ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .bind(cursor)
         .bind(cursor)
         .bind(limit)
@@ -975,30 +975,30 @@ impl Storage {
     pub async fn replace_current_embedding(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         embedding: NewEmbedding,
     ) -> Result<bool, StorageError> {
         let result = sqlx::query(
             r#"
-            INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
             SELECT ?, ?, ?, ?, ?
             WHERE EXISTS (
-                SELECT 1 FROM transcripts WHERE api_key_id = ? AND id = ?
+                SELECT 1 FROM voice_notes WHERE api_key_id = ? AND id = ?
             )
-            ON CONFLICT(transcript_id) DO UPDATE SET
+            ON CONFLICT(voice_note_id) DO UPDATE SET
                 model = excluded.model,
                 vector = excluded.vector,
                 created_at = excluded.created_at
             WHERE embeddings.api_key_id = excluded.api_key_id
             "#,
         )
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .bind(api_key_id)
         .bind(&embedding.model)
         .bind(&embedding.vector)
         .bind(format_timestamp(embedding.created_at)?)
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected() == 1)
@@ -1007,36 +1007,36 @@ impl Storage {
     pub async fn get_current_embedding(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<Option<EmbeddingRecord>, StorageError> {
         let row = sqlx::query(
             r#"
-            SELECT transcript_id, model, vector, created_at
+            SELECT voice_note_id, model, vector, created_at
             FROM embeddings
-            WHERE api_key_id = ? AND transcript_id = ?
+            WHERE api_key_id = ? AND voice_note_id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_optional(&self.pool)
         .await?;
 
         row.map(embedding_from_row).transpose()
     }
 
-    pub async fn delete_transcript(
+    pub async fn delete_voice_note(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<bool, StorageError> {
         let result = sqlx::query(
             r#"
-            DELETE FROM transcripts
+            DELETE FROM voice_notes
             WHERE api_key_id = ? AND id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .execute(&self.pool)
         .await?;
 
@@ -1292,34 +1292,34 @@ impl Storage {
         row.map(session_from_row).transpose()
     }
 
-    pub async fn replace_transcript_tags(
+    pub async fn replace_voice_note_tags(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
         tag_ids: &[String],
-    ) -> Result<ReplaceTranscriptTagsOutcome, StorageError> {
+    ) -> Result<ReplaceVoiceNoteTagsOutcome, StorageError> {
         let mut seen = HashSet::with_capacity(tag_ids.len());
         for tag_id in tag_ids {
             if !seen.insert(tag_id) {
-                return Ok(ReplaceTranscriptTagsOutcome::DuplicateTagIds);
+                return Ok(ReplaceVoiceNoteTagsOutcome::DuplicateTagIds);
             }
         }
 
         let mut tx = self.pool.begin().await?;
-        let transcript_exists: Option<i64> = sqlx::query_scalar(
+        let voice_note_exists: Option<i64> = sqlx::query_scalar(
             r#"
             SELECT 1
-            FROM transcripts
+            FROM voice_notes
             WHERE api_key_id = ? AND id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_optional(&mut *tx)
         .await?;
-        if transcript_exists.is_none() {
+        if voice_note_exists.is_none() {
             tx.commit().await?;
-            return Ok(ReplaceTranscriptTagsOutcome::NotFound);
+            return Ok(ReplaceVoiceNoteTagsOutcome::NotFound);
         }
 
         for tag_id in tag_ids {
@@ -1336,114 +1336,114 @@ impl Storage {
             .await?;
             if tag_exists.is_none() {
                 tx.commit().await?;
-                return Ok(ReplaceTranscriptTagsOutcome::NotFound);
+                return Ok(ReplaceVoiceNoteTagsOutcome::NotFound);
             }
         }
 
         sqlx::query(
             r#"
-            DELETE FROM transcript_tags
-            WHERE api_key_id = ? AND transcript_id = ?
+            DELETE FROM voice_note_tags
+            WHERE api_key_id = ? AND voice_note_id = ?
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .execute(&mut *tx)
         .await?;
 
         for tag_id in tag_ids {
             sqlx::query(
                 r#"
-                INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+                INSERT INTO voice_note_tags (api_key_id, voice_note_id, tag_id)
                 VALUES (?, ?, ?)
                 "#,
             )
             .bind(api_key_id)
-            .bind(transcript_id)
+            .bind(voice_note_id)
             .bind(tag_id)
             .execute(&mut *tx)
             .await?;
         }
 
         tx.commit().await?;
-        Ok(ReplaceTranscriptTagsOutcome::Replaced)
+        Ok(ReplaceVoiceNoteTagsOutcome::Replaced)
     }
 
-    pub async fn list_transcript_tags(
+    pub async fn list_voice_note_tags(
         &self,
         api_key_id: &str,
-        transcript_id: &str,
+        voice_note_id: &str,
     ) -> Result<Vec<TagRecord>, StorageError> {
         let rows = sqlx::query(
             r#"
             SELECT tags.id, tags.api_key_id, tags.name, tags.created_at
             FROM tags
-            JOIN transcript_tags
-                ON transcript_tags.api_key_id = tags.api_key_id
-                AND transcript_tags.tag_id = tags.id
-            WHERE transcript_tags.api_key_id = ?
-                AND transcript_tags.transcript_id = ?
+            JOIN voice_note_tags
+                ON voice_note_tags.api_key_id = tags.api_key_id
+                AND voice_note_tags.tag_id = tags.id
+            WHERE voice_note_tags.api_key_id = ?
+                AND voice_note_tags.voice_note_id = ?
             ORDER BY tags.created_at DESC, tags.id DESC
             "#,
         )
         .bind(api_key_id)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_all(&self.pool)
         .await?;
 
         rows.into_iter().map(tag_from_row).collect()
     }
 
-    pub async fn list_tags_for_transcripts(
+    pub async fn list_tags_for_voice_notes(
         &self,
         api_key_id: &str,
-        transcript_ids: &[String],
+        voice_note_ids: &[String],
     ) -> Result<HashMap<String, Vec<TagRecord>>, StorageError> {
-        if transcript_ids.is_empty() {
+        if voice_note_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
         let mut query = QueryBuilder::new(
             r#"
             SELECT
-                transcript_tags.transcript_id AS transcript_id,
+                voice_note_tags.voice_note_id AS voice_note_id,
                 tags.id AS tag_id,
                 tags.api_key_id AS api_key_id,
                 tags.name AS name,
                 tags.created_at AS created_at
-            FROM transcript_tags
+            FROM voice_note_tags
             JOIN tags
-                ON tags.api_key_id = transcript_tags.api_key_id
-                AND tags.id = transcript_tags.tag_id
-            WHERE transcript_tags.api_key_id =
+                ON tags.api_key_id = voice_note_tags.api_key_id
+                AND tags.id = voice_note_tags.tag_id
+            WHERE voice_note_tags.api_key_id =
             "#,
         );
         query.push_bind(api_key_id);
-        query.push(" AND transcript_tags.transcript_id IN (");
+        query.push(" AND voice_note_tags.voice_note_id IN (");
         let mut separated = query.separated(", ");
-        for transcript_id in transcript_ids {
-            separated.push_bind(transcript_id);
+        for voice_note_id in voice_note_ids {
+            separated.push_bind(voice_note_id);
         }
         separated.push_unseparated(")");
         query.push(
-            " ORDER BY transcript_tags.transcript_id ASC, tags.created_at DESC, tags.id DESC",
+            " ORDER BY voice_note_tags.voice_note_id ASC, tags.created_at DESC, tags.id DESC",
         );
 
         let rows = query.build().fetch_all(&self.pool).await?;
-        let mut tags_by_transcript = HashMap::new();
-        for transcript_id in transcript_ids {
-            tags_by_transcript.insert(transcript_id.clone(), Vec::new());
+        let mut tags_by_voice_note = HashMap::new();
+        for voice_note_id in voice_note_ids {
+            tags_by_voice_note.insert(voice_note_id.clone(), Vec::new());
         }
         for row in rows {
-            let transcript_id: String = row.try_get("transcript_id")?;
+            let voice_note_id: String = row.try_get("voice_note_id")?;
             let tag = tag_from_prefixed_row(row)?;
-            tags_by_transcript
-                .entry(transcript_id)
+            tags_by_voice_note
+                .entry(voice_note_id)
                 .or_default()
                 .push(tag);
         }
 
-        Ok(tags_by_transcript)
+        Ok(tags_by_voice_note)
     }
 }
 
@@ -1567,7 +1567,7 @@ fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, 
         failure_code: row.try_get("failure_code")?,
         failure_message: row.try_get("failure_message")?,
         retryable_by_client,
-        transcript_id: row.try_get("transcript_id")?,
+        voice_note_id: row.try_get("voice_note_id")?,
     })
 }
 
@@ -1577,16 +1577,16 @@ fn settings_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SettingsRecord, Sto
     })
 }
 
-fn transcript_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptRecord, StorageError> {
-    Ok(TranscriptRecord {
+fn voice_note_from_row(row: sqlx::sqlite::SqliteRow) -> Result<VoiceNoteRecord, StorageError> {
+    Ok(VoiceNoteRecord {
         id: row.try_get("id")?,
         api_key_id: row.try_get("api_key_id")?,
         current_version_id: row.try_get("current_version_id")?,
-        transcript: row.try_get("current_transcript")?,
+        text: row.try_get("current_text")?,
         audio_duration_seconds: row.try_get("audio_duration_seconds")?,
         audio_format: row.try_get("audio_format")?,
         audio_size_bytes: row.try_get("audio_size_bytes")?,
-        transcript_language: row.try_get("transcript_language")?,
+        language: row.try_get("language")?,
         model: row.try_get("model")?,
         processing_time_ms: row.try_get("processing_time_ms")?,
         cost_cents: row.try_get("cost_cents")?,
@@ -1596,13 +1596,13 @@ fn transcript_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptRecord,
     })
 }
 
-fn transcript_version_from_row(
+fn voice_note_version_from_row(
     row: sqlx::sqlite::SqliteRow,
-) -> Result<TranscriptVersionRecord, StorageError> {
-    Ok(TranscriptVersionRecord {
+) -> Result<VoiceNoteVersionRecord, StorageError> {
+    Ok(VoiceNoteVersionRecord {
         id: row.try_get("id")?,
-        transcript_id: row.try_get("transcript_id")?,
-        transcript: row.try_get("transcript")?,
+        voice_note_id: row.try_get("voice_note_id")?,
+        text: row.try_get("text")?,
         created_at: parse_timestamp(row.try_get("created_at")?)?,
     })
 }
@@ -1610,7 +1610,7 @@ fn transcript_version_from_row(
 fn segment_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SegmentRecord, StorageError> {
     Ok(SegmentRecord {
         id: row.try_get("id")?,
-        transcript_id: row.try_get("transcript_id")?,
+        voice_note_id: row.try_get("voice_note_id")?,
         position: row.try_get("position")?,
         start_ms: row.try_get("start_ms")?,
         end_ms: row.try_get("end_ms")?,
@@ -1620,7 +1620,7 @@ fn segment_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SegmentRecord, Stora
 
 fn embedding_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EmbeddingRecord, StorageError> {
     Ok(EmbeddingRecord {
-        transcript_id: row.try_get("transcript_id")?,
+        voice_note_id: row.try_get("voice_note_id")?,
         model: row.try_get("model")?,
         vector: row.try_get("vector")?,
         created_at: parse_timestamp(row.try_get("created_at")?)?,

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -12,7 +12,7 @@ use crate::collections::{
 use crate::errors::{ApiError, CollectionEnvelope};
 use crate::state::AppState;
 use crate::storage::{
-    SegmentRecord, TagRecord, TranscriptFilters, TranscriptRecord, TranscriptVersionRecord,
+    SegmentRecord, TagRecord, VoiceNoteFilters, VoiceNoteRecord, VoiceNoteVersionRecord,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,7 +32,7 @@ struct PageQuery<T> {
 #[derive(Debug, Clone)]
 struct VoiceNoteCollectionQuery {
     page: PageQuery<(OffsetDateTime, String)>,
-    filters: TranscriptFilters,
+    filters: VoiceNoteFilters,
     search_requested: bool,
 }
 
@@ -92,7 +92,7 @@ pub async fn list_voice_notes(
 
     let rows = state
         .storage
-        .list_transcripts(
+        .list_voice_notes(
             authenticated_key.api_key_id.as_str(),
             &query.filters,
             query.page.cursor,
@@ -119,7 +119,7 @@ pub async fn get_voice_note(
     validate_ulid_field("voice_note_id", &voice_note_id)?;
     let Some(record) = state
         .storage
-        .get_transcript(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .get_voice_note(authenticated_key.api_key_id.as_str(), &voice_note_id)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note."))?
     else {
@@ -127,7 +127,7 @@ pub async fn get_voice_note(
     };
     let tags = state
         .storage
-        .list_transcript_tags(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .list_voice_note_tags(authenticated_key.api_key_id.as_str(), &voice_note_id)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
 
@@ -151,7 +151,7 @@ pub async fn list_voice_note_versions(
     .await?;
     let mut rows = state
         .storage
-        .list_transcript_versions(
+        .list_voice_note_versions(
             authenticated_key.api_key_id.as_str(),
             &voice_note_id,
             page.cursor,
@@ -251,7 +251,7 @@ pub async fn list_session_voice_notes(
 
     let rows = state
         .storage
-        .list_session_transcripts(
+        .list_session_voice_notes(
             authenticated_key.api_key_id.as_str(),
             &session_id,
             &query.filters,
@@ -278,7 +278,7 @@ async fn ensure_voice_note_exists(
 ) -> Result<(), ApiError> {
     if state
         .storage
-        .get_transcript(api_key_id, voice_note_id)
+        .get_voice_note(api_key_id, voice_note_id)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note."))?
         .is_none()
@@ -292,7 +292,7 @@ async fn ensure_voice_note_exists(
 async fn render_voice_note_page(
     api_key_id: &str,
     state: &AppState,
-    mut rows: Vec<TranscriptRecord>,
+    mut rows: Vec<VoiceNoteRecord>,
     limit: i64,
     cursor_kind: CursorKind,
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
@@ -309,16 +309,16 @@ async fn render_voice_note_page(
     } else {
         None
     };
-    let transcript_ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
-    let mut tags_by_transcript = state
+    let voice_note_ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+    let mut tags_by_voice_note = state
         .storage
-        .list_tags_for_transcripts(api_key_id, &transcript_ids)
+        .list_tags_for_voice_notes(api_key_id, &voice_note_ids)
         .await
         .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
     let items = rows
         .into_iter()
         .map(|row| {
-            let tags = tags_by_transcript.remove(&row.id).unwrap_or_default();
+            let tags = tags_by_voice_note.remove(&row.id).unwrap_or_default();
             voice_note_resource(row, tags)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -346,7 +346,7 @@ fn parse_voice_note_collection_query(
                 .map(|cursor| parse_time_cursor(cursor, cursor_kind.as_str()))
                 .transpose()?,
         },
-        filters: parse_transcript_filters(params, cursor_kind)?,
+        filters: parse_voice_note_filters(params, cursor_kind)?,
         search_requested: query_any(params, "q"),
     })
 }
@@ -451,11 +451,11 @@ fn validate_collection_query_values(
     Ok(())
 }
 
-fn parse_transcript_filters(
+fn parse_voice_note_filters(
     params: &[(String, String)],
     cursor_kind: CursorKind,
-) -> Result<TranscriptFilters, ApiError> {
-    let mut filters = TranscriptFilters::default();
+) -> Result<VoiceNoteFilters, ApiError> {
+    let mut filters = VoiceNoteFilters::default();
     for tag_id in query_values(params, "tag_id") {
         let tag_id = tag_id.to_owned();
         if !filters.tag_ids.contains(&tag_id) {
@@ -483,17 +483,17 @@ fn parse_optional_rfc3339_filter(
 }
 
 fn voice_note_resource(
-    record: TranscriptRecord,
+    record: VoiceNoteRecord,
     tags: Vec<TagRecord>,
 ) -> Result<VoiceNoteResource, ApiError> {
     Ok(VoiceNoteResource {
         id: record.id,
         current_version_id: record.current_version_id,
-        text: record.transcript,
+        text: record.text,
         audio_duration_seconds: record.audio_duration_seconds,
         audio_format: record.audio_format,
         audio_size_bytes: record.audio_size_bytes,
-        language: record.transcript_language,
+        language: record.language,
         model: record.model,
         processing_time_ms: record.processing_time_ms,
         cost_cents: record.cost_cents,
@@ -508,12 +508,12 @@ fn voice_note_resource(
 }
 
 fn voice_note_version_resource(
-    record: TranscriptVersionRecord,
+    record: VoiceNoteVersionRecord,
 ) -> Result<VoiceNoteVersionResource, ApiError> {
     Ok(VoiceNoteVersionResource {
         id: record.id,
-        voice_note_id: record.transcript_id,
-        text: record.transcript,
+        voice_note_id: record.voice_note_id,
+        text: record.text,
         created_at: timestamp(record.created_at)?,
     })
 }
@@ -521,7 +521,7 @@ fn voice_note_version_resource(
 fn segment_resource(record: SegmentRecord) -> SegmentResource {
     SegmentResource {
         id: record.id,
-        voice_note_id: record.transcript_id,
+        voice_note_id: record.voice_note_id,
         position: record.position,
         start_ms: record.start_ms,
         end_ms: record.end_ms,

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -571,10 +571,10 @@ impl MetadataFixture {
     }
 
     async fn insert_voice_note_with_tag(&self, owner: &str, tag_id: &str) {
-        self.insert_transcript(owner, None).await;
+        self.insert_voice_note(owner, None).await;
         sqlx::query(
             r#"
-            INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+            INSERT INTO voice_note_tags (api_key_id, voice_note_id, tag_id)
             VALUES (?, ?, ?)
             "#,
         )
@@ -583,18 +583,18 @@ impl MetadataFixture {
         .bind(tag_id)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript tag");
+        .expect("insert voice note tag");
     }
 
     async fn insert_job_and_voice_note_in_session(&self) {
-        self.insert_transcript("alpha", Some(SESSION_ALPHA)).await;
+        self.insert_voice_note("alpha", Some(SESSION_ALPHA)).await;
         sqlx::query(
             r#"
             INSERT INTO transcription_jobs (
                 id, api_key_id, idempotency_key, audio_sha256_hex,
                 audio_content_hash_algorithm, recorded_at, session_id,
                 accepted_audio_path, status, created_at, updated_at,
-                retry_count, max_retries, transcript_id
+                retry_count, max_retries, voice_note_id
             )
             VALUES (
                 ?, 'alpha', 'attempt-a', 'hash', 'sha256:chunk-sha256-v1',
@@ -612,12 +612,12 @@ impl MetadataFixture {
         .expect("insert job");
     }
 
-    async fn insert_transcript(&self, owner: &str, session_id: Option<&str>) {
+    async fn insert_voice_note(&self, owner: &str, session_id: Option<&str>) {
         sqlx::query(
             r#"
-            INSERT INTO transcripts (
+            INSERT INTO voice_notes (
                 id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-                transcript_language, model, processing_time_ms, cost_cents,
+                language, model, processing_time_ms, cost_cents,
                 created_at, recorded_at, session_id
             )
             VALUES (?, ?, 12.5, 'wav', 401280, 'en', 'gpt-4o-mini-transcribe', 1843, NULL, ?, ?, ?)
@@ -630,12 +630,12 @@ impl MetadataFixture {
         .bind(session_id)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript");
+        .expect("insert voice note");
 
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, 1, 'note text', '2026-04-24T18:00:00.000000000Z')
             "#,
@@ -645,7 +645,7 @@ impl MetadataFixture {
         .bind(NOTE_ALPHA)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript version");
+        .expect("insert voice note version");
     }
 }
 

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use oracy_backend::audio_hash::{AUDIO_CONTENT_HASH_ALGORITHM_ID, compose_audio_content_hash_hex};
 use oracy_backend::storage::{
     AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewSegment, NewSession, NewTag,
-    NewTranscript, NewTranscriptVersion, NewTranscriptionJob, RenameTagOutcome,
-    ReplaceTranscriptTagsOutcome, Storage, StorageError, TranscriptMaterialization,
+    NewTranscriptionJob, NewVoiceNote, NewVoiceNoteVersion, RenameTagOutcome,
+    ReplaceVoiceNoteTagsOutcome, Storage, StorageError, VoiceNoteMaterialization,
 };
 use sqlx::Row;
 use tempfile::TempDir;
@@ -320,23 +320,23 @@ async fn accepted_submission_tuple_is_immutable_in_storage() {
 }
 
 #[tokio::test]
-async fn transcript_materialization_is_transactional() {
+async fn voice_note_materialization_is_transactional() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_processing(&storage, &job.id).await;
-    let mut materialization = materialization("transcript-a");
+    let mut materialization = materialization("voice-note-a");
     materialization.segments[1].position = materialization.segments[0].position;
 
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization)
+        .complete_job_with_voice_note("owner-a", &job.id, materialization)
         .await
         .expect_err("duplicate segment position should fail");
 
     assert!(
         storage
-            .get_transcript("owner-a", "transcript-a")
+            .get_voice_note("owner-a", "voice-note-a")
             .await
-            .expect("transcript lookup")
+            .expect("voice note lookup")
             .is_none()
     );
     let job = storage
@@ -345,41 +345,41 @@ async fn transcript_materialization_is_transactional() {
         .expect("job lookup")
         .expect("job exists");
     assert_eq!(job.status, "processing");
-    assert_eq!(job.transcript_id, None);
+    assert_eq!(job.voice_note_id, None);
 }
 
 #[tokio::test]
-async fn completed_transcripts_expose_current_version_ordered_segments_and_current_embedding() {
+async fn completed_voice_notes_expose_current_version_ordered_segments_and_current_embedding() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_processing(&storage, &job.id).await;
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
-        .expect("materialize transcript");
+        .expect("materialize voice note");
 
     sqlx::query(
         r#"
-        INSERT INTO transcript_versions (
-            id, api_key_id, transcript_id, version_number, transcript, created_at
+        INSERT INTO voice_note_versions (
+            id, api_key_id, voice_note_id, version_number, text, created_at
         )
-        VALUES ('version-2', 'owner-a', 'transcript-a', 2, 'edited text', '2026-04-24T18:01:00Z')
+        VALUES ('version-2', 'owner-a', 'voice-note-a', 2, 'edited text', '2026-04-24T18:01:00Z')
         "#,
     )
     .execute(storage.pool())
     .await
     .expect("insert edited version");
 
-    let transcript = storage
-        .get_transcript("owner-a", "transcript-a")
+    let voice_note = storage
+        .get_voice_note("owner-a", "voice-note-a")
         .await
-        .expect("transcript lookup")
-        .expect("transcript exists");
-    assert_eq!(transcript.current_version_id, "version-2");
-    assert_eq!(transcript.transcript, "edited text");
+        .expect("voice note lookup")
+        .expect("voice note exists");
+    assert_eq!(voice_note.current_version_id, "version-2");
+    assert_eq!(voice_note.text, "edited text");
 
     let segments = storage
-        .list_segments("owner-a", "transcript-a")
+        .list_segments("owner-a", "voice-note-a")
         .await
         .expect("segments");
     assert_eq!(
@@ -391,7 +391,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
     );
 
     let initial_embedding = storage
-        .get_current_embedding("owner-a", "transcript-a")
+        .get_current_embedding("owner-a", "voice-note-a")
         .await
         .expect("embedding lookup")
         .expect("embedding exists");
@@ -401,7 +401,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
         storage
             .replace_current_embedding(
                 "owner-a",
-                "transcript-a",
+                "voice-note-a",
                 NewEmbedding {
                     model: "embedding-v2".to_owned(),
                     vector: vec![4, 5, 6],
@@ -415,7 +415,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
         !storage
             .replace_current_embedding(
                 "owner-b",
-                "transcript-a",
+                "voice-note-a",
                 NewEmbedding {
                     model: "wrong-owner".to_owned(),
                     vector: vec![9],
@@ -427,7 +427,7 @@ async fn completed_transcripts_expose_current_version_ordered_segments_and_curre
     );
 
     let replaced = storage
-        .get_current_embedding("owner-a", "transcript-a")
+        .get_current_embedding("owner-a", "voice-note-a")
         .await
         .expect("embedding lookup")
         .expect("embedding exists");
@@ -442,12 +442,12 @@ async fn duplicate_completion_fails_without_orphaning_materialized_rows() {
     mark_job_processing(&storage, &job.id).await;
 
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
         .expect("first materialization succeeds");
 
     let error = storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-b"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-b"))
         .await
         .expect_err("duplicate materialization should fail");
     assert!(matches!(
@@ -461,30 +461,30 @@ async fn duplicate_completion_fails_without_orphaning_materialized_rows() {
         .expect("job lookup")
         .expect("job exists");
     assert_eq!(job.status, "succeeded");
-    assert_eq!(job.transcript_id.as_deref(), Some("transcript-a"));
-    assert_eq!(row_count(&storage, "transcripts", "transcript-b").await, 0);
+    assert_eq!(job.voice_note_id.as_deref(), Some("voice-note-a"));
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-b").await, 0);
     assert_eq!(
-        child_row_count(&storage, "transcript_versions", "transcript-b").await,
+        child_row_count(&storage, "voice_note_versions", "voice-note-b").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "segments", "transcript-b").await,
+        child_row_count(&storage, "segments", "voice-note-b").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "embeddings", "transcript-b").await,
+        child_row_count(&storage, "embeddings", "voice-note-b").await,
         0
     );
 }
 
 #[tokio::test]
-async fn retry_waiting_jobs_are_not_eligible_for_transcript_completion() {
+async fn retry_waiting_jobs_are_not_eligible_for_voice_note_completion() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_retry_waiting(&storage, &job.id).await;
 
     let error = storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
         .expect_err("retry-waiting completion should fail");
     assert!(matches!(
@@ -498,18 +498,18 @@ async fn retry_waiting_jobs_are_not_eligible_for_transcript_completion() {
         .expect("job lookup")
         .expect("job exists");
     assert_eq!(job.status, "retry_waiting");
-    assert_eq!(job.transcript_id, None);
-    assert_eq!(row_count(&storage, "transcripts", "transcript-a").await, 0);
+    assert_eq!(job.voice_note_id, None);
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-a").await, 0);
     assert_eq!(
-        child_row_count(&storage, "transcript_versions", "transcript-a").await,
+        child_row_count(&storage, "voice_note_versions", "voice-note-a").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "segments", "transcript-a").await,
+        child_row_count(&storage, "segments", "voice-note-a").await,
         0
     );
     assert_eq!(
-        child_row_count(&storage, "embeddings", "transcript-a").await,
+        child_row_count(&storage, "embeddings", "voice-note-a").await,
         0
     );
 }
@@ -607,38 +607,38 @@ async fn persisted_timestamps_order_and_filter_chronologically_under_sql_text_co
 }
 
 #[tokio::test]
-async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
+async fn deleting_a_voice_note_cascades_children_and_nulls_the_succeeded_job() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     mark_job_processing(&storage, &job.id).await;
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-a"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
         .await
-        .expect("materialize transcript");
+        .expect("materialize voice note");
 
     assert!(
         storage
-            .delete_transcript("owner-a", "transcript-a")
+            .delete_voice_note("owner-a", "voice-note-a")
             .await
-            .expect("delete transcript")
+            .expect("delete voice note")
     );
     assert!(
         storage
-            .get_transcript("owner-a", "transcript-a")
+            .get_voice_note("owner-a", "voice-note-a")
             .await
-            .expect("transcript lookup")
+            .expect("voice note lookup")
             .is_none()
     );
     assert!(
         storage
-            .list_segments("owner-a", "transcript-a")
+            .list_segments("owner-a", "voice-note-a")
             .await
             .expect("segments")
             .is_empty()
     );
     assert!(
         storage
-            .get_current_embedding("owner-a", "transcript-a")
+            .get_current_embedding("owner-a", "voice-note-a")
             .await
             .expect("embedding lookup")
             .is_none()
@@ -650,36 +650,36 @@ async fn deleting_a_transcript_cascades_children_and_nulls_the_succeeded_job() {
         .expect("job lookup")
         .expect("job survives");
     assert_eq!(job.status, "succeeded");
-    assert_eq!(job.transcript_id, None);
+    assert_eq!(job.voice_note_id, None);
 }
 
 #[tokio::test]
-async fn transcript_child_rows_must_match_the_parent_transcript_owner() {
+async fn voice_note_child_rows_must_match_the_parent_voice_note_owner() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
 
     sqlx::query(
         r#"
-        INSERT INTO transcript_versions (
-            id, api_key_id, transcript_id, version_number, transcript, created_at
+        INSERT INTO voice_note_versions (
+            id, api_key_id, voice_note_id, version_number, text, created_at
         )
         VALUES (
-            'owner-mismatched-version', 'owner-b', 'transcript-a', 1,
+            'owner-mismatched-version', 'owner-b', 'voice-note-a', 1,
             'cross-owner version', '2026-04-24T18:00:30.000000000Z'
         )
         "#,
     )
     .execute(storage.pool())
     .await
-    .expect_err("mismatched transcript version owner should fail");
+    .expect_err("mismatched voice note version owner should fail");
 
     sqlx::query(
         r#"
         INSERT INTO segments (
-            id, api_key_id, transcript_id, position, start_ms, end_ms, text
+            id, api_key_id, voice_note_id, position, start_ms, end_ms, text
         )
         VALUES (
-            'owner-mismatched-segment', 'owner-b', 'transcript-a', 0, 0, 1000,
+            'owner-mismatched-segment', 'owner-b', 'voice-note-a', 0, 0, 1000,
             'cross-owner segment'
         )
         "#,
@@ -690,9 +690,9 @@ async fn transcript_child_rows_must_match_the_parent_transcript_owner() {
 
     sqlx::query(
         r#"
-        INSERT INTO embeddings (transcript_id, api_key_id, model, vector, created_at)
+        INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
         VALUES (
-            'transcript-a', 'owner-b', 'embedding-v1', x'010203',
+            'voice-note-a', 'owner-b', 'embedding-v1', x'010203',
             '2026-04-24T18:00:31.000000000Z'
         )
         "#,
@@ -703,31 +703,31 @@ async fn transcript_child_rows_must_match_the_parent_transcript_owner() {
 }
 
 #[tokio::test]
-async fn completed_job_transcript_link_must_match_the_job_owner() {
+async fn completed_job_voice_note_link_must_match_the_job_owner() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let job = created_job(&storage, "owner-b", "attempt-1").await;
 
     sqlx::query(
         r#"
         UPDATE transcription_jobs
-        SET transcript_id = 'transcript-a'
+        SET voice_note_id = 'voice-note-a'
         WHERE id = ?
         "#,
     )
     .bind(&job.id)
     .execute(storage.pool())
     .await
-    .expect_err("mismatched job transcript owner should fail");
+    .expect_err("mismatched job voice note owner should fail");
 }
 
 #[tokio::test]
-async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many_with_transcripts()
+async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many_with_voice_notes()
 {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
-    insert_transcript_only(&storage, "owner-a", "transcript-b").await;
-    insert_transcript_only(&storage, "owner-b", "transcript-c").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-b").await;
+    insert_voice_note_only(&storage, "owner-b", "voice-note-c").await;
 
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
@@ -760,31 +760,31 @@ async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many
 
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&meeting.id))
+            .replace_voice_note_tags("owner-a", "voice-note-a", std::slice::from_ref(&meeting.id))
             .await
-            .expect("tag transcript"),
-        ReplaceTranscriptTagsOutcome::Replaced
+            .expect("tag voice note"),
+        ReplaceVoiceNoteTagsOutcome::Replaced
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-b", std::slice::from_ref(&meeting.id))
+            .replace_voice_note_tags("owner-a", "voice-note-b", std::slice::from_ref(&meeting.id))
             .await
-            .expect("tag second transcript"),
-        ReplaceTranscriptTagsOutcome::Replaced
+            .expect("tag second voice note"),
+        ReplaceVoiceNoteTagsOutcome::Replaced
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-b", "transcript-c", std::slice::from_ref(&meeting.id))
+            .replace_voice_note_tags("owner-b", "voice-note-c", std::slice::from_ref(&meeting.id))
             .await
             .expect("wrong-owner tag is rejected"),
-        ReplaceTranscriptTagsOutcome::NotFound
+        ReplaceVoiceNoteTagsOutcome::NotFound
     );
 
     assert_eq!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
-            .expect("list transcript tags"),
+            .expect("list voice note tags"),
         vec![replayed.clone()]
     );
 
@@ -796,13 +796,13 @@ async fn tags_are_owner_scoped_case_insensitive_latest_spelling_and_many_to_many
     );
     assert!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
             .expect("tag associations removed")
             .is_empty()
     );
-    assert_eq!(row_count(&storage, "transcripts", "transcript-a").await, 1);
-    assert_eq!(row_count(&storage, "transcripts", "transcript-b").await, 1);
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-a").await, 1);
+    assert_eq!(row_count(&storage, "voice_notes", "voice-note-b").await, 1);
 }
 
 #[tokio::test]
@@ -837,9 +837,9 @@ async fn unicode_case_equivalent_tag_names_share_one_owner_scoped_identity() {
 }
 
 #[tokio::test]
-async fn duplicate_transcript_tag_ids_are_rejected_without_mutating_prior_tags() {
+async fn duplicate_voice_note_tag_ids_are_rejected_without_mutating_prior_tags() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
         .await
@@ -858,35 +858,35 @@ async fn duplicate_transcript_tag_ids_are_rejected_without_mutating_prior_tags()
     };
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&notes.id))
+            .replace_voice_note_tags("owner-a", "voice-note-a", std::slice::from_ref(&notes.id))
             .await
             .expect("set prior tag"),
-        ReplaceTranscriptTagsOutcome::Replaced
+        ReplaceVoiceNoteTagsOutcome::Replaced
     );
 
     let outcome = storage
-        .replace_transcript_tags(
+        .replace_voice_note_tags(
             "owner-a",
-            "transcript-a",
+            "voice-note-a",
             &[meeting.id.clone(), meeting.id.clone()],
         )
         .await
         .expect("duplicate-input outcome");
 
-    assert_eq!(outcome, ReplaceTranscriptTagsOutcome::DuplicateTagIds);
+    assert_eq!(outcome, ReplaceVoiceNoteTagsOutcome::DuplicateTagIds);
     assert_eq!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
-            .expect("list transcript tags"),
+            .expect("list voice note tags"),
         vec![notes]
     );
 }
 
 #[tokio::test]
-async fn transcript_tag_replacement_collapses_missing_transcript_and_tag_to_not_found() {
+async fn voice_note_tag_replacement_collapses_missing_voice_note_and_tag_to_not_found() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
         .await
@@ -898,22 +898,22 @@ async fn transcript_tag_replacement_collapses_missing_transcript_and_tag_to_not_
 
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-missing", &[meeting.id])
+            .replace_voice_note_tags("owner-a", "voice-note-missing", &[meeting.id])
             .await
-            .expect("missing transcript outcome"),
-        ReplaceTranscriptTagsOutcome::NotFound
+            .expect("missing voice note outcome"),
+        ReplaceVoiceNoteTagsOutcome::NotFound
     );
     assert_eq!(
         storage
-            .replace_transcript_tags("owner-a", "transcript-a", &["tag-missing".to_owned()])
+            .replace_voice_note_tags("owner-a", "voice-note-a", &["tag-missing".to_owned()])
             .await
             .expect("missing tag outcome"),
-        ReplaceTranscriptTagsOutcome::NotFound
+        ReplaceVoiceNoteTagsOutcome::NotFound
     );
 }
 
 #[tokio::test]
-async fn complete_job_with_transcript_nulls_deleted_accepted_session_without_mutating_job_tuple() {
+async fn complete_job_with_voice_note_nulls_deleted_accepted_session_without_mutating_job_tuple() {
     let (_tempdir, storage) = storage().await;
     let input = new_job("owner-a", "attempt-deleted-session", "hash-a");
     let job = created_job(&storage, "owner-a", "attempt-deleted-session").await;
@@ -927,20 +927,20 @@ async fn complete_job_with_transcript_nulls_deleted_accepted_session_without_mut
     );
 
     storage
-        .complete_job_with_transcript(
+        .complete_job_with_voice_note(
             "owner-a",
             &job.id,
-            materialization("transcript-deleted-session"),
+            materialization("voice-note-deleted-session"),
         )
         .await
-        .expect("materialize transcript after session deletion");
+        .expect("materialize voice note after session deletion");
 
     assert_eq!(
         storage
-            .get_transcript("owner-a", "transcript-deleted-session")
+            .get_voice_note("owner-a", "voice-note-deleted-session")
             .await
-            .expect("transcript lookup")
-            .expect("transcript exists")
+            .expect("voice note lookup")
+            .expect("voice note exists")
             .session_id,
         None
     );
@@ -961,7 +961,7 @@ async fn complete_job_with_transcript_nulls_deleted_accepted_session_without_mut
 }
 
 #[tokio::test]
-async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_tuples() {
+async fn sessions_are_identities_that_null_voice_notes_without_mutating_replay_tuples() {
     let (_tempdir, storage) = storage().await;
     let session = storage
         .create_session(new_session("owner-a", "session-a", "Planning"))
@@ -981,16 +981,16 @@ async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_t
     };
     mark_job_processing(&storage, &job.id).await;
     storage
-        .complete_job_with_transcript("owner-a", &job.id, materialization("transcript-session"))
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-session"))
         .await
-        .expect("materialize transcript");
+        .expect("materialize voice note");
 
     assert_eq!(
         storage
-            .get_transcript("owner-a", "transcript-session")
+            .get_voice_note("owner-a", "voice-note-session")
             .await
-            .expect("transcript lookup")
-            .expect("transcript exists")
+            .expect("voice note lookup")
+            .expect("voice note exists")
             .session_id
             .as_deref(),
         Some("session-a")
@@ -1004,10 +1004,10 @@ async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_t
     );
     assert_eq!(
         storage
-            .get_transcript("owner-a", "transcript-session")
+            .get_voice_note("owner-a", "voice-note-session")
             .await
-            .expect("transcript lookup")
-            .expect("transcript exists")
+            .expect("voice note lookup")
+            .expect("voice note exists")
             .session_id,
         None
     );
@@ -1030,7 +1030,7 @@ async fn sessions_are_identities_that_null_transcripts_without_mutating_replay_t
 #[tokio::test]
 async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collisions() {
     let (_tempdir, storage) = storage().await;
-    insert_transcript_only(&storage, "owner-a", "transcript-a").await;
+    insert_voice_note_only(&storage, "owner-a", "voice-note-a").await;
     let meeting = match storage
         .create_tag(new_tag("owner-a", "tag-meeting", "Meeting"))
         .await
@@ -1048,9 +1048,9 @@ async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collis
         other => panic!("expected created tag, got {other:?}"),
     };
     storage
-        .replace_transcript_tags("owner-a", "transcript-a", std::slice::from_ref(&meeting.id))
+        .replace_voice_note_tags("owner-a", "voice-note-a", std::slice::from_ref(&meeting.id))
         .await
-        .expect("tag transcript");
+        .expect("tag voice note");
 
     let renamed = match storage
         .rename_tag("owner-a", &meeting.id, "MEETING")
@@ -1064,9 +1064,9 @@ async fn tag_renames_preserve_latest_spelling_and_reject_case_insensitive_collis
     assert_eq!(renamed.name, "MEETING");
     assert_eq!(
         storage
-            .list_transcript_tags("owner-a", "transcript-a")
+            .list_voice_note_tags("owner-a", "voice-note-a")
             .await
-            .expect("list transcript tags")
+            .expect("list voice note tags")
             .first()
             .expect("tag exists")
             .name,
@@ -1311,12 +1311,12 @@ async fn accept_while_uncommitted_row_exists(
     handle.await.expect("accept task should not panic")
 }
 
-async fn insert_transcript_only(storage: &Storage, owner: &str, transcript_id: &str) {
+async fn insert_voice_note_only(storage: &Storage, owner: &str, voice_note_id: &str) {
     sqlx::query(
         r#"
-        INSERT INTO transcripts (
+        INSERT INTO voice_notes (
             id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-            transcript_language, model, processing_time_ms, cost_cents,
+            language, model, processing_time_ms, cost_cents,
             created_at, recorded_at, session_id
         )
         VALUES (
@@ -1327,11 +1327,11 @@ async fn insert_transcript_only(storage: &Storage, owner: &str, transcript_id: &
         )
         "#,
     )
-    .bind(transcript_id)
+    .bind(voice_note_id)
     .bind(owner)
     .execute(storage.pool())
     .await
-    .expect("insert transcript");
+    .expect("insert voice note");
 }
 
 async fn insert_session_row(storage: &Storage, owner: &str, session_id: &str) {
@@ -1405,10 +1405,10 @@ async fn row_count(storage: &Storage, table: &str, id: &str) -> i64 {
         .get("count")
 }
 
-async fn child_row_count(storage: &Storage, table: &str, transcript_id: &str) -> i64 {
-    let sql = format!("SELECT COUNT(*) AS count FROM {table} WHERE transcript_id = ?");
+async fn child_row_count(storage: &Storage, table: &str, voice_note_id: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) AS count FROM {table} WHERE voice_note_id = ?");
     sqlx::query(&sql)
-        .bind(transcript_id)
+        .bind(voice_note_id)
         .fetch_one(storage.pool())
         .await
         .expect("count child rows")
@@ -1447,35 +1447,35 @@ fn new_session(owner: &str, id: &str, name: &str) -> NewSession {
     }
 }
 
-fn materialization(transcript_id: &str) -> TranscriptMaterialization {
-    TranscriptMaterialization {
-        transcript: NewTranscript {
-            id: transcript_id.to_owned(),
+fn materialization(voice_note_id: &str) -> VoiceNoteMaterialization {
+    VoiceNoteMaterialization {
+        voice_note: NewVoiceNote {
+            id: voice_note_id.to_owned(),
             audio_duration_seconds: 12.5,
             audio_format: "wav".to_owned(),
             audio_size_bytes: 401_280,
-            transcript_language: Some("en".to_owned()),
+            language: Some("en".to_owned()),
             model: "general-transcription-v1".to_owned(),
             processing_time_ms: 1_843,
             cost_cents: Some(1),
             created_at: datetime!(2026-04-24 18:00:30 UTC),
             recorded_at: datetime!(2026-04-24 17:59:00 UTC),
         },
-        initial_version: NewTranscriptVersion {
-            id: format!("{transcript_id}-version-1"),
-            transcript: "initial text".to_owned(),
+        initial_version: NewVoiceNoteVersion {
+            id: format!("{voice_note_id}-version-1"),
+            text: "initial text".to_owned(),
             created_at: datetime!(2026-04-24 18:00:30 UTC),
         },
         segments: vec![
             NewSegment {
-                id: format!("{transcript_id}-segment-1"),
+                id: format!("{voice_note_id}-segment-1"),
                 position: 0,
                 start_ms: 0,
                 end_ms: 1_000,
                 text: "first segment".to_owned(),
             },
             NewSegment {
-                id: format!("{transcript_id}-segment-2"),
+                id: format!("{voice_note_id}-segment-2"),
                 position: 1,
                 start_ms: 1_000,
                 end_ms: 2_000,

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -972,9 +972,9 @@ impl VoiceNoteFixture {
 
         sqlx::query(
             r#"
-            INSERT INTO transcripts (
+            INSERT INTO voice_notes (
                 id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
-                transcript_language, model, processing_time_ms, cost_cents,
+                language, model, processing_time_ms, cost_cents,
                 created_at, recorded_at, session_id
             )
             VALUES (?, ?, 12.5, 'wav', 401280, 'en', 'gpt-4o-mini-transcribe', 1843, NULL, ?, ?, ?)
@@ -987,12 +987,12 @@ impl VoiceNoteFixture {
         .bind(seed.session_id)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript");
+        .expect("insert voice note");
 
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, 1, ?, ?)
             "#,
@@ -1004,7 +1004,7 @@ impl VoiceNoteFixture {
         .bind(seed.created_at)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript version");
+        .expect("insert voice note version");
 
         for tag in seed.tags {
             sqlx::query(
@@ -1024,7 +1024,7 @@ impl VoiceNoteFixture {
 
             sqlx::query(
                 r#"
-                INSERT INTO transcript_tags (api_key_id, transcript_id, tag_id)
+                INSERT INTO voice_note_tags (api_key_id, voice_note_id, tag_id)
                 VALUES (?, ?, ?)
                 "#,
             )
@@ -1033,7 +1033,7 @@ impl VoiceNoteFixture {
             .bind(tag.id)
             .execute(self.storage.pool())
             .await
-            .expect("insert transcript tag");
+            .expect("insert voice note tag");
         }
     }
 
@@ -1048,8 +1048,8 @@ impl VoiceNoteFixture {
     ) {
         sqlx::query(
             r#"
-            INSERT INTO transcript_versions (
-                id, api_key_id, transcript_id, version_number, transcript, created_at
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
             )
             VALUES (?, ?, ?, ?, ?, ?)
             "#,
@@ -1062,7 +1062,7 @@ impl VoiceNoteFixture {
         .bind(created_at)
         .execute(self.storage.pool())
         .await
-        .expect("insert transcript version");
+        .expect("insert voice note version");
     }
 
     async fn insert_segment(
@@ -1076,7 +1076,7 @@ impl VoiceNoteFixture {
         sqlx::query(
             r#"
             INSERT INTO segments (
-                id, api_key_id, transcript_id, position, start_ms, end_ms, text
+                id, api_key_id, voice_note_id, position, start_ms, end_ms, text
             )
             VALUES (?, ?, ?, ?, ?, ?, ?)
             "#,


### PR DESCRIPTION
## Summary

- Renames the unreleased SQLite voice-note substrate from `transcripts*` to `voice_notes*`, including FK columns, indexes, and version text storage.
- Renames storage-facing Rust records, builders, methods, and handler consumers so `backend/src/voice_notes.rs` no longer translates from transcript-named substrate types.
- Updates backend fixtures/tests and unreleased changelog substrate wording while preserving public HTTP contract and client scope.

## Changes

- Persistence schema now uses `voice_notes`, `voice_note_versions`, `voice_note_tags`, `voice_note_id`, `language`, and version `text`.
- Storage exposes `VoiceNote*` types and `voice_note*` methods, while `TranscriptionJob` and `transcription_model` remain transcription-domain vocabulary.
- Backend tests and CHANGELOG entries describe the renamed substrate consistently.

## GitHub Issue(s)

Closes #56

## Test plan

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `git grep -n -i 'transcript' -- ':!backend/target' ':!client' | awk 'tolower($0) !~ /transcription/'`
- `git diff --check`
