### PR TITLE
feat(transcription-jobs): finish chunked acceptance

### DIFF
--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -721,6 +721,35 @@ impl Storage {
         Ok(Some((job, chunks)))
     }
 
+    pub async fn list_accepting_chunks_jobs_eligible_for_abandonment(
+        &self,
+        cutoff: OffsetDateTime,
+    ) -> Result<Vec<TranscriptionJobRecord>, StorageError> {
+        let cutoff = format_timestamp(cutoff)?;
+        // #59 supplies the cutoff from its configured window. Eligibility is
+        // strictly older than that cutoff; jobs created exactly at it are not eligible.
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                transcription_jobs.*,
+                COUNT(transcription_job_chunks.chunk_index) AS chunks_received
+            FROM transcription_jobs
+            LEFT JOIN transcription_job_chunks
+                ON transcription_job_chunks.api_key_id = transcription_jobs.api_key_id
+                AND transcription_job_chunks.job_id = transcription_jobs.id
+            WHERE transcription_jobs.status = 'accepting_chunks'
+                AND transcription_jobs.created_at < ?
+            GROUP BY transcription_jobs.id
+            ORDER BY transcription_jobs.created_at ASC, transcription_jobs.id ASC
+            "#,
+        )
+        .bind(cutoff)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(job_from_row).collect()
+    }
+
     pub async fn finalize_job(
         &self,
         api_key_id: &str,

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -326,6 +326,63 @@ async fn racing_open_resolves_unique_conflicts_as_replay_or_submission_conflict(
 }
 
 #[tokio::test]
+async fn abandonment_candidates_are_accepting_chunks_jobs_created_before_the_cutoff() {
+    let (_tempdir, storage) = storage().await;
+    let old_alpha = opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-old-alpha",
+        datetime!(2026-04-24 17:00:00 UTC),
+    )
+    .await;
+    let queued_old = opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-queued-old",
+        datetime!(2026-04-24 17:15:00 UTC),
+    )
+    .await;
+    mark_open_job_queued(&storage, &queued_old.id).await;
+    let old_beta = opened_job_at(
+        &storage,
+        "owner-b",
+        "attempt-old-beta",
+        datetime!(2026-04-24 17:30:00 UTC),
+    )
+    .await;
+    opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-at-cutoff",
+        datetime!(2026-04-24 18:00:00 UTC),
+    )
+    .await;
+    opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-recent",
+        datetime!(2026-04-24 18:30:00 UTC),
+    )
+    .await;
+
+    let candidates = storage
+        .list_accepting_chunks_jobs_eligible_for_abandonment(datetime!(2026-04-24 18:00:00 UTC))
+        .await
+        .expect("abandonment candidates");
+
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|job| (job.api_key_id.as_str(), job.id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("owner-a", old_alpha.id.as_str()),
+            ("owner-b", old_beta.id.as_str())
+        ]
+    );
+}
+
+#[tokio::test]
 async fn racing_same_hash_chunk_push_resolves_as_idempotent_replay() {
     let (_tempdir, storage) = storage().await;
     let job = opened_job(&storage, "owner-a", "attempt-racing-same-chunk").await;
@@ -1376,12 +1433,31 @@ async fn opened_job(
     owner: &str,
     idempotency_key: &str,
 ) -> oracy_backend::storage::TranscriptionJobRecord {
-    insert_session_row(storage, owner, "session-a").await;
-    match storage
-        .open_job(new_open_job(owner, idempotency_key))
-        .await
-        .expect("open job")
-    {
+    opened_job_at(
+        storage,
+        owner,
+        idempotency_key,
+        datetime!(2026-04-24 18:00:00 UTC),
+    )
+    .await
+}
+
+async fn opened_job_at(
+    storage: &Storage,
+    owner: &str,
+    idempotency_key: &str,
+    now: OffsetDateTime,
+) -> oracy_backend::storage::TranscriptionJobRecord {
+    let session_id = if owner == "owner-a" {
+        "session-a".to_owned()
+    } else {
+        format!("{owner}-session-a")
+    };
+    insert_session_row(storage, owner, &session_id).await;
+    let mut input = new_open_job(owner, idempotency_key);
+    input.session_id = Some(session_id);
+    input.now = now;
+    match storage.open_job(input).await.expect("open job") {
         OpenJobOutcome::Created(job) => job,
         other => panic!("expected opened job, got {other:?}"),
     }
@@ -1621,6 +1697,23 @@ async fn mark_job_retry_waiting(storage: &Storage, job_id: &str) {
     .execute(storage.pool())
     .await
     .expect("mark job retry waiting");
+    assert_eq!(result.rows_affected(), 1);
+}
+
+async fn mark_open_job_queued(storage: &Storage, job_id: &str) {
+    let result = sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET audio_sha256_hex = 'queued-open-job-hash',
+            accepted_audio_path = '/var/lib/oracy/accepted-audio/queued-open-job.wav',
+            status = 'queued'
+        WHERE api_key_id = 'owner-a' AND id = ?
+        "#,
+    )
+    .bind(job_id)
+    .execute(storage.pool())
+    .await
+    .expect("mark open job queued");
     assert_eq!(result.rows_affected(), 1);
 }
 

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use oracy_backend::audio_store::MAX_CHUNK_BYTES;
 use oracy_backend::auth::AuthStore;
 use oracy_backend::config::ApiKeyConfig;
 use oracy_backend::router::build_router;
@@ -60,6 +61,95 @@ async fn chunked_submission_reaches_queued_after_all_chunks_are_finalized() {
     assert_eq!(fetched["chunk_count"], 2);
     assert_eq!(fetched["chunks_received"], 2);
     assert_eq!(fetched["retry_count"], 0);
+}
+
+#[tokio::test]
+async fn spec_ceiling_chunk_is_accepted_through_the_multipart_route_limit() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-spec-ceiling-chunk"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 1,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+    let bytes = vec![0xA5; MAX_CHUNK_BYTES];
+
+    let response = fixture.push_chunk_response(job_id, 0, &bytes).await;
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let chunk_path = fixture.accepted_chunk_path(job_id, 0).await;
+    assert_eq!(
+        std::fs::metadata(&chunk_path)
+            .expect("accepted chunk metadata")
+            .len(),
+        MAX_CHUNK_BYTES as u64
+    );
+}
+
+#[tokio::test]
+async fn finalize_composes_large_multi_chunk_submission_in_chunk_order() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-large-finalize"),
+            Some(json!({
+                "recorded_at": "2026-04-24T17:59:00Z",
+                "chunk_count": 3,
+                "audio_format": "wav"
+            })),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+    let chunks = [
+        vec![0x11; 10 * 1024 * 1024],
+        vec![0x22; 10 * 1024 * 1024],
+        vec![0x33; 10 * 1024 * 1024],
+    ];
+    for (index, bytes) in chunks.iter().enumerate() {
+        fixture.push_chunk(job_id, index, bytes).await;
+    }
+
+    let finalized = fixture
+        .request(
+            "POST",
+            &format!("/api/v1/transcription-jobs/{job_id}/finalize"),
+            None,
+            Body::empty(),
+            None,
+        )
+        .await;
+
+    assert_eq!(finalized.status(), StatusCode::ACCEPTED);
+    let accepted_audio_path = fixture.accepted_audio_path(job_id).await;
+    assert_eq!(
+        std::fs::metadata(&accepted_audio_path)
+            .expect("accepted audio metadata")
+            .len(),
+        chunks.iter().map(|chunk| chunk.len() as u64).sum::<u64>()
+    );
+    assert_eq!(
+        fixture.file_prefix(&accepted_audio_path, 4).await,
+        vec![0x11; 4]
+    );
+    assert_eq!(
+        fixture.file_suffix(&accepted_audio_path, 4).await,
+        vec![0x33; 4]
+    );
+    assert_eq!(
+        fixture.stored_audio_hash(job_id).await,
+        composed_audio_hash_hex(&chunks)
+    );
 }
 
 #[tokio::test]
