### PR TITLE
feat(transcription-jobs): accept chunked submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add authenticated chunked transcription-job submission APIs for opening
+  attempts, accepting durable chunks, finalizing composed audio to queued jobs,
+  and reading upload progress.
 - Add authenticated tag and session management APIs, including owner-scoped
   CRUD, shared cursor pagination, case-insensitive tag identity with
   latest-spelling display updates, and metadata deletion cascades.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -289,6 +290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -889,6 +899,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/pentaxis93/oracy"
 
 [dependencies]
-axum = "0.8.9"
+axum = { version = "0.8.9", features = ["multipart"] }
 base64 = "0.22"
 caseless = "0.2.2"
 form_urlencoded = "1.2"
@@ -18,7 +18,7 @@ sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio
 subtle = "2.6"
 thiserror = "2.0"
 time = { version = "0.3.47", features = ["formatting", "macros", "parsing"] }
-tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "net"] }
+tokio = { version = "1.48", features = ["fs", "io-util", "macros", "rt-multi-thread", "net"] }
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/backend/migrations/20260501000000_accepting_chunks_submission.sql
+++ b/backend/migrations/20260501000000_accepting_chunks_submission.sql
@@ -70,20 +70,8 @@ CREATE INDEX transcription_jobs_ready_idx
     ON transcription_jobs (status, next_attempt_at, created_at, id);
 
 CREATE TRIGGER transcription_jobs_open_tuple_immutable
-BEFORE UPDATE OF api_key_id, idempotency_key, recorded_at, language, chunk_count, audio_format
+BEFORE UPDATE OF api_key_id, idempotency_key, recorded_at, session_id, language, chunk_count, audio_format
 ON transcription_jobs
-BEGIN
-    SELECT RAISE(ABORT, 'open submission tuple is immutable');
-END;
-
-CREATE TRIGGER transcription_jobs_session_tuple_immutable
-BEFORE UPDATE OF session_id
-ON transcription_jobs
-WHEN NOT (
-    OLD.status = 'accepting_chunks'
-    AND NEW.status = 'queued'
-    AND NEW.session_id IS NULL
-)
 BEGIN
     SELECT RAISE(ABORT, 'open submission tuple is immutable');
 END;

--- a/backend/migrations/20260501000000_accepting_chunks_submission.sql
+++ b/backend/migrations/20260501000000_accepting_chunks_submission.sql
@@ -1,0 +1,125 @@
+PRAGMA foreign_keys = OFF;
+
+DROP TRIGGER IF EXISTS transcription_jobs_accepted_tuple_immutable;
+DROP TRIGGER IF EXISTS transcription_jobs_session_owner_insert;
+
+CREATE TABLE transcription_jobs_new (
+    id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    audio_sha256_hex TEXT NOT NULL DEFAULT '',
+    audio_content_hash_algorithm TEXT NOT NULL DEFAULT 'sha256:chunk-sha256-raw-concat:v1',
+    recorded_at TEXT NOT NULL,
+    session_id TEXT,
+    language TEXT,
+    accepted_audio_path TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL CHECK (status IN ('accepting_chunks', 'queued', 'processing', 'retry_waiting', 'succeeded', 'failed')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    max_retries INTEGER NOT NULL CHECK (max_retries >= 0),
+    next_attempt_at TEXT,
+    failure_code TEXT CHECK (
+        failure_code IS NULL OR failure_code IN (
+            'audio_invalid',
+            'engine_timeout',
+            'engine_rate_limited',
+            'engine_error',
+            'storage_error',
+            'internal_error',
+            'submission_abandoned'
+        )
+    ),
+    failure_message TEXT,
+    retryable_by_client INTEGER CHECK (retryable_by_client IS NULL OR retryable_by_client IN (0, 1)),
+    voice_note_id TEXT REFERENCES voice_notes(id) ON DELETE SET NULL,
+    chunk_count INTEGER NOT NULL DEFAULT 1 CHECK (chunk_count BETWEEN 1 AND 256),
+    audio_format TEXT NOT NULL DEFAULT 'wav' CHECK (audio_format IN ('m4a', 'mp3', 'wav', 'webm')),
+    transcription_model TEXT NOT NULL DEFAULT 'gpt-4o-mini-transcribe' CHECK (
+        transcription_model IN (
+            'gpt-4o-mini-transcribe',
+            'gpt-4o-transcribe'
+        )
+    ),
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id),
+    UNIQUE (api_key_id, idempotency_key)
+);
+
+INSERT INTO transcription_jobs_new (
+    id, api_key_id, idempotency_key, audio_sha256_hex,
+    audio_content_hash_algorithm, recorded_at, session_id, language,
+    accepted_audio_path, status, created_at, updated_at, retry_count,
+    max_retries, next_attempt_at, failure_code, failure_message,
+    retryable_by_client, voice_note_id
+)
+SELECT
+    id, api_key_id, idempotency_key, audio_sha256_hex,
+    audio_content_hash_algorithm, recorded_at, session_id, language,
+    accepted_audio_path, status, created_at, updated_at, retry_count,
+    max_retries, next_attempt_at, failure_code, failure_message,
+    retryable_by_client, voice_note_id
+FROM transcription_jobs;
+
+DROP TABLE transcription_jobs;
+ALTER TABLE transcription_jobs_new RENAME TO transcription_jobs;
+
+CREATE UNIQUE INDEX transcription_jobs_owner_id_idx
+    ON transcription_jobs (api_key_id, id);
+
+CREATE INDEX transcription_jobs_ready_idx
+    ON transcription_jobs (status, next_attempt_at, created_at, id);
+
+CREATE TRIGGER transcription_jobs_open_tuple_immutable
+BEFORE UPDATE OF api_key_id, idempotency_key, recorded_at, language, chunk_count, audio_format
+ON transcription_jobs
+BEGIN
+    SELECT RAISE(ABORT, 'open submission tuple is immutable');
+END;
+
+CREATE TRIGGER transcription_jobs_session_tuple_immutable
+BEFORE UPDATE OF session_id
+ON transcription_jobs
+WHEN NOT (
+    OLD.status = 'accepting_chunks'
+    AND NEW.status = 'queued'
+    AND NEW.session_id IS NULL
+)
+BEGIN
+    SELECT RAISE(ABORT, 'open submission tuple is immutable');
+END;
+
+CREATE TRIGGER transcription_jobs_accepted_tuple_immutable
+BEFORE UPDATE OF audio_sha256_hex, audio_content_hash_algorithm
+ON transcription_jobs
+WHEN OLD.audio_sha256_hex <> ''
+BEGIN
+    SELECT RAISE(ABORT, 'accepted submission tuple is immutable');
+END;
+
+CREATE TRIGGER transcription_jobs_session_owner_insert
+BEFORE INSERT ON transcription_jobs
+WHEN NEW.session_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'job session must belong to same owner')
+    WHERE NOT EXISTS (
+        SELECT 1 FROM sessions
+        WHERE api_key_id = NEW.api_key_id AND id = NEW.session_id
+    );
+END;
+
+CREATE TABLE transcription_job_chunks (
+    api_key_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL CHECK (chunk_index >= 0),
+    chunk_sha256_hex TEXT NOT NULL,
+    chunk_path TEXT NOT NULL,
+    chunk_size_bytes INTEGER NOT NULL CHECK (chunk_size_bytes >= 0),
+    accepted_at TEXT NOT NULL,
+    PRIMARY KEY (api_key_id, job_id, chunk_index),
+    FOREIGN KEY (api_key_id, job_id) REFERENCES transcription_jobs(api_key_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX transcription_job_chunks_order_idx
+    ON transcription_job_chunks (api_key_id, job_id, chunk_index);
+
+PRAGMA foreign_keys = ON;

--- a/backend/src/audio_hash.rs
+++ b/backend/src/audio_hash.rs
@@ -25,6 +25,14 @@ where
     Ok(hex_lower(&hasher.finalize()))
 }
 
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    hex_lower(&Sha256::digest(bytes))
+}
+
+pub fn validate_lowercase_sha256_hex(value: &str) -> Result<(), AudioContentHashError> {
+    decode_lowercase_sha256_hex(value, 0).map(|_| ())
+}
+
 fn decode_lowercase_sha256_hex(
     value: &str,
     index: usize,

--- a/backend/src/audio_store.rs
+++ b/backend/src/audio_store.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use tokio::io::{AsyncWriteExt, BufReader};
 use ulid::Ulid;
@@ -28,7 +28,7 @@ pub async fn persist_chunk(
     file.sync_all().await?;
     drop(file);
 
-    sync_directory(&chunk_dir)?;
+    sync_directory_chain(accepted_audio_dir, &chunk_dir)?;
     Ok(final_path)
 }
 
@@ -58,10 +58,57 @@ pub async fn compose_chunks(
     drop(output);
 
     tokio::fs::rename(&temp_path, &final_path).await?;
-    sync_directory(&job_dir)?;
+    sync_directory_chain(accepted_audio_dir, &job_dir)?;
     Ok(final_path)
 }
 
 fn sync_directory(path: &Path) -> std::io::Result<()> {
     std::fs::File::open(path)?.sync_all()
+}
+
+fn sync_directory_chain(root: &Path, leaf: &Path) -> std::io::Result<()> {
+    let relative_leaf = leaf.strip_prefix(root).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "directory sync leaf must be under the durable root",
+        )
+    })?;
+
+    sync_directory(root)?;
+    let mut path = root.to_path_buf();
+    for component in relative_leaf.components() {
+        match component {
+            Component::Normal(name) => {
+                path.push(name);
+                sync_directory(&path)?;
+            }
+            Component::CurDir => {}
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "directory sync leaf must not traverse outside the durable root",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sync_directory_chain;
+
+    #[test]
+    fn sync_directory_chain_rejects_leaf_outside_root() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let root = tempdir.path().join("accepted-audio");
+        let other = tempdir.path().join("other").join("chunks");
+        std::fs::create_dir(&root).expect("create accepted audio dir");
+        std::fs::create_dir_all(&other).expect("create outside leaf");
+
+        let error = sync_directory_chain(&root, &other).expect_err("outside leaf should fail");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
 }

--- a/backend/src/audio_store.rs
+++ b/backend/src/audio_store.rs
@@ -1,0 +1,77 @@
+use std::path::{Path, PathBuf};
+
+use tokio::io::{AsyncWriteExt, BufReader};
+use ulid::Ulid;
+
+use crate::storage::ChunkRecord;
+
+pub const MAX_CHUNK_BYTES: usize = 26_214_400;
+pub const MULTIPART_BODY_LIMIT_BYTES: usize = MAX_CHUNK_BYTES + 1_048_576;
+
+pub async fn persist_chunk(
+    accepted_audio_dir: &Path,
+    job_id: &str,
+    chunk_index: i64,
+    bytes: &[u8],
+) -> std::io::Result<PathBuf> {
+    let chunk_dir = accepted_audio_dir.join(job_id).join("chunks");
+    tokio::fs::create_dir_all(&chunk_dir).await?;
+    let final_path = chunk_dir.join(format!("{chunk_index}.chunk"));
+    let temp_path = chunk_dir.join(format!(".{chunk_index}.{}.tmp", Ulid::new()));
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .await?;
+    file.write_all(bytes).await?;
+    file.flush().await?;
+    file.sync_all().await?;
+    drop(file);
+
+    match std::fs::hard_link(&temp_path, &final_path) {
+        Ok(()) => {
+            std::fs::remove_file(&temp_path)?;
+            sync_directory(&chunk_dir)?;
+            Ok(final_path)
+        }
+        Err(error) => {
+            let _ = std::fs::remove_file(&temp_path);
+            Err(error)
+        }
+    }
+}
+
+pub async fn compose_chunks(
+    accepted_audio_dir: &Path,
+    job_id: &str,
+    audio_format: &str,
+    chunks: &[ChunkRecord],
+) -> std::io::Result<PathBuf> {
+    let job_dir = accepted_audio_dir.join(job_id);
+    tokio::fs::create_dir_all(&job_dir).await?;
+    let final_path = job_dir.join(format!("accepted.{audio_format}"));
+    let temp_path = job_dir.join(format!(".accepted.{}.tmp", Ulid::new()));
+
+    let mut output = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .await?;
+    for chunk in chunks {
+        let input = tokio::fs::File::open(&chunk.chunk_path).await?;
+        let mut input = BufReader::new(input);
+        tokio::io::copy(&mut input, &mut output).await?;
+    }
+    output.flush().await?;
+    output.sync_all().await?;
+    drop(output);
+
+    tokio::fs::rename(&temp_path, &final_path).await?;
+    sync_directory(&job_dir)?;
+    Ok(final_path)
+}
+
+fn sync_directory(path: &Path) -> std::io::Result<()> {
+    std::fs::File::open(path)?.sync_all()
+}

--- a/backend/src/audio_store.rs
+++ b/backend/src/audio_store.rs
@@ -16,30 +16,20 @@ pub async fn persist_chunk(
 ) -> std::io::Result<PathBuf> {
     let chunk_dir = accepted_audio_dir.join(job_id).join("chunks");
     tokio::fs::create_dir_all(&chunk_dir).await?;
-    let final_path = chunk_dir.join(format!("{chunk_index}.chunk"));
-    let temp_path = chunk_dir.join(format!(".{chunk_index}.{}.tmp", Ulid::new()));
+    let final_path = chunk_dir.join(format!("{chunk_index}.{}.chunk", Ulid::new()));
 
     let mut file = tokio::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(&temp_path)
+        .open(&final_path)
         .await?;
     file.write_all(bytes).await?;
     file.flush().await?;
     file.sync_all().await?;
     drop(file);
 
-    match std::fs::hard_link(&temp_path, &final_path) {
-        Ok(()) => {
-            std::fs::remove_file(&temp_path)?;
-            sync_directory(&chunk_dir)?;
-            Ok(final_path)
-        }
-        Err(error) => {
-            let _ = std::fs::remove_file(&temp_path);
-            Err(error)
-        }
-    }
+    sync_directory(&chunk_dir)?;
+    Ok(final_path)
 }
 
 pub async fn compose_chunks(

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -138,7 +138,7 @@ impl ApiError {
         }
     }
 
-    fn payload_too_large() -> Self {
+    pub fn payload_too_large() -> Self {
         Self {
             status: StatusCode::PAYLOAD_TOO_LARGE,
             body: ErrorResponse {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg(unix)]
 
 pub mod audio_hash;
+pub mod audio_store;
 pub mod auth;
 pub mod bootstrap;
 pub mod collections;
@@ -12,4 +13,5 @@ pub mod router;
 pub mod settings;
 pub mod state;
 pub mod storage;
+pub mod transcription_jobs;
 pub mod voice_notes;

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -8,6 +8,7 @@ use crate::metadata::{
 };
 use crate::settings::{get_settings, patch_settings};
 use crate::state::AppState;
+use crate::transcription_jobs;
 use crate::voice_notes::{
     get_voice_note, list_session_voice_notes, list_voice_note_segments, list_voice_note_versions,
     list_voice_notes,
@@ -16,6 +17,7 @@ use crate::voice_notes::{
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/api/v1/settings", get(get_settings).patch(patch_settings))
+        .nest("/api/v1/transcription-jobs", transcription_jobs::routes())
         .route("/api/v1/tags", get(list_tags).post(create_tag))
         .route(
             "/api/v1/tags/{tag_id}",

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use caseless::Caseless;
 use sqlx::migrate::Migrator;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
-use sqlx::{QueryBuilder, Row, SqlitePool};
+use sqlx::{Column, QueryBuilder, Row, Sqlite, SqlitePool, Transaction};
 use thiserror::Error;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
@@ -76,6 +76,33 @@ pub enum AcceptJobOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenJobOutcome {
+    Created(TranscriptionJobRecord),
+    ReplayedOpen(TranscriptionJobRecord),
+    ReplayedFinalized(TranscriptionJobRecord),
+    Conflict(SubmissionConflict),
+    SessionNotFound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreChunkOutcome {
+    Stored,
+    Replayed,
+    Conflict,
+    NotFound,
+    NotAcceptingChunks,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinalizeJobOutcome {
+    Accepted(TranscriptionJobRecord),
+    Replayed(TranscriptionJobRecord),
+    MissingChunks,
+    NotFound,
+    NotAcceptingChunks,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CreateTagOutcome {
     Created(TagRecord),
     Existing(TagRecord),
@@ -124,6 +151,30 @@ pub struct NewTranscriptionJob {
 }
 
 #[derive(Debug, Clone)]
+pub struct NewOpenTranscriptionJob {
+    pub api_key_id: String,
+    pub idempotency_key: String,
+    pub recorded_at: OffsetDateTime,
+    pub session_id: Option<String>,
+    pub language: Option<String>,
+    pub chunk_count: i64,
+    pub audio_format: String,
+    pub max_retries: i64,
+    pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct AcceptedChunk {
+    pub api_key_id: String,
+    pub job_id: String,
+    pub chunk_index: i64,
+    pub chunk_sha256_hex: String,
+    pub chunk_path: PathBuf,
+    pub chunk_size_bytes: i64,
+    pub accepted_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
 pub struct NewTag {
     pub id: String,
     pub api_key_id: String,
@@ -160,6 +211,18 @@ pub struct TranscriptionJobRecord {
     pub failure_message: Option<String>,
     pub retryable_by_client: Option<bool>,
     pub voice_note_id: Option<String>,
+    pub chunk_count: i64,
+    pub audio_format: String,
+    pub transcription_model: String,
+    pub chunks_received: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChunkRecord {
+    pub chunk_index: i64,
+    pub chunk_sha256_hex: String,
+    pub chunk_path: PathBuf,
+    pub chunk_size_bytes: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -360,6 +423,78 @@ impl Storage {
         self.get_settings(api_key_id).await
     }
 
+    pub async fn open_job(
+        &self,
+        input: NewOpenTranscriptionJob,
+    ) -> Result<OpenJobOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let existing =
+            select_job_by_idempotency_key(&mut tx, &input.api_key_id, &input.idempotency_key)
+                .await?;
+        if let Some(job) = existing {
+            tx.commit().await?;
+            if !job.matches_open_submission(&input) {
+                return Ok(OpenJobOutcome::Conflict(SubmissionConflict {
+                    job_id: job.id,
+                }));
+            }
+            if job.status == "accepting_chunks" {
+                return Ok(OpenJobOutcome::ReplayedOpen(job));
+            }
+            return Ok(OpenJobOutcome::ReplayedFinalized(job));
+        }
+
+        if let Some(session_id) = input.session_id.as_deref() {
+            let exists: Option<i64> = sqlx::query_scalar(
+                r#"
+                SELECT 1
+                FROM sessions
+                WHERE api_key_id = ? AND id = ?
+                "#,
+            )
+            .bind(&input.api_key_id)
+            .bind(session_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if exists.is_none() {
+                tx.commit().await?;
+                return Ok(OpenJobOutcome::SessionNotFound);
+            }
+        }
+
+        let id = new_id();
+        let now = format_timestamp(input.now)?;
+        sqlx::query(
+            r#"
+            INSERT INTO transcription_jobs (
+                id, api_key_id, idempotency_key, recorded_at, session_id,
+                language, status, created_at, updated_at, retry_count,
+                max_retries, chunk_count, audio_format
+            )
+            VALUES (?, ?, ?, ?, ?, ?, 'accepting_chunks', ?, ?, 0, ?, ?, ?)
+            "#,
+        )
+        .bind(&id)
+        .bind(&input.api_key_id)
+        .bind(&input.idempotency_key)
+        .bind(format_timestamp(input.recorded_at)?)
+        .bind(&input.session_id)
+        .bind(&input.language)
+        .bind(&now)
+        .bind(&now)
+        .bind(input.max_retries)
+        .bind(input.chunk_count)
+        .bind(&input.audio_format)
+        .execute(&mut *tx)
+        .await?;
+
+        let job = select_job_by_id(&mut tx, &input.api_key_id, &id)
+            .await?
+            .expect("inserted job is visible");
+        tx.commit().await?;
+        Ok(OpenJobOutcome::Created(job))
+    }
+
     pub async fn accept_job(
         &self,
         input: NewTranscriptionJob,
@@ -456,18 +591,10 @@ impl Storage {
         api_key_id: &str,
         idempotency_key: &str,
     ) -> Result<Option<TranscriptionJobRecord>, StorageError> {
-        let row = sqlx::query(
-            r#"
-            SELECT * FROM transcription_jobs
-            WHERE api_key_id = ? AND idempotency_key = ?
-            "#,
-        )
-        .bind(api_key_id)
-        .bind(idempotency_key)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        row.map(job_from_row).transpose()
+        let mut tx = self.pool.begin().await?;
+        let job = select_job_by_idempotency_key(&mut tx, api_key_id, idempotency_key).await?;
+        tx.commit().await?;
+        Ok(job)
     }
 
     pub async fn get_job(
@@ -475,18 +602,199 @@ impl Storage {
         api_key_id: &str,
         job_id: &str,
     ) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let job = select_job_by_id(&mut tx, api_key_id, job_id).await?;
+        tx.commit().await?;
+        Ok(job)
+    }
+
+    pub async fn get_chunk(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        chunk_index: i64,
+    ) -> Result<Option<ChunkRecord>, StorageError> {
         let row = sqlx::query(
             r#"
-            SELECT * FROM transcription_jobs
-            WHERE api_key_id = ? AND id = ?
+            SELECT chunk_index, chunk_sha256_hex, chunk_path, chunk_size_bytes
+            FROM transcription_job_chunks
+            WHERE api_key_id = ? AND job_id = ? AND chunk_index = ?
             "#,
         )
         .bind(api_key_id)
         .bind(job_id)
+        .bind(chunk_index)
         .fetch_optional(&self.pool)
         .await?;
 
-        row.map(job_from_row).transpose()
+        row.map(chunk_from_row).transpose()
+    }
+
+    pub async fn store_chunk(
+        &self,
+        chunk: AcceptedChunk,
+    ) -> Result<StoreChunkOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let Some(job) = select_job_by_id(&mut tx, &chunk.api_key_id, &chunk.job_id).await? else {
+            tx.commit().await?;
+            return Ok(StoreChunkOutcome::NotFound);
+        };
+        if job.status != "accepting_chunks" {
+            tx.commit().await?;
+            return Ok(StoreChunkOutcome::NotAcceptingChunks);
+        }
+
+        let accepted_at = format_timestamp(chunk.accepted_at)?;
+        let chunk_path = chunk.chunk_path.to_string_lossy().into_owned();
+        let result = sqlx::query(
+            r#"
+            INSERT INTO transcription_job_chunks (
+                api_key_id, job_id, chunk_index, chunk_sha256_hex,
+                chunk_path, chunk_size_bytes, accepted_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(api_key_id, job_id, chunk_index) DO NOTHING
+            "#,
+        )
+        .bind(&chunk.api_key_id)
+        .bind(&chunk.job_id)
+        .bind(chunk.chunk_index)
+        .bind(&chunk.chunk_sha256_hex)
+        .bind(&chunk_path)
+        .bind(chunk.chunk_size_bytes)
+        .bind(&accepted_at)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 1 {
+            sqlx::query(
+                r#"
+                UPDATE transcription_jobs
+                SET updated_at = ?
+                WHERE api_key_id = ? AND id = ?
+                "#,
+            )
+            .bind(&accepted_at)
+            .bind(&chunk.api_key_id)
+            .bind(&chunk.job_id)
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            return Ok(StoreChunkOutcome::Stored);
+        }
+
+        let existing =
+            select_chunk_by_index(&mut tx, &chunk.api_key_id, &chunk.job_id, chunk.chunk_index)
+                .await?
+                .expect("conflicting chunk row exists");
+        tx.commit().await?;
+        if existing.chunk_sha256_hex == chunk.chunk_sha256_hex {
+            Ok(StoreChunkOutcome::Replayed)
+        } else {
+            Ok(StoreChunkOutcome::Conflict)
+        }
+    }
+
+    pub async fn list_chunks_for_finalize(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+    ) -> Result<Option<(TranscriptionJobRecord, Vec<ChunkRecord>)>, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let Some(job) = select_job_by_id(&mut tx, api_key_id, job_id).await? else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+        let rows = sqlx::query(
+            r#"
+            SELECT chunk_index, chunk_sha256_hex, chunk_path, chunk_size_bytes
+            FROM transcription_job_chunks
+            WHERE api_key_id = ? AND job_id = ?
+            ORDER BY chunk_index ASC
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_all(&mut *tx)
+        .await?;
+        let chunks = rows
+            .into_iter()
+            .map(chunk_from_row)
+            .collect::<Result<Vec<_>, _>>()?;
+        tx.commit().await?;
+        Ok(Some((job, chunks)))
+    }
+
+    pub async fn finalize_job(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        audio_sha256_hex: &str,
+        accepted_audio_path: &Path,
+        transcription_model: &str,
+        now: OffsetDateTime,
+    ) -> Result<FinalizeJobOutcome, StorageError> {
+        let mut tx = self.pool.begin().await?;
+        let Some(job) = select_job_by_id(&mut tx, api_key_id, job_id).await? else {
+            tx.commit().await?;
+            return Ok(FinalizeJobOutcome::NotFound);
+        };
+        if job.status != "accepting_chunks" {
+            tx.commit().await?;
+            if job.audio_sha256_hex == audio_sha256_hex && !job.audio_sha256_hex.is_empty() {
+                return Ok(FinalizeJobOutcome::Replayed(job));
+            }
+            return Ok(FinalizeJobOutcome::NotAcceptingChunks);
+        }
+
+        let accepted_count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM transcription_job_chunks
+            WHERE api_key_id = ? AND job_id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        if accepted_count != job.chunk_count {
+            tx.commit().await?;
+            return Ok(FinalizeJobOutcome::MissingChunks);
+        }
+
+        let now = format_timestamp(now)?;
+        let accepted_audio_path = accepted_audio_path.to_string_lossy().into_owned();
+        sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET audio_sha256_hex = ?,
+                accepted_audio_path = ?,
+                transcription_model = ?,
+                status = 'queued',
+                session_id = (
+                    SELECT sessions.id
+                    FROM sessions
+                    WHERE sessions.api_key_id = transcription_jobs.api_key_id
+                        AND sessions.id = transcription_jobs.session_id
+                ),
+                updated_at = ?
+            WHERE api_key_id = ? AND id = ? AND status = 'accepting_chunks'
+            "#,
+        )
+        .bind(audio_sha256_hex)
+        .bind(accepted_audio_path)
+        .bind(transcription_model)
+        .bind(&now)
+        .bind(api_key_id)
+        .bind(job_id)
+        .execute(&mut *tx)
+        .await?;
+        let job = select_job_by_id(&mut tx, api_key_id, job_id)
+            .await?
+            .expect("finalized job is visible");
+        tx.commit().await?;
+        Ok(FinalizeJobOutcome::Accepted(job))
     }
 
     pub async fn complete_job_with_voice_note(
@@ -1454,6 +1762,89 @@ impl TranscriptionJobRecord {
             && self.session_id == input.session_id
             && self.language == input.language
     }
+
+    fn matches_open_submission(&self, input: &NewOpenTranscriptionJob) -> bool {
+        self.recorded_at == input.recorded_at
+            && self.session_id == input.session_id
+            && self.language == input.language
+            && self.chunk_count == input.chunk_count
+            && self.audio_format == input.audio_format
+    }
+}
+
+async fn select_job_by_id(
+    tx: &mut Transaction<'_, Sqlite>,
+    api_key_id: &str,
+    job_id: &str,
+) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            transcription_jobs.*,
+            COUNT(transcription_job_chunks.chunk_index) AS chunks_received
+        FROM transcription_jobs
+        LEFT JOIN transcription_job_chunks
+            ON transcription_job_chunks.api_key_id = transcription_jobs.api_key_id
+            AND transcription_job_chunks.job_id = transcription_jobs.id
+        WHERE transcription_jobs.api_key_id = ? AND transcription_jobs.id = ?
+        GROUP BY transcription_jobs.id
+        "#,
+    )
+    .bind(api_key_id)
+    .bind(job_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    row.map(job_from_row).transpose()
+}
+
+async fn select_job_by_idempotency_key(
+    tx: &mut Transaction<'_, Sqlite>,
+    api_key_id: &str,
+    idempotency_key: &str,
+) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            transcription_jobs.*,
+            COUNT(transcription_job_chunks.chunk_index) AS chunks_received
+        FROM transcription_jobs
+        LEFT JOIN transcription_job_chunks
+            ON transcription_job_chunks.api_key_id = transcription_jobs.api_key_id
+            AND transcription_job_chunks.job_id = transcription_jobs.id
+        WHERE transcription_jobs.api_key_id = ?
+            AND transcription_jobs.idempotency_key = ?
+        GROUP BY transcription_jobs.id
+        "#,
+    )
+    .bind(api_key_id)
+    .bind(idempotency_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    row.map(job_from_row).transpose()
+}
+
+async fn select_chunk_by_index(
+    tx: &mut Transaction<'_, Sqlite>,
+    api_key_id: &str,
+    job_id: &str,
+    chunk_index: i64,
+) -> Result<Option<ChunkRecord>, StorageError> {
+    let row = sqlx::query(
+        r#"
+        SELECT chunk_index, chunk_sha256_hex, chunk_path, chunk_size_bytes
+        FROM transcription_job_chunks
+        WHERE api_key_id = ? AND job_id = ? AND chunk_index = ?
+        "#,
+    )
+    .bind(api_key_id)
+    .bind(job_id)
+    .bind(chunk_index)
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    row.map(chunk_from_row).transpose()
 }
 
 fn validate_database_path(database_path: &Path) -> Result<(), StorageError> {
@@ -1568,7 +1959,35 @@ fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, 
         failure_message: row.try_get("failure_message")?,
         retryable_by_client,
         voice_note_id: row.try_get("voice_note_id")?,
+        chunk_count: row.try_get("chunk_count")?,
+        audio_format: row.try_get("audio_format")?,
+        transcription_model: row.try_get("transcription_model")?,
+        chunks_received: optional_i64(&row, "chunks_received")?.unwrap_or(0),
     })
+}
+
+fn chunk_from_row(row: sqlx::sqlite::SqliteRow) -> Result<ChunkRecord, StorageError> {
+    Ok(ChunkRecord {
+        chunk_index: row.try_get("chunk_index")?,
+        chunk_sha256_hex: row.try_get("chunk_sha256_hex")?,
+        chunk_path: PathBuf::from(row.try_get::<String, _>("chunk_path")?),
+        chunk_size_bytes: row.try_get("chunk_size_bytes")?,
+    })
+}
+
+fn optional_i64(
+    row: &sqlx::sqlite::SqliteRow,
+    column_name: &str,
+) -> Result<Option<i64>, StorageError> {
+    if row
+        .columns()
+        .iter()
+        .any(|column| column.name() == column_name)
+    {
+        Ok(Some(row.try_get(column_name)?))
+    } else {
+        Ok(None)
+    }
 }
 
 fn settings_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SettingsRecord, StorageError> {

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -428,42 +428,9 @@ impl Storage {
         input: NewOpenTranscriptionJob,
     ) -> Result<OpenJobOutcome, StorageError> {
         let mut tx = self.pool.begin().await?;
-        let existing =
-            select_job_by_idempotency_key(&mut tx, &input.api_key_id, &input.idempotency_key)
-                .await?;
-        if let Some(job) = existing {
-            tx.commit().await?;
-            if !job.matches_open_submission(&input) {
-                return Ok(OpenJobOutcome::Conflict(SubmissionConflict {
-                    job_id: job.id,
-                }));
-            }
-            if job.status == "accepting_chunks" {
-                return Ok(OpenJobOutcome::ReplayedOpen(job));
-            }
-            return Ok(OpenJobOutcome::ReplayedFinalized(job));
-        }
-
-        if let Some(session_id) = input.session_id.as_deref() {
-            let exists: Option<i64> = sqlx::query_scalar(
-                r#"
-                SELECT 1
-                FROM sessions
-                WHERE api_key_id = ? AND id = ?
-                "#,
-            )
-            .bind(&input.api_key_id)
-            .bind(session_id)
-            .fetch_optional(&mut *tx)
-            .await?;
-            if exists.is_none() {
-                tx.commit().await?;
-                return Ok(OpenJobOutcome::SessionNotFound);
-            }
-        }
-
         let id = new_id();
         let now = format_timestamp(input.now)?;
+        let recorded_at = format_timestamp(input.recorded_at)?;
         sqlx::query(
             r#"
             INSERT INTO transcription_jobs (
@@ -471,13 +438,19 @@ impl Storage {
                 language, status, created_at, updated_at, retry_count,
                 max_retries, chunk_count, audio_format
             )
-            VALUES (?, ?, ?, ?, ?, ?, 'accepting_chunks', ?, ?, 0, ?, ?, ?)
+            SELECT ?, ?, ?, ?, ?, ?, 'accepting_chunks', ?, ?, 0, ?, ?, ?
+            WHERE ? IS NULL
+                OR EXISTS (
+                    SELECT 1 FROM sessions
+                    WHERE api_key_id = ? AND id = ?
+                )
+            ON CONFLICT(api_key_id, idempotency_key) DO NOTHING
             "#,
         )
         .bind(&id)
         .bind(&input.api_key_id)
         .bind(&input.idempotency_key)
-        .bind(format_timestamp(input.recorded_at)?)
+        .bind(recorded_at)
         .bind(&input.session_id)
         .bind(&input.language)
         .bind(&now)
@@ -485,14 +458,33 @@ impl Storage {
         .bind(input.max_retries)
         .bind(input.chunk_count)
         .bind(&input.audio_format)
+        .bind(&input.session_id)
+        .bind(&input.api_key_id)
+        .bind(&input.session_id)
         .execute(&mut *tx)
         .await?;
 
-        let job = select_job_by_id(&mut tx, &input.api_key_id, &id)
-            .await?
-            .expect("inserted job is visible");
+        let Some(job) =
+            select_job_by_idempotency_key(&mut tx, &input.api_key_id, &input.idempotency_key)
+                .await?
+        else {
+            tx.commit().await?;
+            return Ok(OpenJobOutcome::SessionNotFound);
+        };
         tx.commit().await?;
-        Ok(OpenJobOutcome::Created(job))
+
+        if !job.matches_open_submission(&input) {
+            return Ok(OpenJobOutcome::Conflict(SubmissionConflict {
+                job_id: job.id,
+            }));
+        }
+        if job.id == id {
+            return Ok(OpenJobOutcome::Created(job));
+        }
+        if job.status == "accepting_chunks" {
+            return Ok(OpenJobOutcome::ReplayedOpen(job));
+        }
+        Ok(OpenJobOutcome::ReplayedFinalized(job))
     }
 
     pub async fn accept_job(
@@ -772,12 +764,6 @@ impl Storage {
                 accepted_audio_path = ?,
                 transcription_model = ?,
                 status = 'queued',
-                session_id = (
-                    SELECT sessions.id
-                    FROM sessions
-                    WHERE sessions.api_key_id = transcription_jobs.api_key_id
-                        AND sessions.id = transcription_jobs.session_id
-                ),
                 updated_at = ?
             WHERE api_key_id = ? AND id = ? AND status = 'accepting_chunks'
             "#,

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -374,6 +374,10 @@ impl Storage {
         &self.pool
     }
 
+    async fn begin_immediate_tx(&self) -> Result<Transaction<'static, Sqlite>, StorageError> {
+        Ok(self.pool.begin_with("BEGIN IMMEDIATE").await?)
+    }
+
     pub async fn get_settings(&self, api_key_id: &str) -> Result<SettingsRecord, StorageError> {
         let row = sqlx::query(
             r#"
@@ -626,7 +630,7 @@ impl Storage {
         &self,
         chunk: AcceptedChunk,
     ) -> Result<StoreChunkOutcome, StorageError> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_immediate_tx().await?;
         let Some(job) = select_job_by_id(&mut tx, &chunk.api_key_id, &chunk.job_id).await? else {
             tx.commit().await?;
             return Ok(StoreChunkOutcome::NotFound);
@@ -726,7 +730,7 @@ impl Storage {
         transcription_model: &str,
         now: OffsetDateTime,
     ) -> Result<FinalizeJobOutcome, StorageError> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_immediate_tx().await?;
         let Some(job) = select_job_by_id(&mut tx, api_key_id, job_id).await? else {
             tx.commit().await?;
             return Ok(FinalizeJobOutcome::NotFound);

--- a/backend/src/transcription_jobs.rs
+++ b/backend/src/transcription_jobs.rs
@@ -186,31 +186,50 @@ async fn push_chunk(
     )
     .await
     .map_err(|_| ApiError::internal("Failed to persist chunk."))?;
-    let outcome = state
+    let outcome = match state
         .storage
         .store_chunk(AcceptedChunk {
             api_key_id,
             job_id,
             chunk_index: parsed.chunk_index,
             chunk_sha256_hex: parsed.chunk_sha256,
-            chunk_path,
+            chunk_path: chunk_path.clone(),
             chunk_size_bytes: parsed.bytes.len() as i64,
             accepted_at: OffsetDateTime::now_utc(),
         })
         .await
-        .map_err(|_| ApiError::internal("Failed to persist chunk state."))?;
+    {
+        Ok(outcome) => outcome,
+        Err(_) => {
+            discard_chunk_candidate(&chunk_path).await;
+            return Err(ApiError::internal("Failed to persist chunk state."));
+        }
+    };
 
     match outcome {
-        StoreChunkOutcome::Stored | StoreChunkOutcome::Replayed => Ok(StatusCode::NO_CONTENT),
-        StoreChunkOutcome::Conflict => Err(ApiError::conflict(
-            "Chunk index already has different accepted bytes.",
-            None,
-        )),
-        StoreChunkOutcome::NotFound => Err(ApiError::not_found("Transcription job not found.")),
-        StoreChunkOutcome::NotAcceptingChunks => Err(ApiError::conflict(
-            "Transcription job is not accepting chunks.",
-            None,
-        )),
+        StoreChunkOutcome::Stored => Ok(StatusCode::NO_CONTENT),
+        StoreChunkOutcome::Replayed => {
+            discard_chunk_candidate(&chunk_path).await;
+            Ok(StatusCode::NO_CONTENT)
+        }
+        StoreChunkOutcome::Conflict => {
+            discard_chunk_candidate(&chunk_path).await;
+            Err(ApiError::conflict(
+                "Chunk index already has different accepted bytes.",
+                None,
+            ))
+        }
+        StoreChunkOutcome::NotFound => {
+            discard_chunk_candidate(&chunk_path).await;
+            Err(ApiError::not_found("Transcription job not found."))
+        }
+        StoreChunkOutcome::NotAcceptingChunks => {
+            discard_chunk_candidate(&chunk_path).await;
+            Err(ApiError::conflict(
+                "Transcription job is not accepting chunks.",
+                None,
+            ))
+        }
     }
 }
 
@@ -328,6 +347,10 @@ fn validate_open_body(body: &OpenTranscriptionJobRequest) -> Result<(), ApiError
     }
 
     Ok(())
+}
+
+async fn discard_chunk_candidate(path: &std::path::Path) {
+    let _ = tokio::fs::remove_file(path).await;
 }
 
 fn idempotency_key(headers: &HeaderMap) -> Result<String, ApiError> {

--- a/backend/src/transcription_jobs.rs
+++ b/backend/src/transcription_jobs.rs
@@ -1,0 +1,469 @@
+use axum::extract::{DefaultBodyLimit, FromRequest, Multipart, Path, Request, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::audio_hash::{
+    compose_audio_content_hash_hex, sha256_hex, validate_lowercase_sha256_hex,
+};
+use crate::audio_store::{
+    MAX_CHUNK_BYTES, MULTIPART_BODY_LIMIT_BYTES, compose_chunks, persist_chunk,
+};
+use crate::auth::AuthenticatedKey;
+use crate::collections::{parse_rfc3339_field, timestamp, validate_ulid_field, validation_error};
+use crate::errors::ApiError;
+use crate::json::JsonBody;
+use crate::state::AppState;
+use crate::storage::{
+    AcceptedChunk, ChunkRecord, FinalizeJobOutcome, NewOpenTranscriptionJob, OpenJobOutcome,
+    StoreChunkOutcome, TranscriptionJobRecord,
+};
+
+const MAX_RETRIES: i64 = 3;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OpenTranscriptionJobRequest {
+    recorded_at: String,
+    chunk_count: i64,
+    audio_format: String,
+    session_id: Option<String>,
+    language: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TranscriptionJobResource {
+    id: String,
+    status: String,
+    created_at: String,
+    updated_at: String,
+    chunk_count: i64,
+    chunks_received: i64,
+    retry_count: i64,
+    max_retries: i64,
+    next_attempt_at: Option<String>,
+    failure_code: Option<String>,
+    failure_message: Option<String>,
+    retryable_by_client: Option<bool>,
+    voice_note_id: Option<String>,
+}
+
+#[derive(Debug)]
+struct ParsedChunk {
+    chunk_index: i64,
+    chunk_sha256: String,
+    bytes: Vec<u8>,
+}
+
+struct MultipartBody(Multipart);
+
+impl<S> FromRequest<S> for MultipartBody
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        Multipart::from_request(req, state)
+            .await
+            .map(Self)
+            .map_err(map_multipart_rejection)
+    }
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/", post(open_transcription_job))
+        .route("/{job_id}", axum::routing::get(get_transcription_job))
+        .route(
+            "/{job_id}/chunks",
+            post(push_chunk).layer(DefaultBodyLimit::max(MULTIPART_BODY_LIMIT_BYTES)),
+        )
+        .route("/{job_id}/finalize", post(finalize_transcription_job))
+}
+
+async fn open_transcription_job(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    JsonBody(body): JsonBody<OpenTranscriptionJobRequest>,
+) -> Result<(StatusCode, Json<TranscriptionJobResource>), ApiError> {
+    let idempotency_key = idempotency_key(&headers)?;
+    let recorded_at = parse_rfc3339_field("recorded_at", &body.recorded_at)?;
+    validate_open_body(&body)?;
+    let outcome = state
+        .storage
+        .open_job(NewOpenTranscriptionJob {
+            api_key_id: authenticated_key.api_key_id.to_string(),
+            idempotency_key,
+            recorded_at,
+            session_id: body.session_id,
+            language: body.language,
+            chunk_count: body.chunk_count,
+            audio_format: body.audio_format,
+            max_retries: MAX_RETRIES,
+            now: OffsetDateTime::now_utc(),
+        })
+        .await
+        .map_err(|_| ApiError::internal("Failed to open transcription job."))?;
+
+    match outcome {
+        OpenJobOutcome::Created(job) | OpenJobOutcome::ReplayedOpen(job) => {
+            Ok((StatusCode::CREATED, Json(job_resource(job)?)))
+        }
+        OpenJobOutcome::ReplayedFinalized(job) => Ok((StatusCode::OK, Json(job_resource(job)?))),
+        OpenJobOutcome::Conflict(_) => Err(ApiError::conflict(
+            "Idempotency key was already used with different submission fields.",
+            None,
+        )),
+        OpenJobOutcome::SessionNotFound => Err(ApiError::not_found("Session not found.")),
+    }
+}
+
+async fn push_chunk(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+    MultipartBody(multipart): MultipartBody,
+) -> Result<StatusCode, ApiError> {
+    validate_ulid_field("job_id", &job_id)?;
+    let api_key_id = authenticated_key.api_key_id.to_string();
+    let Some(job) = state
+        .storage
+        .get_job(&api_key_id, &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load transcription job."))?
+    else {
+        return Err(ApiError::not_found("Transcription job not found."));
+    };
+    if job.status != "accepting_chunks" {
+        return Err(ApiError::conflict(
+            "Transcription job is not accepting chunks.",
+            None,
+        ));
+    }
+
+    let parsed = parse_chunk_multipart(multipart).await?;
+    if parsed.chunk_index < 0 || parsed.chunk_index >= job.chunk_count {
+        return Err(validation_error(
+            "chunk_index",
+            "Must be within the declared chunk range.",
+        ));
+    }
+    if parsed.bytes.len() > MAX_CHUNK_BYTES {
+        return Err(ApiError::payload_too_large());
+    }
+    let actual_sha256 = sha256_hex(&parsed.bytes);
+    if actual_sha256 != parsed.chunk_sha256 {
+        return Err(validation_error(
+            "chunk_sha256",
+            "Must match the received chunk bytes.",
+        ));
+    }
+
+    if let Some(existing) = state
+        .storage
+        .get_chunk(&api_key_id, &job_id, parsed.chunk_index)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load chunk state."))?
+    {
+        if existing.chunk_sha256_hex == parsed.chunk_sha256 {
+            return Ok(StatusCode::NO_CONTENT);
+        }
+        return Err(ApiError::conflict(
+            "Chunk index already has different accepted bytes.",
+            None,
+        ));
+    }
+
+    let chunk_path = persist_chunk(
+        &state.accepted_audio_dir,
+        &job_id,
+        parsed.chunk_index,
+        &parsed.bytes,
+    )
+    .await
+    .map_err(|_| ApiError::internal("Failed to persist chunk."))?;
+    let outcome = state
+        .storage
+        .store_chunk(AcceptedChunk {
+            api_key_id,
+            job_id,
+            chunk_index: parsed.chunk_index,
+            chunk_sha256_hex: parsed.chunk_sha256,
+            chunk_path,
+            chunk_size_bytes: parsed.bytes.len() as i64,
+            accepted_at: OffsetDateTime::now_utc(),
+        })
+        .await
+        .map_err(|_| ApiError::internal("Failed to persist chunk state."))?;
+
+    match outcome {
+        StoreChunkOutcome::Stored | StoreChunkOutcome::Replayed => Ok(StatusCode::NO_CONTENT),
+        StoreChunkOutcome::Conflict => Err(ApiError::conflict(
+            "Chunk index already has different accepted bytes.",
+            None,
+        )),
+        StoreChunkOutcome::NotFound => Err(ApiError::not_found("Transcription job not found.")),
+        StoreChunkOutcome::NotAcceptingChunks => Err(ApiError::conflict(
+            "Transcription job is not accepting chunks.",
+            None,
+        )),
+    }
+}
+
+async fn finalize_transcription_job(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+) -> Result<(StatusCode, Json<TranscriptionJobResource>), ApiError> {
+    validate_ulid_field("job_id", &job_id)?;
+    let api_key_id = authenticated_key.api_key_id.to_string();
+    let Some((job, chunks)) = state
+        .storage
+        .list_chunks_for_finalize(&api_key_id, &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load transcription job."))?
+    else {
+        return Err(ApiError::not_found("Transcription job not found."));
+    };
+    if job.status != "accepting_chunks" {
+        if !job.audio_sha256_hex.is_empty() {
+            return Ok((StatusCode::OK, Json(job_resource(job)?)));
+        }
+        return Err(ApiError::conflict(
+            "Transcription job is not accepting chunks.",
+            None,
+        ));
+    }
+    ensure_complete_chunk_set(&job, &chunks)?;
+
+    let audio_sha256_hex =
+        compose_audio_content_hash_hex(chunks.iter().map(|chunk| chunk.chunk_sha256_hex.as_str()))
+            .map_err(|_| ApiError::internal("Accepted chunk hash state is invalid."))?;
+    let accepted_audio_path = compose_chunks(
+        &state.accepted_audio_dir,
+        &job_id,
+        &job.audio_format,
+        &chunks,
+    )
+    .await
+    .map_err(|_| ApiError::internal("Failed to compose accepted audio."))?;
+    let settings = state
+        .storage
+        .get_settings(&api_key_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load settings."))?;
+
+    match state
+        .storage
+        .finalize_job(
+            &api_key_id,
+            &job_id,
+            &audio_sha256_hex,
+            &accepted_audio_path,
+            &settings.transcription_model,
+            OffsetDateTime::now_utc(),
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to finalize transcription job."))?
+    {
+        FinalizeJobOutcome::Accepted(job) => Ok((StatusCode::ACCEPTED, Json(job_resource(job)?))),
+        FinalizeJobOutcome::Replayed(job) => Ok((StatusCode::OK, Json(job_resource(job)?))),
+        FinalizeJobOutcome::MissingChunks => Err(ApiError::conflict(
+            "Every declared chunk must be accepted before finalize.",
+            None,
+        )),
+        FinalizeJobOutcome::NotFound => Err(ApiError::not_found("Transcription job not found.")),
+        FinalizeJobOutcome::NotAcceptingChunks => Err(ApiError::conflict(
+            "Transcription job is not accepting chunks.",
+            None,
+        )),
+    }
+}
+
+async fn get_transcription_job(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+) -> Result<Json<TranscriptionJobResource>, ApiError> {
+    validate_ulid_field("job_id", &job_id)?;
+    let Some(job) = state
+        .storage
+        .get_job(authenticated_key.api_key_id.as_str(), &job_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load transcription job."))?
+    else {
+        return Err(ApiError::not_found("Transcription job not found."));
+    };
+
+    Ok(Json(job_resource(job)?))
+}
+
+fn validate_open_body(body: &OpenTranscriptionJobRequest) -> Result<(), ApiError> {
+    if !(1..=256).contains(&body.chunk_count) {
+        return Err(validation_error(
+            "chunk_count",
+            "Must be an integer in 1..256.",
+        ));
+    }
+    if !matches!(body.audio_format.as_str(), "m4a" | "mp3" | "wav" | "webm") {
+        return Err(validation_error(
+            "audio_format",
+            "Must be a supported audio format.",
+        ));
+    }
+    if let Some(session_id) = body.session_id.as_deref() {
+        validate_ulid_field("session_id", session_id)?;
+    }
+    if let Some(language) = body.language.as_deref()
+        && (language.len() != 2 || !language.bytes().all(|byte| byte.is_ascii_lowercase()))
+    {
+        return Err(validation_error(
+            "language",
+            "Must be an ISO 639-1 language code.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn idempotency_key(headers: &HeaderMap) -> Result<String, ApiError> {
+    let mut values = headers.get_all("Idempotency-Key").iter();
+    let Some(value) = values.next() else {
+        return Err(validation_error("Idempotency-Key", "Header is required."));
+    };
+    if values.next().is_some() {
+        return Err(validation_error("Idempotency-Key", "Header is malformed."));
+    }
+    let value = value
+        .to_str()
+        .map_err(|_| validation_error("Idempotency-Key", "Header is malformed."))?;
+    if value.trim().is_empty()
+        || value != value.trim()
+        || value.len() > 255
+        || !value.bytes().all(|byte| (0x21..=0x7e).contains(&byte))
+    {
+        return Err(validation_error("Idempotency-Key", "Header is malformed."));
+    }
+
+    Ok(value.to_owned())
+}
+
+async fn parse_chunk_multipart(mut multipart: Multipart) -> Result<ParsedChunk, ApiError> {
+    let mut chunk_index = None;
+    let mut chunk_sha256 = None;
+    let mut file = None;
+
+    while let Some(field) = multipart.next_field().await.map_err(map_multipart_error)? {
+        let Some(name) = field.name().map(str::to_owned) else {
+            continue;
+        };
+        match name.as_str() {
+            "chunk_index" => {
+                if chunk_index.is_some() {
+                    return Err(validation_error(
+                        "chunk_index",
+                        "Must be supplied exactly once.",
+                    ));
+                }
+                let value = field.bytes().await.map_err(map_multipart_error)?;
+                let value = std::str::from_utf8(&value)
+                    .map_err(|_| validation_error("chunk_index", "Must be an integer."))?;
+                chunk_index = Some(
+                    value
+                        .parse::<i64>()
+                        .map_err(|_| validation_error("chunk_index", "Must be an integer."))?,
+                );
+            }
+            "chunk_sha256" => {
+                if chunk_sha256.is_some() {
+                    return Err(validation_error(
+                        "chunk_sha256",
+                        "Must be supplied exactly once.",
+                    ));
+                }
+                let value = field.bytes().await.map_err(map_multipart_error)?;
+                let value = std::str::from_utf8(&value).map_err(|_| {
+                    validation_error("chunk_sha256", "Must be lowercase SHA-256 hex.")
+                })?;
+                validate_lowercase_sha256_hex(value).map_err(|_| {
+                    validation_error("chunk_sha256", "Must be lowercase SHA-256 hex.")
+                })?;
+                chunk_sha256 = Some(value.to_owned());
+            }
+            "file" => {
+                if file.is_some() {
+                    return Err(validation_error("file", "Must be supplied exactly once."));
+                }
+                file = Some(field.bytes().await.map_err(map_multipart_error)?.to_vec());
+            }
+            _ => {}
+        }
+    }
+
+    Ok(ParsedChunk {
+        chunk_index: chunk_index
+            .ok_or_else(|| validation_error("chunk_index", "Must be supplied."))?,
+        chunk_sha256: chunk_sha256
+            .ok_or_else(|| validation_error("chunk_sha256", "Must be supplied."))?,
+        bytes: file.ok_or_else(|| validation_error("file", "Must be supplied."))?,
+    })
+}
+
+fn map_multipart_error(error: axum::extract::multipart::MultipartError) -> ApiError {
+    if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        ApiError::payload_too_large()
+    } else {
+        ApiError::validation("Malformed multipart body.", None)
+    }
+}
+
+fn map_multipart_rejection(error: axum::extract::multipart::MultipartRejection) -> ApiError {
+    if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        ApiError::payload_too_large()
+    } else {
+        ApiError::validation("Malformed multipart body.", None)
+    }
+}
+
+fn ensure_complete_chunk_set(
+    job: &TranscriptionJobRecord,
+    chunks: &[ChunkRecord],
+) -> Result<(), ApiError> {
+    if chunks.len() as i64 != job.chunk_count {
+        return Err(ApiError::conflict(
+            "Every declared chunk must be accepted before finalize.",
+            None,
+        ));
+    }
+    for (expected, chunk) in chunks.iter().enumerate() {
+        if chunk.chunk_index != expected as i64 {
+            return Err(ApiError::conflict(
+                "Every declared chunk must be accepted before finalize.",
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn job_resource(record: TranscriptionJobRecord) -> Result<TranscriptionJobResource, ApiError> {
+    Ok(TranscriptionJobResource {
+        id: record.id,
+        status: record.status,
+        created_at: timestamp(record.created_at)?,
+        updated_at: timestamp(record.updated_at)?,
+        chunk_count: record.chunk_count,
+        chunks_received: record.chunks_received,
+        retry_count: record.retry_count,
+        max_retries: record.max_retries,
+        next_attempt_at: record.next_attempt_at.map(timestamp).transpose()?,
+        failure_code: record.failure_code,
+        failure_message: record.failure_message,
+        retryable_by_client: record.retryable_by_client,
+        voice_note_id: record.voice_note_id,
+    })
+}

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 
 use oracy_backend::audio_hash::{AUDIO_CONTENT_HASH_ALGORITHM_ID, compose_audio_content_hash_hex};
 use oracy_backend::storage::{
-    AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewOpenTranscriptionJob, NewSegment,
-    NewSession, NewTag, NewTranscriptionJob, NewVoiceNote, NewVoiceNoteVersion, OpenJobOutcome,
-    RenameTagOutcome, ReplaceVoiceNoteTagsOutcome, Storage, StorageError, VoiceNoteMaterialization,
+    AcceptJobOutcome, AcceptedChunk, CreateTagOutcome, FinalizeJobOutcome, NewEmbedding,
+    NewOpenTranscriptionJob, NewSegment, NewSession, NewTag, NewTranscriptionJob, NewVoiceNote,
+    NewVoiceNoteVersion, OpenJobOutcome, RenameTagOutcome, ReplaceVoiceNoteTagsOutcome, Storage,
+    StorageError, StoreChunkOutcome, VoiceNoteMaterialization,
 };
 use sqlx::Row;
 use tempfile::TempDir;
@@ -322,6 +323,58 @@ async fn racing_open_resolves_unique_conflicts_as_replay_or_submission_conflict(
         job_count_by_key(&storage, "owner-a", "attempt-open-2").await,
         1
     );
+}
+
+#[tokio::test]
+async fn racing_same_hash_chunk_push_resolves_as_idempotent_replay() {
+    let (_tempdir, storage) = storage().await;
+    let job = opened_job(&storage, "owner-a", "attempt-racing-same-chunk").await;
+    let chunk = accepted_chunk(&job.id, "chunk-hash-a");
+
+    let outcome = store_chunk_while_uncommitted_chunk_exists(&storage, chunk.clone(), chunk)
+        .await
+        .expect("racing same-hash chunk should not return storage error");
+
+    assert_eq!(outcome, StoreChunkOutcome::Replayed);
+    assert_eq!(chunk_count_by_job(&storage, "owner-a", &job.id).await, 1);
+}
+
+#[tokio::test]
+async fn racing_different_hash_chunk_push_resolves_as_conflict() {
+    let (_tempdir, storage) = storage().await;
+    let job = opened_job(&storage, "owner-a", "attempt-racing-conflicting-chunk").await;
+
+    let outcome = store_chunk_while_uncommitted_chunk_exists(
+        &storage,
+        accepted_chunk(&job.id, "chunk-hash-a"),
+        accepted_chunk(&job.id, "chunk-hash-b"),
+    )
+    .await
+    .expect("racing conflicting chunk should not return storage error");
+
+    assert_eq!(outcome, StoreChunkOutcome::Conflict);
+    assert_eq!(chunk_count_by_job(&storage, "owner-a", &job.id).await, 1);
+}
+
+#[tokio::test]
+async fn racing_finalize_resolves_as_idempotent_replay() {
+    let (_tempdir, storage) = storage().await;
+    let job = opened_job(&storage, "owner-a", "attempt-racing-finalize").await;
+    storage
+        .store_chunk(accepted_chunk(&job.id, "chunk-hash-a"))
+        .await
+        .expect("store accepted chunk");
+
+    let outcome =
+        finalize_while_uncommitted_finalize_exists(&storage, &job.id, "accepted-audio-hash")
+            .await
+            .expect("racing finalize should not return storage error");
+
+    assert!(matches!(
+        outcome,
+        FinalizeJobOutcome::Replayed(job) if job.status == "queued"
+            && job.audio_sha256_hex == "accepted-audio-hash"
+    ));
 }
 
 #[tokio::test]
@@ -1318,6 +1371,22 @@ async fn created_job(
     }
 }
 
+async fn opened_job(
+    storage: &Storage,
+    owner: &str,
+    idempotency_key: &str,
+) -> oracy_backend::storage::TranscriptionJobRecord {
+    insert_session_row(storage, owner, "session-a").await;
+    match storage
+        .open_job(new_open_job(owner, idempotency_key))
+        .await
+        .expect("open job")
+    {
+        OpenJobOutcome::Created(job) => job,
+        other => panic!("expected opened job, got {other:?}"),
+    }
+}
+
 async fn accept_while_uncommitted_row_exists(
     storage: &Storage,
     existing_job_id: &str,
@@ -1394,6 +1463,97 @@ async fn open_while_uncommitted_row_exists(
     sleep(Duration::from_millis(100)).await;
     tx.commit().await.expect("commit open row");
     handle.await.expect("open task should not panic")
+}
+
+async fn store_chunk_while_uncommitted_chunk_exists(
+    storage: &Storage,
+    stored: AcceptedChunk,
+    attempted: AcceptedChunk,
+) -> Result<StoreChunkOutcome, oracy_backend::storage::StorageError> {
+    let mut tx = storage.pool().begin().await.expect("begin transaction");
+    insert_chunk(&mut tx, &stored).await;
+
+    let racing_storage = storage.clone();
+    let handle = tokio::spawn(async move { racing_storage.store_chunk(attempted).await });
+    sleep(Duration::from_millis(100)).await;
+    assert!(
+        !handle.is_finished(),
+        "racing chunk push should wait on the held write"
+    );
+    tx.commit().await.expect("commit accepted chunk row");
+    handle.await.expect("store chunk task should not panic")
+}
+
+async fn finalize_while_uncommitted_finalize_exists(
+    storage: &Storage,
+    job_id: &str,
+    audio_sha256_hex: &str,
+) -> Result<FinalizeJobOutcome, oracy_backend::storage::StorageError> {
+    let mut tx = storage.pool().begin().await.expect("begin transaction");
+    sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET audio_sha256_hex = ?,
+            accepted_audio_path = ?,
+            transcription_model = ?,
+            status = 'queued',
+            updated_at = ?
+        WHERE api_key_id = 'owner-a' AND id = ?
+        "#,
+    )
+    .bind(audio_sha256_hex)
+    .bind("/var/lib/oracy/accepted-audio/racing-finalized.wav")
+    .bind("gpt-4o-mini-transcribe")
+    .bind("2026-04-24T18:00:05Z")
+    .bind(job_id)
+    .execute(&mut *tx)
+    .await
+    .expect("update uncommitted finalized row");
+
+    let racing_storage = storage.clone();
+    let job_id = job_id.to_owned();
+    let audio_sha256_hex = audio_sha256_hex.to_owned();
+    let handle = tokio::spawn(async move {
+        racing_storage
+            .finalize_job(
+                "owner-a",
+                &job_id,
+                &audio_sha256_hex,
+                std::path::Path::new("/var/lib/oracy/accepted-audio/racing-finalized.wav"),
+                "gpt-4o-mini-transcribe",
+                datetime!(2026-04-24 18:00:05 UTC),
+            )
+            .await
+    });
+    sleep(Duration::from_millis(100)).await;
+    assert!(
+        !handle.is_finished(),
+        "racing finalize should wait on the held write"
+    );
+    tx.commit().await.expect("commit finalized row");
+    handle.await.expect("finalize task should not panic")
+}
+
+async fn insert_chunk(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>, chunk: &AcceptedChunk) {
+    sqlx::query(
+        r#"
+        INSERT INTO transcription_job_chunks (
+            api_key_id, job_id, chunk_index, chunk_sha256_hex,
+            chunk_path, chunk_size_bytes, accepted_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(&chunk.api_key_id)
+    .bind(&chunk.job_id)
+    .bind(chunk.chunk_index)
+    .bind(&chunk.chunk_sha256_hex)
+    .bind(chunk.chunk_path.to_string_lossy().into_owned())
+    .bind(chunk.chunk_size_bytes)
+    .bind("2026-04-24T18:00:01Z")
+    .execute(&mut **tx)
+    .await
+    .expect("insert uncommitted chunk row");
 }
 
 async fn insert_voice_note_only(storage: &Storage, owner: &str, voice_note_id: &str) {
@@ -1480,6 +1640,22 @@ async fn job_count_by_key(storage: &Storage, owner: &str, idempotency_key: &str)
     .get("count")
 }
 
+async fn chunk_count_by_job(storage: &Storage, owner: &str, job_id: &str) -> i64 {
+    sqlx::query(
+        r#"
+        SELECT COUNT(*) AS count
+        FROM transcription_job_chunks
+        WHERE api_key_id = ? AND job_id = ?
+        "#,
+    )
+    .bind(owner)
+    .bind(job_id)
+    .fetch_one(storage.pool())
+    .await
+    .expect("count chunks")
+    .get("count")
+}
+
 async fn row_count(storage: &Storage, table: &str, id: &str) -> i64 {
     let sql = format!("SELECT COUNT(*) AS count FROM {table} WHERE id = ?");
     sqlx::query(&sql)
@@ -1525,6 +1701,20 @@ fn new_open_job(owner: &str, idempotency_key: &str) -> NewOpenTranscriptionJob {
         audio_format: "wav".to_owned(),
         max_retries: 3,
         now: datetime!(2026-04-24 18:00:00 UTC),
+    }
+}
+
+fn accepted_chunk(job_id: &str, hash: &str) -> AcceptedChunk {
+    AcceptedChunk {
+        api_key_id: "owner-a".to_owned(),
+        job_id: job_id.to_owned(),
+        chunk_index: 0,
+        chunk_sha256_hex: hash.to_owned(),
+        chunk_path: PathBuf::from(format!(
+            "/var/lib/oracy/accepted-audio/{job_id}/chunks/0.chunk"
+        )),
+        chunk_size_bytes: 12,
+        accepted_at: datetime!(2026-04-24 18:00:01 UTC),
     }
 }
 

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 
 use oracy_backend::audio_hash::{AUDIO_CONTENT_HASH_ALGORITHM_ID, compose_audio_content_hash_hex};
 use oracy_backend::storage::{
-    AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewSegment, NewSession, NewTag,
-    NewTranscriptionJob, NewVoiceNote, NewVoiceNoteVersion, RenameTagOutcome,
-    ReplaceVoiceNoteTagsOutcome, Storage, StorageError, VoiceNoteMaterialization,
+    AcceptJobOutcome, CreateTagOutcome, NewEmbedding, NewOpenTranscriptionJob, NewSegment,
+    NewSession, NewTag, NewTranscriptionJob, NewVoiceNote, NewVoiceNoteVersion, OpenJobOutcome,
+    RenameTagOutcome, ReplaceVoiceNoteTagsOutcome, Storage, StorageError, VoiceNoteMaterialization,
 };
 use sqlx::Row;
 use tempfile::TempDir;
@@ -276,6 +276,52 @@ async fn racing_acceptance_resolves_unique_conflicts_as_replay_or_submission_con
 
     assert_eq!(job_count_by_key(&storage, "owner-a", "attempt-1").await, 1);
     assert_eq!(job_count_by_key(&storage, "owner-a", "attempt-2").await, 1);
+}
+
+#[tokio::test]
+async fn racing_open_resolves_unique_conflicts_as_replay_or_submission_conflict() {
+    let (_tempdir, storage) = storage().await;
+    insert_session_row(&storage, "owner-a", "session-a").await;
+    let input = new_open_job("owner-a", "attempt-open-1");
+
+    let replayed = open_while_uncommitted_row_exists(
+        &storage,
+        "racing-open-replay-job",
+        input.clone(),
+        input.clone(),
+    )
+    .await
+    .expect("racing open replay should not return storage error");
+    assert!(matches!(
+        replayed,
+        OpenJobOutcome::ReplayedOpen(job) if job.id == "racing-open-replay-job"
+    ));
+
+    let mut mismatched = new_open_job("owner-a", "attempt-open-2");
+    mismatched.chunk_count = 2;
+    let conflict = open_while_uncommitted_row_exists(
+        &storage,
+        "racing-open-conflict-job",
+        new_open_job("owner-a", "attempt-open-2"),
+        mismatched,
+    )
+    .await
+    .expect("racing open conflict should not return storage error");
+    assert_eq!(
+        conflict,
+        OpenJobOutcome::Conflict(oracy_backend::storage::SubmissionConflict {
+            job_id: "racing-open-conflict-job".to_owned()
+        })
+    );
+
+    assert_eq!(
+        job_count_by_key(&storage, "owner-a", "attempt-open-1").await,
+        1
+    );
+    assert_eq!(
+        job_count_by_key(&storage, "owner-a", "attempt-open-2").await,
+        1
+    );
 }
 
 #[tokio::test]
@@ -1311,6 +1357,45 @@ async fn accept_while_uncommitted_row_exists(
     handle.await.expect("accept task should not panic")
 }
 
+async fn open_while_uncommitted_row_exists(
+    storage: &Storage,
+    existing_job_id: &str,
+    stored: NewOpenTranscriptionJob,
+    attempted: NewOpenTranscriptionJob,
+) -> Result<OpenJobOutcome, oracy_backend::storage::StorageError> {
+    let mut tx = storage.pool().begin().await.expect("begin transaction");
+    sqlx::query(
+        r#"
+        INSERT INTO transcription_jobs (
+            id, api_key_id, idempotency_key, recorded_at, session_id,
+            language, status, created_at, updated_at, retry_count,
+            max_retries, chunk_count, audio_format
+        )
+        VALUES (?, ?, ?, ?, ?, ?, 'accepting_chunks', ?, ?, 0, ?, ?, ?)
+        "#,
+    )
+    .bind(existing_job_id)
+    .bind(&stored.api_key_id)
+    .bind(&stored.idempotency_key)
+    .bind("2026-04-24T17:59:00Z")
+    .bind(&stored.session_id)
+    .bind(&stored.language)
+    .bind("2026-04-24T18:00:00Z")
+    .bind("2026-04-24T18:00:00Z")
+    .bind(stored.max_retries)
+    .bind(stored.chunk_count)
+    .bind(&stored.audio_format)
+    .execute(&mut *tx)
+    .await
+    .expect("insert uncommitted open row");
+
+    let racing_storage = storage.clone();
+    let handle = tokio::spawn(async move { racing_storage.open_job(attempted).await });
+    sleep(Duration::from_millis(100)).await;
+    tx.commit().await.expect("commit open row");
+    handle.await.expect("open task should not panic")
+}
+
 async fn insert_voice_note_only(storage: &Storage, owner: &str, voice_note_id: &str) {
     sqlx::query(
         r#"
@@ -1424,6 +1509,20 @@ fn new_job(owner: &str, idempotency_key: &str, hash: &str) -> NewTranscriptionJo
         session_id: Some("session-a".to_owned()),
         language: Some("en".to_owned()),
         accepted_audio_path: PathBuf::from("/var/lib/oracy/accepted-audio/job-a"),
+        max_retries: 3,
+        now: datetime!(2026-04-24 18:00:00 UTC),
+    }
+}
+
+fn new_open_job(owner: &str, idempotency_key: &str) -> NewOpenTranscriptionJob {
+    NewOpenTranscriptionJob {
+        api_key_id: owner.to_owned(),
+        idempotency_key: idempotency_key.to_owned(),
+        recorded_at: datetime!(2026-04-24 17:59:00 UTC),
+        session_id: Some("session-a".to_owned()),
+        language: Some("en".to_owned()),
+        chunk_count: 1,
+        audio_format: "wav".to_owned(),
         max_retries: 3,
         now: datetime!(2026-04-24 18:00:00 UTC),
     }

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -63,6 +63,59 @@ async fn chunked_submission_reaches_queued_after_all_chunks_are_finalized() {
 }
 
 #[tokio::test]
+async fn session_scoped_submission_finalizes_without_mutating_replay_tuple() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let created_session = fixture
+        .json_request(
+            "POST",
+            "/api/v1/sessions",
+            None,
+            Some(json!({"name": "Planning"})),
+        )
+        .await;
+    assert_eq!(created_session.status, StatusCode::CREATED);
+    let session_id = created_session.body["id"].as_str().expect("session id");
+
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-session-finalize"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav",
+                "session_id": session_id
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+
+    fixture.push_chunk(job_id, 0, b"audio").await;
+    let finalized = fixture
+        .request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(finalized.status(), StatusCode::ACCEPTED);
+    assert_eq!(json_body(finalized).await["status"], "queued");
+
+    let stored_session_id: Option<String> = sqlx::query_scalar(
+        "SELECT session_id FROM transcription_jobs WHERE api_key_id = 'alpha' AND id = ?",
+    )
+    .bind(job_id)
+    .fetch_one(fixture.storage.pool())
+    .await
+    .expect("job row");
+    assert_eq!(stored_session_id.as_deref(), Some(session_id));
+}
+
+#[tokio::test]
 async fn open_replays_matching_idempotency_keys_and_rejects_mismatched_bodies() {
     let fixture = TranscriptionJobFixture::new().await;
     let body = json!({
@@ -123,6 +176,41 @@ async fn open_replays_matching_idempotency_keys_and_rejects_mismatched_bodies() 
 }
 
 #[tokio::test]
+async fn concurrent_open_replays_return_the_same_job() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let body = json!({
+        "recorded_at": "2026-04-24T17:59:00Z",
+        "chunk_count": 1,
+        "audio_format": "wav"
+    });
+
+    let (first, second) = tokio::join!(
+        fixture.json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-concurrent-open"),
+            Some(body.clone()),
+        ),
+        fixture.json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-concurrent-open"),
+            Some(body),
+        ),
+    );
+
+    assert_eq!(first.status, StatusCode::CREATED);
+    assert_eq!(second.status, StatusCode::CREATED);
+    assert_eq!(first.body["id"], second.body["id"]);
+    assert_eq!(
+        fixture
+            .job_count_by_idempotency_key("attempt-concurrent-open")
+            .await,
+        1
+    );
+}
+
+#[tokio::test]
 async fn malformed_job_ids_are_rejected_before_existence_checks() {
     let fixture = TranscriptionJobFixture::new().await;
 
@@ -176,11 +264,7 @@ async fn chunk_replay_is_noop_and_conflicting_chunk_preserves_accepted_file() {
     let job_id = opened.body["id"].as_str().expect("job id");
 
     fixture.push_chunk(job_id, 0, b"accepted bytes").await;
-    let chunk_path = fixture
-        .accepted_audio_dir
-        .join(job_id)
-        .join("chunks")
-        .join("0.chunk");
+    let chunk_path = fixture.accepted_chunk_path(job_id, 0).await;
     assert_eq!(
         std::fs::read(&chunk_path).expect("accepted chunk"),
         b"accepted bytes"
@@ -199,6 +283,66 @@ async fn chunk_replay_is_noop_and_conflicting_chunk_preserves_accepted_file() {
         std::fs::read(&chunk_path).expect("accepted chunk unchanged"),
         b"accepted bytes"
     );
+}
+
+#[tokio::test]
+async fn concurrent_same_hash_chunk_pushes_are_both_idempotent_successes() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-concurrent-same-chunk"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+
+    let (first, second) = tokio::join!(
+        fixture.push_chunk_response(job_id, 0, b"accepted bytes"),
+        fixture.push_chunk_response(job_id, 0, b"accepted bytes"),
+    );
+
+    assert_eq!(first.status(), StatusCode::NO_CONTENT);
+    assert_eq!(second.status(), StatusCode::NO_CONTENT);
+    assert_eq!(fixture.chunk_count(job_id).await, 1);
+}
+
+#[tokio::test]
+async fn concurrent_different_hash_chunk_pushes_return_success_and_conflict() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-concurrent-conflicting-chunk"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+
+    let (first, second) = tokio::join!(
+        fixture.push_chunk_response(job_id, 0, b"accepted bytes"),
+        fixture.push_chunk_response(job_id, 0, b"different bytes"),
+    );
+    let mut statuses = [first.status(), second.status()];
+    statuses.sort_by_key(|status| status.as_u16());
+
+    assert_eq!(statuses, [StatusCode::NO_CONTENT, StatusCode::CONFLICT]);
+    assert_eq!(fixture.chunk_count(job_id).await, 1);
+    let accepted_path = fixture.accepted_chunk_path(job_id, 0).await;
+    let accepted_bytes = std::fs::read(&accepted_path).expect("accepted chunk");
+    assert!(accepted_bytes == b"accepted bytes" || accepted_bytes == b"different bytes");
 }
 
 #[tokio::test]
@@ -330,8 +474,25 @@ async fn finalize_captures_current_settings_and_nulls_sessions_deleted_after_ope
     .fetch_one(fixture.storage.pool())
     .await
     .expect("job row");
-    assert_eq!(row.0, None);
+    assert_eq!(row.0.as_deref(), Some(session_id));
     assert_eq!(row.1, "gpt-4o-transcribe");
+
+    let replayed = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-settings-and-session"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav",
+                "session_id": session_id
+            })),
+        )
+        .await;
+    assert_eq!(replayed.status, StatusCode::OK);
+    assert_eq!(replayed.body["id"], job_id);
+    assert_eq!(replayed.body["status"], "queued");
 }
 
 struct JsonResponse {
@@ -341,7 +502,6 @@ struct JsonResponse {
 
 struct TranscriptionJobFixture {
     _tempdir: TempDir,
-    accepted_audio_dir: std::path::PathBuf,
     storage: Storage,
     app: axum::Router,
 }
@@ -367,7 +527,6 @@ impl TranscriptionJobFixture {
 
         Self {
             _tempdir: tempdir,
-            accepted_audio_dir,
             storage,
             app,
         }
@@ -422,6 +581,50 @@ impl TranscriptionJobFixture {
             Some(&format!("multipart/form-data; boundary={boundary}")),
         )
         .await
+    }
+
+    async fn accepted_chunk_path(&self, job_id: &str, chunk_index: usize) -> std::path::PathBuf {
+        let path: String = sqlx::query_scalar(
+            r#"
+            SELECT chunk_path
+            FROM transcription_job_chunks
+            WHERE api_key_id = 'alpha' AND job_id = ? AND chunk_index = ?
+            "#,
+        )
+        .bind(job_id)
+        .bind(chunk_index as i64)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("accepted chunk path");
+        std::path::PathBuf::from(path)
+    }
+
+    async fn chunk_count(&self, job_id: &str) -> i64 {
+        sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM transcription_job_chunks
+            WHERE api_key_id = 'alpha' AND job_id = ?
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("chunk count")
+    }
+
+    async fn job_count_by_idempotency_key(&self, idempotency_key: &str) -> i64 {
+        sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM transcription_jobs
+            WHERE api_key_id = 'alpha' AND idempotency_key = ?
+            "#,
+        )
+        .bind(idempotency_key)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("job count")
     }
 
     async fn request(

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -1,0 +1,485 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use oracy_backend::auth::AuthStore;
+use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::router::build_router;
+use oracy_backend::state::AppState;
+use oracy_backend::storage::Storage;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+#[tokio::test]
+async fn chunked_submission_reaches_queued_after_all_chunks_are_finalized() {
+    let fixture = TranscriptionJobFixture::new().await;
+
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-happy-path"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 2,
+                "audio_format": "wav",
+                "language": "en"
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    assert_eq!(opened.body["status"], "accepting_chunks");
+    assert_eq!(opened.body["chunk_count"], 2);
+    assert_eq!(opened.body["chunks_received"], 0);
+    let job_id = opened.body["id"].as_str().expect("job id");
+
+    fixture.push_chunk(job_id, 0, b"first audio bytes").await;
+    fixture.push_chunk(job_id, 1, b"second audio bytes").await;
+
+    let finalized = fixture
+        .request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(finalized.status(), StatusCode::ACCEPTED);
+    let finalized_body = json_body(finalized).await;
+    assert_eq!(finalized_body["status"], "queued");
+    assert_eq!(finalized_body["chunks_received"], 2);
+    assert_eq!(finalized_body["voice_note_id"], Value::Null);
+
+    let fetched = fixture
+        .get_json(&format!("/api/v1/transcription-jobs/{job_id}"))
+        .await;
+    assert_eq!(fetched["status"], "queued");
+    assert_eq!(fetched["chunk_count"], 2);
+    assert_eq!(fetched["chunks_received"], 2);
+    assert_eq!(fetched["retry_count"], 0);
+}
+
+#[tokio::test]
+async fn open_replays_matching_idempotency_keys_and_rejects_mismatched_bodies() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let body = json!({
+        "recorded_at": "2026-04-24T17:59:00Z",
+        "chunk_count": 1,
+        "audio_format": "wav"
+    });
+
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-replay"),
+            Some(body.clone()),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id").to_owned();
+
+    let replayed = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-replay"),
+            Some(body),
+        )
+        .await;
+    assert_eq!(replayed.status, StatusCode::CREATED);
+    assert_eq!(replayed.body["id"], job_id);
+
+    let conflict = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-replay"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 2,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(conflict.status, StatusCode::CONFLICT);
+
+    let missing_key = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            None,
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(missing_key.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn malformed_job_ids_are_rejected_before_existence_checks() {
+    let fixture = TranscriptionJobFixture::new().await;
+
+    let get = fixture
+        .request(
+            "GET",
+            "/api/v1/transcription-jobs/not-a-ulid",
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(get.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(json_body(get).await["details"][0]["field"], "job_id");
+
+    let finalize = fixture
+        .request(
+            "POST",
+            "/api/v1/transcription-jobs/not-a-ulid/finalize",
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(finalize.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(json_body(finalize).await["details"][0]["field"], "job_id");
+
+    let response = fixture
+        .push_chunk_response("not-a-ulid", 0, b"audio bytes")
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(json_body(response).await["details"][0]["field"], "job_id");
+}
+
+#[tokio::test]
+async fn chunk_replay_is_noop_and_conflicting_chunk_preserves_accepted_file() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-chunk-conflict"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+
+    fixture.push_chunk(job_id, 0, b"accepted bytes").await;
+    let chunk_path = fixture
+        .accepted_audio_dir
+        .join(job_id)
+        .join("chunks")
+        .join("0.chunk");
+    assert_eq!(
+        std::fs::read(&chunk_path).expect("accepted chunk"),
+        b"accepted bytes"
+    );
+
+    let replay = fixture
+        .push_chunk_response(job_id, 0, b"accepted bytes")
+        .await;
+    assert_eq!(replay.status(), StatusCode::NO_CONTENT);
+
+    let conflict = fixture
+        .push_chunk_response(job_id, 0, b"different bytes")
+        .await;
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        std::fs::read(&chunk_path).expect("accepted chunk unchanged"),
+        b"accepted bytes"
+    );
+}
+
+#[tokio::test]
+async fn finalize_requires_all_chunks_and_replays_after_acceptance() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-finalize-replay"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 2,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+    fixture.push_chunk(job_id, 0, b"first").await;
+
+    let missing = fixture
+        .request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(missing.status(), StatusCode::CONFLICT);
+
+    fixture.push_chunk(job_id, 1, b"second").await;
+    let accepted = fixture
+        .request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+
+    let replay = fixture
+        .request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(replay.status(), StatusCode::OK);
+    assert_eq!(json_body(replay).await["status"], "queued");
+}
+
+#[tokio::test]
+async fn finalize_captures_current_settings_and_nulls_sessions_deleted_after_open() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let created_session = fixture
+        .json_request(
+            "POST",
+            "/api/v1/sessions",
+            None,
+            Some(json!({"name": "Planning"})),
+        )
+        .await;
+    assert_eq!(created_session.status, StatusCode::CREATED);
+    let session_id = created_session.body["id"].as_str().expect("session id");
+
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-settings-and-session"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav",
+                "session_id": session_id
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+
+    let settings = fixture
+        .json_request(
+            "PATCH",
+            "/api/v1/settings",
+            None,
+            Some(json!({"transcription_model": "gpt-4o-transcribe"})),
+        )
+        .await;
+    assert_eq!(settings.status, StatusCode::OK);
+
+    let deleted = fixture
+        .request(
+            "DELETE",
+            &format!("/api/v1/sessions/{session_id}"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+
+    fixture.push_chunk(job_id, 0, b"audio").await;
+    let finalized = fixture
+        .request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+    assert_eq!(finalized.status(), StatusCode::ACCEPTED);
+
+    let row: (Option<String>, String) = sqlx::query_as(
+        r#"
+        SELECT session_id, transcription_model
+        FROM transcription_jobs
+        WHERE api_key_id = 'alpha' AND id = ?
+        "#,
+    )
+    .bind(job_id)
+    .fetch_one(fixture.storage.pool())
+    .await
+    .expect("job row");
+    assert_eq!(row.0, None);
+    assert_eq!(row.1, "gpt-4o-transcribe");
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+struct TranscriptionJobFixture {
+    _tempdir: TempDir,
+    accepted_audio_dir: std::path::PathBuf,
+    storage: Storage,
+    app: axum::Router,
+}
+
+impl TranscriptionJobFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let accepted_audio_dir = tempdir.path().join("accepted-audio");
+        std::fs::create_dir(&accepted_audio_dir).expect("create accepted audio dir");
+        let storage = Storage::connect(&tempdir.path().join("oracy.sqlite"))
+            .await
+            .expect("connect storage");
+        let auth_store = AuthStore::try_from_configs(&[ApiKeyConfig {
+            api_key_id: "alpha".to_owned(),
+            key: "alpha-secret".to_owned(),
+        }])
+        .expect("auth config");
+        let app = build_router(AppState {
+            accepted_audio_dir: accepted_audio_dir.clone(),
+            auth_store: Arc::new(auth_store),
+            storage: storage.clone(),
+        });
+
+        Self {
+            _tempdir: tempdir,
+            accepted_audio_dir,
+            storage,
+            app,
+        }
+    }
+
+    async fn get_json(&self, path: &str) -> Value {
+        let response = self.request("GET", path, None, Body::empty(), None).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        json_body(response).await
+    }
+
+    async fn json_request(
+        &self,
+        method: &str,
+        path: &str,
+        idempotency_key: Option<&str>,
+        body: Option<Value>,
+    ) -> JsonResponse {
+        let response = self
+            .request(
+                method,
+                path,
+                idempotency_key,
+                Body::from(body.map(|value| value.to_string()).unwrap_or_default()),
+                Some("application/json"),
+            )
+            .await;
+        let status = response.status();
+        let body = json_body(response).await;
+        JsonResponse { status, body }
+    }
+
+    async fn push_chunk(&self, job_id: &str, chunk_index: usize, bytes: &[u8]) {
+        let response = self.push_chunk_response(job_id, chunk_index, bytes).await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    async fn push_chunk_response(
+        &self,
+        job_id: &str,
+        chunk_index: usize,
+        bytes: &[u8],
+    ) -> axum::response::Response {
+        let boundary = format!("oracy-boundary-{chunk_index}");
+        let chunk_sha256 = sha256_hex(bytes);
+        let body = multipart_body(&boundary, chunk_index, &chunk_sha256, bytes);
+        self.request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/chunks"),
+            None,
+            Body::from(body),
+            Some(&format!("multipart/form-data; boundary={boundary}")),
+        )
+        .await
+    }
+
+    async fn request(
+        &self,
+        method: &str,
+        path: &str,
+        idempotency_key: Option<&str>,
+        body: Body,
+        content_type: Option<&str>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(path)
+            .header("Authorization", "Bearer alpha-secret");
+        if let Some(content_type) = content_type {
+            builder = builder.header("Content-Type", content_type);
+        }
+        if let Some(idempotency_key) = idempotency_key {
+            builder = builder.header("Idempotency-Key", idempotency_key);
+        }
+
+        self.app
+            .clone()
+            .oneshot(builder.body(body).unwrap())
+            .await
+            .expect("response")
+    }
+}
+
+async fn json_body(response: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    if bytes.is_empty() {
+        return Value::Null;
+    }
+    serde_json::from_slice(&bytes).expect("valid json")
+}
+
+fn multipart_body(boundary: &str, chunk_index: usize, chunk_sha256: &str, bytes: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(b"Content-Disposition: form-data; name=\"chunk_index\"\r\n\r\n");
+    body.extend_from_slice(chunk_index.to_string().as_bytes());
+    body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(b"Content-Disposition: form-data; name=\"chunk_sha256\"\r\n\r\n");
+    body.extend_from_slice(chunk_sha256.as_bytes());
+    body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"file\"; filename=\"chunk.wav\"\r\n",
+    );
+    body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+    body.extend_from_slice(bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    body
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}


### PR DESCRIPTION
## Summary

- Adds the v0.1.0 chunked transcription-job submission HTTP surface: open, push chunks, finalize, and read.
- Persists `accepting_chunks` jobs, accepted chunk metadata, streamed composed audio, and finalize-time `queued` acceptance.
- Captures Settings model at finalize and keeps the processing pipeline, sweeper, and terminal cleanup out of scope.

## Changes

- Adds transcription-job routing and handlers with shared auth/error-envelope behavior.
- Adds durable audio-store helpers for chunk writes and streamed composition.
- Adds a migration for `accepting_chunks`, chunk metadata, open-call dimensions, finalize-only accepted tuple fields, and captured `transcription_model`.
- Extends storage with open replay/conflict, chunk idempotency, finalize-to-queued, and read-side `chunks_received`.
- Adds integration tests for happy path, idempotency, malformed job IDs, chunk replay/conflict preservation, finalize replay, Settings capture, and deleted-session finalization.
- Updates the changelog for the new API surface.

## GitHub Issue(s)

Closes #57

## Test plan

- `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