@@ -599,6 +689,57 @@ impl TranscriptionJobFixture {
         std::path::PathBuf::from(path)
     }
 
+    async fn accepted_audio_path(&self, job_id: &str) -> std::path::PathBuf {
+        let path: String = sqlx::query_scalar(
+            r#"
+            SELECT accepted_audio_path
+            FROM transcription_jobs
+            WHERE api_key_id = 'alpha' AND id = ?
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("accepted audio path");
+        std::path::PathBuf::from(path)
+    }
+
+    async fn stored_audio_hash(&self, job_id: &str) -> String {
+        sqlx::query_scalar(
+            r#"
+            SELECT audio_sha256_hex
+            FROM transcription_jobs
+            WHERE api_key_id = 'alpha' AND id = ?
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("stored audio hash")
+    }
+
+    async fn file_prefix(&self, path: &std::path::Path, len: usize) -> Vec<u8> {
+        use tokio::io::AsyncReadExt;
+
+        let mut file = tokio::fs::File::open(path).await.expect("open file");
+        let mut prefix = vec![0; len];
+        file.read_exact(&mut prefix).await.expect("read prefix");
+        prefix
+    }
+
+    async fn file_suffix(&self, path: &std::path::Path, len: usize) -> Vec<u8> {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+        let mut file = tokio::fs::File::open(path).await.expect("open file");
+        let size = file.metadata().await.expect("file metadata").len();
+        file.seek(std::io::SeekFrom::Start(size - len as u64))
+            .await
+            .expect("seek suffix");
+        let mut suffix = vec![0; len];
+        file.read_exact(&mut suffix).await.expect("read suffix");
+        suffix
+    }
+
     async fn chunk_count(&self, job_id: &str) -> i64 {
         sqlx::query_scalar(
             r#"
@@ -684,5 +825,15 @@ fn multipart_body(boundary: &str, chunk_index: usize, chunk_sha256: &str, bytes:
 
 fn sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn composed_audio_hash_hex(chunks: &[Vec<u8>]) -> String {
+    let mut hasher = Sha256::new();
+    for chunk in chunks {
+        let chunk_hash = Sha256::digest(chunk);
+        hasher.update(chunk_hash);
+    }
+    let digest = hasher.finalize();
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }


### PR DESCRIPTION
## Summary

- Completes the remaining #57 acceptance gaps after PR #62's partial landing.
- Adds explicit HTTP integration evidence that a spec-compliant 25 MiB multipart chunk is accepted through the route body limit.
- Adds large multi-chunk finalize evidence and a storage-owned `accepting_chunks` abandonment eligibility predicate for #59.

## Changes

- Covers max-size chunk acceptance and large finalize composition in `backend/tests/transcription_jobs.rs`, including persisted artifact size/order and composed hash checks.
- Adds `Storage::list_accepting_chunks_jobs_eligible_for_abandonment(cutoff)`, with `created_at < cutoff` pinned as the predicate contract.
- Covers the abandonment candidate query across owners while excluding queued, exact-cutoff, and recent jobs.

## GitHub Issue(s)

Closes #57

## Test plan

- `cargo fmt --manifest-path backend/Cargo.toml`
- `cargo test --manifest-path backend/Cargo.toml --test transcription_jobs -- --nocapture`
- `cargo test --manifest-path backend/Cargo.toml --test storage -- --nocapture`
- `cargo test --manifest-path backend/Cargo.toml`
