### PR TITLE
feat(transcription-jobs): processing pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Add authenticated chunked transcription-job submission APIs for opening
   attempts, accepting durable chunks, finalizing composed audio to queued jobs,
   and reading upload progress.
+- Add the backend transcription-job processing worker, including leased job
+  claiming, OpenAI transcription requests, FFmpeg-backed audio slicing,
+  coarse segment materialization, backend-owned retries, and terminal failure
+  classification. Until #27 lands, this implementation can reach `succeeded`
+  after voice-note/version/segment materialization without a current embedding;
+  that remains a v0.1.0 release-blocker deviation.
 - Add authenticated tag and session management APIs, including owner-scoped
   CRUD, shared cursor pagination, case-insensitive tag identity with
   latest-spelling display updates, and metadata deletion cascades.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Harden transcription worker reliability so stalled OpenAI requests enter the
+  backend retry path, processing leases renew during long transcriptions,
+  successful retries expose no stale failure metadata, failed sliced
+  transcriptions release generated slice files, and queued chunked jobs are
+  claimed by finalize order.
 - Add authenticated chunked transcription-job submission APIs for opening
   attempts, accepting durable chunks, finalizing composed audio to queued jobs,
   and reading upload progress.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -171,6 +171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,8 +471,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -476,9 +484,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -622,6 +632,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -630,13 +657,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -761,6 +796,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +823,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -854,6 +907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +948,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -993,6 +1062,7 @@ dependencies = [
  "base64",
  "caseless",
  "form_urlencoded",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1137,6 +1207,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1377,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1467,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1419,6 +1639,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -1698,6 +1928,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1818,6 +2051,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1832,6 +2066,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1898,6 +2142,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1975,6 +2237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +2257,12 @@ dependencies = [
  "rand 0.9.4",
  "web-time",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -2022,6 +2296,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2058,6 +2338,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2100,6 +2389,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2169,6 +2468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,6 +2485,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2200,7 +2518,25 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2218,13 +2554,46 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2234,10 +2603,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2246,10 +2639,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2258,16 +2687,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,6 +11,7 @@ axum = { version = "0.8.9", features = ["multipart"] }
 base64 = "0.22"
 caseless = "0.2.2"
 form_urlencoded = "1.2"
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -18,7 +19,7 @@ sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio
 subtle = "2.6"
 thiserror = "2.0"
 time = { version = "0.3.47", features = ["formatting", "macros", "parsing"] }
-tokio = { version = "1.48", features = ["fs", "io-util", "macros", "rt-multi-thread", "net"] }
+tokio = { version = "1.48", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread"] }
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,8 +20,9 @@ Startup fails unless `api_keys` contains at least one valid operator-provisioned
 key, `accepted_audio_dir` already exists as a writable directory, and
 `database_path` points to a SQLite database file whose parent directory exists
 and is writable. `OPENAI_API_KEY` must also be set to a non-empty environment
-value. Relative storage paths resolve from the real configuration file
-directory.
+value. `ffmpeg` and `ffprobe` must be available on `PATH`; the worker uses
+them for duration probing and format-safe request slicing. Relative storage
+paths resolve from the real configuration file directory.
 
 Every API route requires `Authorization: Bearer <api_key>`. The bearer scheme is
 case-insensitive, and missing or invalid keys return the shared JSON

--- a/backend/migrations/20260502000000_processing_leases.sql
+++ b/backend/migrations/20260502000000_processing_leases.sql
@@ -1,0 +1,8 @@
+ALTER TABLE transcription_jobs
+ADD COLUMN processing_lease_token TEXT;
+
+ALTER TABLE transcription_jobs
+ADD COLUMN processing_lease_expires_at TEXT;
+
+CREATE INDEX transcription_jobs_processing_lease_idx
+    ON transcription_jobs (status, processing_lease_expires_at, next_attempt_at, created_at, id);

--- a/backend/migrations/20260503000000_job_acceptance_ordering.sql
+++ b/backend/migrations/20260503000000_job_acceptance_ordering.sql
@@ -1,0 +1,16 @@
+ALTER TABLE transcription_jobs
+ADD COLUMN accepted_at TEXT;
+
+UPDATE transcription_jobs
+SET accepted_at = updated_at
+WHERE status IN ('queued', 'processing', 'retry_waiting', 'succeeded', 'failed')
+    AND accepted_at IS NULL;
+
+DROP INDEX IF EXISTS transcription_jobs_ready_idx;
+DROP INDEX IF EXISTS transcription_jobs_processing_lease_idx;
+
+CREATE INDEX transcription_jobs_ready_idx
+    ON transcription_jobs (status, next_attempt_at, accepted_at, id);
+
+CREATE INDEX transcription_jobs_processing_lease_idx
+    ON transcription_jobs (status, processing_lease_expires_at, next_attempt_at, accepted_at, id);

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -22,6 +22,8 @@ pub enum BootstrapError {
     MissingOpenAiApiKeyEnv,
     #[error("{OPENAI_API_KEY_ENV_VAR} must not be empty")]
     EmptyOpenAiApiKeyEnv,
+    #[error("required media tool is unavailable: {tool}")]
+    MissingMediaTool { tool: &'static str },
     #[error("failed to read config file {path}: {source}")]
     ReadConfig {
         path: PathBuf,
@@ -58,11 +60,19 @@ pub async fn load_runtime_from_env() -> Result<(std::net::SocketAddr, AppState),
         return Err(BootstrapError::EmptyOpenAiApiKeyEnv);
     }
 
-    load_runtime_from_path(Path::new(&config_path)).await
+    let openai_api_key = openai_api_key.to_string_lossy().into_owned();
+    load_runtime_from_path_with_openai_key(Path::new(&config_path), openai_api_key).await
 }
 
 pub async fn load_runtime_from_path(
     config_path: &Path,
+) -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
+    load_runtime_from_path_with_openai_key(config_path, "test-openai-key".to_owned()).await
+}
+
+async fn load_runtime_from_path_with_openai_key(
+    config_path: &Path,
+    openai_api_key: String,
 ) -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
     let raw = fs::read_to_string(config_path).map_err(|source| BootstrapError::ReadConfig {
         path: config_path.to_path_buf(),
@@ -87,6 +97,8 @@ pub async fn load_runtime_from_path(
     );
 
     validate_settings(&settings)?;
+    ensure_media_tool("ffmpeg")?;
+    ensure_media_tool("ffprobe")?;
     ensure_writable_directory(&settings.accepted_audio_dir)?;
     let auth_store = AuthStore::try_from_configs(&settings.api_keys)
         .map_err(|error| BootstrapError::InvalidConfiguration(error.to_string()))?;
@@ -95,10 +107,23 @@ pub async fn load_runtime_from_path(
     let state = AppState {
         accepted_audio_dir: settings.accepted_audio_dir.clone(),
         auth_store: Arc::new(auth_store),
+        openai_api_key,
         storage,
     };
 
     Ok((settings.listen_addr, state))
+}
+
+fn ensure_media_tool(tool: &'static str) -> Result<(), BootstrapError> {
+    match std::process::Command::new(tool)
+        .arg("-version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+    {
+        Ok(status) if status.success() => Ok(()),
+        _ => Err(BootstrapError::MissingMediaTool { tool }),
+    }
 }
 
 fn resolve_config_relative_path(

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -14,4 +14,5 @@ pub mod settings;
 pub mod state;
 pub mod storage;
 pub mod transcription_jobs;
+pub mod transcription_worker;
 pub mod voice_notes;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,6 +2,10 @@ use std::net::SocketAddr;
 
 use oracy_backend::bootstrap::load_runtime_from_env;
 use oracy_backend::router::build_router;
+use oracy_backend::transcription_worker::{
+    FfmpegAudioSlicer, FfprobeDurationProbe, OpenAiTranscriptionEngine, WorkerConfig,
+    run_worker_loop,
+};
 use tracing::error;
 
 #[tokio::main]
@@ -16,6 +20,18 @@ async fn main() {
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let (listen_addr, state) = load_runtime_from_env().await?;
+    let worker_storage = state.storage.clone();
+    let worker_engine = OpenAiTranscriptionEngine::new(
+        "https://api.openai.com".to_owned(),
+        state.openai_api_key.clone(),
+        FfmpegAudioSlicer::openai_limit(),
+    );
+    tokio::spawn(run_worker_loop(
+        worker_storage,
+        worker_engine,
+        FfprobeDurationProbe,
+        WorkerConfig::default(),
+    ));
     serve(listen_addr, build_router(state)).await
 }
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,16 +1,30 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::{fmt, fmt::Debug};
 
 use axum::extract::FromRef;
 
 use crate::auth::AuthStore;
 use crate::storage::Storage;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct AppState {
     pub accepted_audio_dir: PathBuf,
     pub auth_store: Arc<AuthStore>,
+    pub openai_api_key: String,
     pub storage: Storage,
+}
+
+impl Debug for AppState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AppState")
+            .field("accepted_audio_dir", &self.accepted_audio_dir)
+            .field("auth_store", &self.auth_store)
+            .field("openai_api_key", &"<redacted>")
+            .field("storage", &self.storage)
+            .finish()
+    }
 }
 
 impl FromRef<AppState> for Arc<AuthStore> {

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -103,6 +103,12 @@ pub enum FinalizeJobOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryOutcome {
+    RetryWaiting(TranscriptionJobRecord),
+    Failed(TranscriptionJobRecord),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CreateTagOutcome {
     Created(TagRecord),
     Existing(TagRecord),
@@ -175,6 +181,28 @@ pub struct AcceptedChunk {
 }
 
 #[derive(Debug, Clone)]
+pub struct TransientJobFailure {
+    pub api_key_id: String,
+    pub job_id: String,
+    pub lease_token: String,
+    pub failure_code: String,
+    pub failure_message: String,
+    pub now: OffsetDateTime,
+    pub next_attempt_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct TerminalJobFailure {
+    pub api_key_id: String,
+    pub job_id: String,
+    pub lease_token: String,
+    pub failure_code: String,
+    pub failure_message: String,
+    pub retryable_by_client: bool,
+    pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
 pub struct NewTag {
     pub id: String,
     pub api_key_id: String,
@@ -214,6 +242,8 @@ pub struct TranscriptionJobRecord {
     pub chunk_count: i64,
     pub audio_format: String,
     pub transcription_model: String,
+    pub processing_lease_token: Option<String>,
+    pub processing_lease_expires_at: Option<OffsetDateTime>,
     pub chunks_received: i64,
 }
 
@@ -230,7 +260,7 @@ pub struct VoiceNoteMaterialization {
     pub voice_note: NewVoiceNote,
     pub initial_version: NewVoiceNoteVersion,
     pub segments: Vec<NewSegment>,
-    pub embedding: NewEmbedding,
+    pub embedding: Option<NewEmbedding>,
 }
 
 #[derive(Debug, Clone)]
@@ -816,10 +846,102 @@ impl Storage {
         Ok(FinalizeJobOutcome::Accepted(job))
     }
 
+    pub async fn claim_next_transcription_job(
+        &self,
+        lease_token: &str,
+        now: OffsetDateTime,
+        lease_expires_at: OffsetDateTime,
+    ) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let now_text = format_timestamp(now)?;
+        let lease_expires_at_text = format_timestamp(lease_expires_at)?;
+
+        let candidate = sqlx::query(
+            r#"
+            SELECT * FROM transcription_jobs
+            WHERE status = 'queued'
+                OR (status = 'retry_waiting' AND julianday(next_attempt_at) <= julianday(?))
+                OR (status = 'processing' AND julianday(processing_lease_expires_at) < julianday(?))
+            ORDER BY
+                CASE status
+                    WHEN 'processing' THEN 0
+                    WHEN 'retry_waiting' THEN 1
+                    ELSE 2
+                END,
+                created_at ASC,
+                id ASC
+            LIMIT 1
+            "#,
+        )
+        .bind(&now_text)
+        .bind(&now_text)
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(job_from_row)
+        .transpose()?;
+
+        let Some(candidate) = candidate else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+
+        sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'processing',
+                next_attempt_at = NULL,
+                processing_lease_token = ?,
+                processing_lease_expires_at = ?,
+                updated_at = ?
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(lease_token)
+        .bind(&lease_expires_at_text)
+        .bind(&now_text)
+        .bind(&candidate.api_key_id)
+        .bind(&candidate.id)
+        .execute(&mut *tx)
+        .await?;
+
+        let claimed = select_job_by_id(&mut tx, &candidate.api_key_id, &candidate.id)
+            .await?
+            .expect("claimed job remains visible");
+        tx.commit().await?;
+        Ok(Some(claimed))
+    }
+
     pub async fn complete_job_with_voice_note(
         &self,
         api_key_id: &str,
         job_id: &str,
+        materialization: VoiceNoteMaterialization,
+    ) -> Result<(), StorageError> {
+        self.complete_job_with_voice_note_by_lease(api_key_id, job_id, None, materialization)
+            .await
+    }
+
+    pub async fn complete_leased_job_with_voice_note(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        lease_token: &str,
+        materialization: VoiceNoteMaterialization,
+    ) -> Result<(), StorageError> {
+        self.complete_job_with_voice_note_by_lease(
+            api_key_id,
+            job_id,
+            Some(lease_token),
+            materialization,
+        )
+        .await
+    }
+
+    async fn complete_job_with_voice_note_by_lease(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        lease_token: Option<&str>,
         materialization: VoiceNoteMaterialization,
     ) -> Result<(), StorageError> {
         let mut tx = self.pool.begin().await?;
@@ -827,22 +949,17 @@ impl Storage {
         let version = materialization.initial_version;
         let now = format_timestamp(voice_note.created_at)?;
 
-        let result = sqlx::query(
-            r#"
-            UPDATE transcription_jobs
-            SET updated_at = ?
-            WHERE api_key_id = ?
-                AND id = ?
-                AND status = 'processing'
-                AND voice_note_id IS NULL
-            "#,
-        )
-        .bind(&now)
-        .bind(api_key_id)
-        .bind(job_id)
-        .execute(&mut *tx)
-        .await?;
-        if result.rows_affected() != 1 {
+        let Some(job) = select_job_by_id(&mut tx, api_key_id, job_id).await? else {
+            return Err(StorageError::JobNotCompletable {
+                job_id: job_id.to_owned(),
+            });
+        };
+        if job.status != "processing"
+            || job.voice_note_id.is_some()
+            || lease_token.is_some_and(|lease_token| {
+                job.processing_lease_token.as_deref() != Some(lease_token)
+            })
+        {
             return Err(StorageError::JobNotCompletable {
                 job_id: job_id.to_owned(),
             });
@@ -926,24 +1043,30 @@ impl Storage {
             .await?;
         }
 
-        sqlx::query(
-            r#"
-            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
-            VALUES (?, ?, ?, ?, ?)
-            "#,
-        )
-        .bind(&voice_note.id)
-        .bind(api_key_id)
-        .bind(&materialization.embedding.model)
-        .bind(&materialization.embedding.vector)
-        .bind(format_timestamp(materialization.embedding.created_at)?)
-        .execute(&mut *tx)
-        .await?;
+        if let Some(embedding) = materialization.embedding {
+            sqlx::query(
+                r#"
+                INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(&voice_note.id)
+            .bind(api_key_id)
+            .bind(&embedding.model)
+            .bind(&embedding.vector)
+            .bind(format_timestamp(embedding.created_at)?)
+            .execute(&mut *tx)
+            .await?;
+        }
 
         let result = sqlx::query(
             r#"
             UPDATE transcription_jobs
-            SET status = 'succeeded', voice_note_id = ?, updated_at = ?
+            SET status = 'succeeded',
+                voice_note_id = ?,
+                processing_lease_token = NULL,
+                processing_lease_expires_at = NULL,
+                updated_at = ?
             WHERE api_key_id = ?
                 AND id = ?
                 AND status = 'processing'
@@ -964,6 +1087,138 @@ impl Storage {
 
         tx.commit().await?;
         Ok(())
+    }
+
+    pub async fn record_transient_job_failure(
+        &self,
+        failure: TransientJobFailure,
+    ) -> Result<RetryOutcome, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let Some(job) = select_job_by_id(&mut tx, &failure.api_key_id, &failure.job_id).await?
+        else {
+            return Err(StorageError::JobNotCompletable {
+                job_id: failure.job_id,
+            });
+        };
+        if job.status != "processing"
+            || job.processing_lease_token.as_deref() != Some(failure.lease_token.as_str())
+        {
+            return Err(StorageError::JobNotCompletable {
+                job_id: failure.job_id,
+            });
+        }
+
+        let retry_count = job.retry_count + 1;
+        let now = format_timestamp(failure.now)?;
+        if retry_count >= job.max_retries {
+            sqlx::query(
+                r#"
+                UPDATE transcription_jobs
+                SET status = 'failed',
+                    retry_count = ?,
+                    next_attempt_at = NULL,
+                    failure_code = ?,
+                    failure_message = ?,
+                    retryable_by_client = 1,
+                    processing_lease_token = NULL,
+                    processing_lease_expires_at = NULL,
+                    updated_at = ?
+                WHERE api_key_id = ? AND id = ? AND status = 'processing'
+                "#,
+            )
+            .bind(retry_count)
+            .bind(&failure.failure_code)
+            .bind(&failure.failure_message)
+            .bind(&now)
+            .bind(&failure.api_key_id)
+            .bind(&failure.job_id)
+            .execute(&mut *tx)
+            .await?;
+            let failed = select_job_by_id(&mut tx, &failure.api_key_id, &failure.job_id)
+                .await?
+                .expect("failed job remains visible");
+            tx.commit().await?;
+            return Ok(RetryOutcome::Failed(failed));
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'retry_waiting',
+                retry_count = ?,
+                next_attempt_at = ?,
+                failure_code = ?,
+                failure_message = ?,
+                retryable_by_client = NULL,
+                processing_lease_token = NULL,
+                processing_lease_expires_at = NULL,
+                updated_at = ?
+            WHERE api_key_id = ? AND id = ? AND status = 'processing'
+            "#,
+        )
+        .bind(retry_count)
+        .bind(format_timestamp(failure.next_attempt_at)?)
+        .bind(&failure.failure_code)
+        .bind(&failure.failure_message)
+        .bind(&now)
+        .bind(&failure.api_key_id)
+        .bind(&failure.job_id)
+        .execute(&mut *tx)
+        .await?;
+        let retry_waiting = select_job_by_id(&mut tx, &failure.api_key_id, &failure.job_id)
+            .await?
+            .expect("retry-waiting job remains visible");
+        tx.commit().await?;
+        Ok(RetryOutcome::RetryWaiting(retry_waiting))
+    }
+
+    pub async fn fail_leased_job(
+        &self,
+        failure: TerminalJobFailure,
+    ) -> Result<TranscriptionJobRecord, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let Some(job) = select_job_by_id(&mut tx, &failure.api_key_id, &failure.job_id).await?
+        else {
+            return Err(StorageError::JobNotCompletable {
+                job_id: failure.job_id,
+            });
+        };
+        if job.status != "processing"
+            || job.processing_lease_token.as_deref() != Some(failure.lease_token.as_str())
+        {
+            return Err(StorageError::JobNotCompletable {
+                job_id: failure.job_id,
+            });
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'failed',
+                next_attempt_at = NULL,
+                failure_code = ?,
+                failure_message = ?,
+                retryable_by_client = ?,
+                processing_lease_token = NULL,
+                processing_lease_expires_at = NULL,
+                updated_at = ?
+            WHERE api_key_id = ? AND id = ? AND status = 'processing'
+            "#,
+        )
+        .bind(&failure.failure_code)
+        .bind(&failure.failure_message)
+        .bind(if failure.retryable_by_client { 1 } else { 0 })
+        .bind(format_timestamp(failure.now)?)
+        .bind(&failure.api_key_id)
+        .bind(&failure.job_id)
+        .execute(&mut *tx)
+        .await?;
+
+        let failed = select_job_by_id(&mut tx, &failure.api_key_id, &failure.job_id)
+            .await?
+            .expect("failed job remains visible");
+        tx.commit().await?;
+        Ok(failed)
     }
 
     pub async fn get_voice_note(
@@ -1981,6 +2236,11 @@ fn job_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptionJobRecord, 
         chunk_count: row.try_get("chunk_count")?,
         audio_format: row.try_get("audio_format")?,
         transcription_model: row.try_get("transcription_model")?,
+        processing_lease_token: row.try_get("processing_lease_token")?,
+        processing_lease_expires_at: row
+            .try_get::<Option<String>, _>("processing_lease_expires_at")?
+            .map(parse_timestamp)
+            .transpose()?,
         chunks_received: optional_i64(&row, "chunks_received")?.unwrap_or(0),
     })
 }

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -537,9 +537,9 @@ impl Storage {
                 id, api_key_id, idempotency_key, audio_sha256_hex,
                 audio_content_hash_algorithm, recorded_at, session_id, language,
                 accepted_audio_path, status, created_at, updated_at, retry_count,
-                max_retries
+                max_retries, accepted_at
             )
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?, ?
             WHERE ? IS NULL
                 OR EXISTS (
                     SELECT 1 FROM sessions
@@ -560,6 +560,7 @@ impl Storage {
         .bind(&now)
         .bind(&now)
         .bind(input.max_retries)
+        .bind(&now)
         .bind(&input.session_id)
         .bind(&input.api_key_id)
         .bind(&input.session_id)
@@ -827,6 +828,7 @@ impl Storage {
                 accepted_audio_path = ?,
                 transcription_model = ?,
                 status = 'queued',
+                accepted_at = ?,
                 updated_at = ?
             WHERE api_key_id = ? AND id = ? AND status = 'accepting_chunks'
             "#,
@@ -834,6 +836,7 @@ impl Storage {
         .bind(audio_sha256_hex)
         .bind(accepted_audio_path)
         .bind(transcription_model)
+        .bind(&now)
         .bind(&now)
         .bind(api_key_id)
         .bind(job_id)
@@ -868,7 +871,9 @@ impl Storage {
                     WHEN 'retry_waiting' THEN 1
                     ELSE 2
                 END,
-                created_at ASC,
+                CASE WHEN status = 'processing' THEN processing_lease_expires_at END ASC,
+                CASE WHEN status = 'retry_waiting' THEN next_attempt_at END ASC,
+                COALESCE(accepted_at, created_at) ASC,
                 id ASC
             LIMIT 1
             "#,
@@ -909,6 +914,35 @@ impl Storage {
             .expect("claimed job remains visible");
         tx.commit().await?;
         Ok(Some(claimed))
+    }
+
+    pub async fn renew_processing_lease(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        lease_token: &str,
+        _now: OffsetDateTime,
+        lease_expires_at: OffsetDateTime,
+    ) -> Result<bool, StorageError> {
+        let lease_expires_at_text = format_timestamp(lease_expires_at)?;
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET processing_lease_expires_at = ?
+            WHERE api_key_id = ?
+                AND id = ?
+                AND status = 'processing'
+                AND processing_lease_token = ?
+            "#,
+        )
+        .bind(&lease_expires_at_text)
+        .bind(api_key_id)
+        .bind(job_id)
+        .bind(lease_token)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
     }
 
     pub async fn complete_job_with_voice_note(
@@ -1064,6 +1098,10 @@ impl Storage {
             UPDATE transcription_jobs
             SET status = 'succeeded',
                 voice_note_id = ?,
+                next_attempt_at = NULL,
+                failure_code = NULL,
+                failure_message = NULL,
+                retryable_by_client = NULL,
                 processing_lease_token = NULL,
                 processing_lease_expires_at = NULL,
                 updated_at = ?

--- a/backend/src/transcription_worker.rs
+++ b/backend/src/transcription_worker.rs
@@ -1,0 +1,595 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use reqwest::StatusCode;
+use serde::Deserialize;
+use thiserror::Error;
+use time::{Duration, OffsetDateTime};
+use tokio::process::Command;
+use ulid::Ulid;
+
+use crate::storage::{
+    NewSegment, NewVoiceNote, NewVoiceNoteVersion, RetryOutcome, Storage, StorageError,
+    TerminalJobFailure, TransientJobFailure, VoiceNoteMaterialization,
+};
+
+#[derive(Debug, Clone)]
+pub struct WorkerConfig {
+    pub lease_duration: Duration,
+    pub idle_sleep: std::time::Duration,
+    pub error_sleep: std::time::Duration,
+}
+
+impl WorkerConfig {
+    pub fn test() -> Self {
+        Self {
+            lease_duration: Duration::minutes(5),
+            idle_sleep: std::time::Duration::from_millis(10),
+            error_sleep: std::time::Duration::from_millis(10),
+        }
+    }
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            lease_duration: Duration::minutes(5),
+            idle_sleep: std::time::Duration::from_secs(5),
+            error_sleep: std::time::Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessOutcome {
+    NoJob,
+    Succeeded { job_id: String },
+    RetryWaiting { job_id: String },
+    Failed { job_id: String },
+}
+
+#[derive(Debug, Error)]
+pub enum WorkerError {
+    #[error("{0}")]
+    Storage(#[from] StorageError),
+    #[error("failed to read accepted audio metadata: {0}")]
+    AudioMetadata(std::io::Error),
+    #[error("duration probe failed: {0}")]
+    DurationProbe(#[from] DurationProbeError),
+    #[error("transcription engine failed: {0}")]
+    Engine(#[from] EngineFailure),
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptionInput {
+    pub audio_path: PathBuf,
+    pub audio_format: String,
+    pub language: Option<String>,
+    pub model: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptionOutput {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum EngineFailure {
+    #[error("transient engine failure: {message}")]
+    Transient {
+        failure_code: String,
+        message: String,
+        retry_after_seconds: Option<i64>,
+    },
+    #[error("terminal engine failure: {failure_code}: {message}")]
+    Terminal {
+        failure_code: String,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum DurationProbeError {
+    #[error("audio duration could not be derived")]
+    InvalidAudio,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AudioSliceError {
+    #[error("audio could not be sliced")]
+    InvalidAudio,
+    #[error("slicer failed: {0}")]
+    Failed(String),
+}
+
+#[allow(async_fn_in_trait)]
+pub trait TranscriptionEngine {
+    async fn transcribe(
+        &self,
+        input: TranscriptionInput,
+    ) -> Result<TranscriptionOutput, EngineFailure>;
+}
+
+#[allow(async_fn_in_trait)]
+pub trait AudioSlicer {
+    async fn slices(
+        &self,
+        input: &Path,
+        audio_format: &str,
+    ) -> Result<Vec<PathBuf>, AudioSliceError>;
+}
+
+#[allow(async_fn_in_trait)]
+pub trait DurationProbe {
+    async fn duration_ms(
+        &self,
+        input: &Path,
+        audio_format: &str,
+    ) -> Result<i64, DurationProbeError>;
+}
+
+#[derive(Clone)]
+pub struct OpenAiTranscriptionEngine<S> {
+    base_url: String,
+    api_key: String,
+    slicer: S,
+    client: reqwest::Client,
+}
+
+impl<S> OpenAiTranscriptionEngine<S> {
+    pub fn new(base_url: String, api_key: String, slicer: S) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_owned(),
+            api_key,
+            slicer,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl<S> TranscriptionEngine for OpenAiTranscriptionEngine<S>
+where
+    S: AudioSlicer + Sync,
+{
+    async fn transcribe(
+        &self,
+        input: TranscriptionInput,
+    ) -> Result<TranscriptionOutput, EngineFailure> {
+        let slices = self
+            .slicer
+            .slices(&input.audio_path, &input.audio_format)
+            .await
+            .map_err(|error| EngineFailure::Terminal {
+                failure_code: "audio_invalid".to_owned(),
+                message: error.to_string(),
+            })?;
+        let mut texts = Vec::with_capacity(slices.len());
+        for slice in &slices {
+            texts.push(self.transcribe_slice(&input, slice).await?);
+        }
+        cleanup_generated_slices(&input.audio_path, &slices).await;
+        Ok(TranscriptionOutput {
+            text: texts.join("\n"),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FfprobeDurationProbe;
+
+impl DurationProbe for FfprobeDurationProbe {
+    async fn duration_ms(
+        &self,
+        input: &Path,
+        _audio_format: &str,
+    ) -> Result<i64, DurationProbeError> {
+        let output = Command::new("ffprobe")
+            .arg("-v")
+            .arg("error")
+            .arg("-show_entries")
+            .arg("format=duration")
+            .arg("-of")
+            .arg("default=noprint_wrappers=1:nokey=1")
+            .arg(input)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|_| DurationProbeError::InvalidAudio)?;
+        if !output.status.success() {
+            return Err(DurationProbeError::InvalidAudio);
+        }
+        let raw = String::from_utf8_lossy(&output.stdout);
+        let seconds = raw
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| DurationProbeError::InvalidAudio)?;
+        if !seconds.is_finite() || seconds < 0.0 {
+            return Err(DurationProbeError::InvalidAudio);
+        }
+        Ok((seconds * 1_000.0).round() as i64)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FfmpegAudioSlicer {
+    max_slice_bytes: u64,
+}
+
+impl FfmpegAudioSlicer {
+    pub const OPENAI_MAX_AUDIO_BYTES: u64 = 26_214_400;
+
+    pub fn openai_limit() -> Self {
+        Self {
+            max_slice_bytes: Self::OPENAI_MAX_AUDIO_BYTES,
+        }
+    }
+
+    pub fn with_max_slice_bytes(max_slice_bytes: u64) -> Self {
+        Self { max_slice_bytes }
+    }
+}
+
+impl AudioSlicer for FfmpegAudioSlicer {
+    async fn slices(
+        &self,
+        input: &Path,
+        audio_format: &str,
+    ) -> Result<Vec<PathBuf>, AudioSliceError> {
+        let size = tokio::fs::metadata(input)
+            .await
+            .map_err(|error| AudioSliceError::Failed(error.to_string()))?
+            .len();
+        if size <= self.max_slice_bytes {
+            return Ok(vec![input.to_path_buf()]);
+        }
+
+        let duration_ms = FfprobeDurationProbe
+            .duration_ms(input, audio_format)
+            .await
+            .map_err(|_| AudioSliceError::InvalidAudio)?;
+        let base_part_count = size.div_ceil(self.max_slice_bytes).max(1);
+        let duration_seconds = duration_ms as f64 / 1_000.0;
+        let parent = input.parent().ok_or_else(|| {
+            AudioSliceError::Failed("accepted audio path has no parent directory".to_owned())
+        })?;
+
+        for multiplier in [1_u64, 2, 4, 8] {
+            let part_count = base_part_count * multiplier;
+            let part_seconds = duration_seconds / part_count as f64;
+            let slice_dir = parent.join(format!(".oracy-slices-{}", Ulid::new()));
+            tokio::fs::create_dir(&slice_dir)
+                .await
+                .map_err(|error| AudioSliceError::Failed(error.to_string()))?;
+
+            let mut slices = Vec::new();
+            for index in 0..part_count {
+                let start = index as f64 * part_seconds;
+                let length = if index == part_count - 1 {
+                    (duration_seconds - start).max(0.001)
+                } else {
+                    part_seconds.max(0.001)
+                };
+                let output_path = slice_dir.join(format!("slice-{index}.{audio_format}"));
+                let output = Command::new("ffmpeg")
+                    .arg("-hide_banner")
+                    .arg("-loglevel")
+                    .arg("error")
+                    .arg("-y")
+                    .arg("-ss")
+                    .arg(format!("{start:.3}"))
+                    .arg("-t")
+                    .arg(format!("{length:.3}"))
+                    .arg("-i")
+                    .arg(input)
+                    .arg(&output_path)
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::piped())
+                    .output()
+                    .await
+                    .map_err(|error| AudioSliceError::Failed(error.to_string()))?;
+                if !output.status.success() {
+                    cleanup_generated_slices(input, &slices).await;
+                    let _ = tokio::fs::remove_dir(&slice_dir).await;
+                    let message = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+                    return Err(AudioSliceError::Failed(message));
+                }
+                slices.push(output_path);
+            }
+
+            let mut all_under_limit = true;
+            for slice in &slices {
+                let slice_size = tokio::fs::metadata(slice)
+                    .await
+                    .map_err(|error| AudioSliceError::Failed(error.to_string()))?
+                    .len();
+                if slice_size > self.max_slice_bytes {
+                    all_under_limit = false;
+                    break;
+                }
+            }
+            if all_under_limit {
+                return Ok(slices);
+            }
+            cleanup_generated_slices(input, &slices).await;
+        }
+        Err(AudioSliceError::Failed(
+            "ffmpeg slices remained over the per-request byte limit".to_owned(),
+        ))
+    }
+}
+
+async fn cleanup_generated_slices(original: &Path, slices: &[PathBuf]) {
+    let original = original.to_path_buf();
+    let mut parents = HashSet::new();
+    for slice in slices {
+        if slice != &original {
+            if let Some(parent) = slice.parent() {
+                parents.insert(parent.to_path_buf());
+            }
+            let _ = tokio::fs::remove_file(slice).await;
+        }
+    }
+    for parent in parents {
+        let _ = tokio::fs::remove_dir(parent).await;
+    }
+}
+
+impl<S> OpenAiTranscriptionEngine<S> {
+    async fn transcribe_slice(
+        &self,
+        input: &TranscriptionInput,
+        slice: &Path,
+    ) -> Result<String, EngineFailure> {
+        let bytes = tokio::fs::read(slice)
+            .await
+            .map_err(|error| EngineFailure::Terminal {
+                failure_code: "storage_error".to_owned(),
+                message: format!("failed to read audio slice: {error}"),
+            })?;
+        let filename = slice
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("audio")
+            .to_owned();
+        let mut form = reqwest::multipart::Form::new()
+            .text("model", input.model.clone())
+            .part(
+                "file",
+                reqwest::multipart::Part::bytes(bytes).file_name(filename),
+            );
+        if let Some(language) = input.language.as_deref() {
+            form = form.text("language", language.to_owned());
+        }
+
+        let response = self
+            .client
+            .post(format!("{}/v1/audio/transcriptions", self.base_url))
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|error| EngineFailure::Transient {
+                failure_code: "engine_error".to_owned(),
+                message: error.to_string(),
+                retry_after_seconds: None,
+            })?;
+
+        if !response.status().is_success() {
+            return Err(classify_openai_error(response).await);
+        }
+
+        let body = response
+            .json::<OpenAiTranscriptionResponse>()
+            .await
+            .map_err(|error| EngineFailure::Transient {
+                failure_code: "engine_error".to_owned(),
+                message: format!("OpenAI transcription response was invalid: {error}"),
+                retry_after_seconds: None,
+            })?;
+        Ok(body.text)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiTranscriptionResponse {
+    text: String,
+}
+
+async fn classify_openai_error(response: reqwest::Response) -> EngineFailure {
+    let status = response.status();
+    let retry_after_seconds = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<i64>().ok());
+    let message = response
+        .text()
+        .await
+        .unwrap_or_else(|_| format!("OpenAI transcription request failed with {status}"));
+
+    match status {
+        StatusCode::REQUEST_TIMEOUT => EngineFailure::Transient {
+            failure_code: "engine_timeout".to_owned(),
+            message,
+            retry_after_seconds,
+        },
+        StatusCode::TOO_MANY_REQUESTS => EngineFailure::Transient {
+            failure_code: "engine_rate_limited".to_owned(),
+            message,
+            retry_after_seconds,
+        },
+        status if status.is_server_error() => EngineFailure::Transient {
+            failure_code: "engine_error".to_owned(),
+            message,
+            retry_after_seconds,
+        },
+        StatusCode::BAD_REQUEST | StatusCode::UNSUPPORTED_MEDIA_TYPE => EngineFailure::Terminal {
+            failure_code: "audio_invalid".to_owned(),
+            message,
+        },
+        _ => EngineFailure::Terminal {
+            failure_code: "engine_error".to_owned(),
+            message,
+        },
+    }
+}
+
+pub async fn process_one_available_job<E, D>(
+    storage: &Storage,
+    engine: &E,
+    duration_probe: &D,
+    config: WorkerConfig,
+) -> Result<ProcessOutcome, WorkerError>
+where
+    E: TranscriptionEngine,
+    D: DurationProbe,
+{
+    let now = OffsetDateTime::now_utc();
+    let lease_token = Ulid::new().to_string();
+    let Some(job) = storage
+        .claim_next_transcription_job(&lease_token, now, now + config.lease_duration)
+        .await?
+    else {
+        return Ok(ProcessOutcome::NoJob);
+    };
+
+    let duration_ms = match duration_probe
+        .duration_ms(&job.accepted_audio_path, &job.audio_format)
+        .await
+    {
+        Ok(duration_ms) => duration_ms,
+        Err(error) => {
+            storage
+                .fail_leased_job(TerminalJobFailure {
+                    api_key_id: job.api_key_id.clone(),
+                    job_id: job.id.clone(),
+                    lease_token: lease_token.clone(),
+                    failure_code: "audio_invalid".to_owned(),
+                    failure_message: error.to_string(),
+                    retryable_by_client: false,
+                    now: OffsetDateTime::now_utc(),
+                })
+                .await?;
+            return Ok(ProcessOutcome::Failed { job_id: job.id });
+        }
+    };
+    let transcription = match engine
+        .transcribe(TranscriptionInput {
+            audio_path: job.accepted_audio_path.clone(),
+            audio_format: job.audio_format.clone(),
+            language: job.language.clone(),
+            model: job.transcription_model.clone(),
+        })
+        .await
+    {
+        Ok(transcription) => transcription,
+        Err(EngineFailure::Transient {
+            failure_code,
+            message,
+            retry_after_seconds,
+        }) => {
+            let now = OffsetDateTime::now_utc();
+            let next_attempt_at = now + Duration::seconds(retry_after_seconds.unwrap_or(60).max(1));
+            let outcome = storage
+                .record_transient_job_failure(TransientJobFailure {
+                    api_key_id: job.api_key_id.clone(),
+                    job_id: job.id.clone(),
+                    lease_token: lease_token.clone(),
+                    failure_code,
+                    failure_message: message,
+                    now,
+                    next_attempt_at,
+                })
+                .await?;
+            return match outcome {
+                RetryOutcome::RetryWaiting(job) => {
+                    Ok(ProcessOutcome::RetryWaiting { job_id: job.id })
+                }
+                RetryOutcome::Failed(job) => Ok(ProcessOutcome::Failed { job_id: job.id }),
+            };
+        }
+        Err(EngineFailure::Terminal {
+            failure_code,
+            message,
+        }) => {
+            storage
+                .fail_leased_job(TerminalJobFailure {
+                    api_key_id: job.api_key_id.clone(),
+                    job_id: job.id.clone(),
+                    lease_token: lease_token.clone(),
+                    retryable_by_client: failure_code != "audio_invalid",
+                    failure_code,
+                    failure_message: message,
+                    now: OffsetDateTime::now_utc(),
+                })
+                .await?;
+            return Ok(ProcessOutcome::Failed { job_id: job.id });
+        }
+    };
+    let audio_size_bytes = tokio::fs::metadata(&job.accepted_audio_path)
+        .await
+        .map_err(WorkerError::AudioMetadata)?
+        .len() as i64;
+    let created_at = OffsetDateTime::now_utc();
+    let voice_note_id = Ulid::new().to_string();
+
+    storage
+        .complete_leased_job_with_voice_note(
+            &job.api_key_id,
+            &job.id,
+            &lease_token,
+            VoiceNoteMaterialization {
+                voice_note: NewVoiceNote {
+                    id: voice_note_id.clone(),
+                    audio_duration_seconds: duration_ms as f64 / 1_000.0,
+                    audio_format: job.audio_format.clone(),
+                    audio_size_bytes,
+                    language: job.language.clone(),
+                    model: job.transcription_model.clone(),
+                    processing_time_ms: (created_at - now).whole_milliseconds() as i64,
+                    cost_cents: None,
+                    created_at,
+                    recorded_at: job.recorded_at,
+                },
+                initial_version: NewVoiceNoteVersion {
+                    id: Ulid::new().to_string(),
+                    text: transcription.text.clone(),
+                    created_at,
+                },
+                segments: vec![NewSegment {
+                    id: Ulid::new().to_string(),
+                    position: 0,
+                    start_ms: 0,
+                    end_ms: duration_ms,
+                    text: transcription.text,
+                }],
+                embedding: None,
+            },
+        )
+        .await?;
+
+    Ok(ProcessOutcome::Succeeded { job_id: job.id })
+}
+
+pub async fn run_worker_loop<E, D>(
+    storage: Storage,
+    engine: E,
+    duration_probe: D,
+    config: WorkerConfig,
+) where
+    E: TranscriptionEngine + Sync,
+    D: DurationProbe + Sync,
+{
+    loop {
+        match process_one_available_job(&storage, &engine, &duration_probe, config.clone()).await {
+            Ok(ProcessOutcome::NoJob) => tokio::time::sleep(config.idle_sleep).await,
+            Ok(_) => {}
+            Err(error) => {
+                tracing::error!("transcription worker iteration failed: {error}");
+                tokio::time::sleep(config.error_sleep).await;
+            }
+        }
+    }
+}

--- a/backend/src/transcription_worker.rs
+++ b/backend/src/transcription_worker.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -14,9 +15,12 @@ use crate::storage::{
     TerminalJobFailure, TransientJobFailure, VoiceNoteMaterialization,
 };
 
+const DEFAULT_OPENAI_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 #[derive(Debug, Clone)]
 pub struct WorkerConfig {
     pub lease_duration: Duration,
+    pub lease_renewal_interval: std::time::Duration,
     pub idle_sleep: std::time::Duration,
     pub error_sleep: std::time::Duration,
 }
@@ -25,6 +29,7 @@ impl WorkerConfig {
     pub fn test() -> Self {
         Self {
             lease_duration: Duration::minutes(5),
+            lease_renewal_interval: std::time::Duration::from_secs(60),
             idle_sleep: std::time::Duration::from_millis(10),
             error_sleep: std::time::Duration::from_millis(10),
         }
@@ -35,6 +40,7 @@ impl Default for WorkerConfig {
     fn default() -> Self {
         Self {
             lease_duration: Duration::minutes(5),
+            lease_renewal_interval: std::time::Duration::from_secs(60),
             idle_sleep: std::time::Duration::from_secs(5),
             error_sleep: std::time::Duration::from_secs(30),
         }
@@ -53,6 +59,8 @@ pub enum ProcessOutcome {
 pub enum WorkerError {
     #[error("{0}")]
     Storage(#[from] StorageError),
+    #[error("processing lease was lost for transcription job {job_id}")]
+    LeaseLost { job_id: String },
     #[error("failed to read accepted audio metadata: {0}")]
     AudioMetadata(std::io::Error),
     #[error("duration probe failed: {0}")]
@@ -135,15 +143,26 @@ pub struct OpenAiTranscriptionEngine<S> {
     api_key: String,
     slicer: S,
     client: reqwest::Client,
+    request_timeout: std::time::Duration,
 }
 
 impl<S> OpenAiTranscriptionEngine<S> {
     pub fn new(base_url: String, api_key: String, slicer: S) -> Self {
+        Self::with_request_timeout(base_url, api_key, slicer, DEFAULT_OPENAI_REQUEST_TIMEOUT)
+    }
+
+    pub fn with_request_timeout(
+        base_url: String,
+        api_key: String,
+        slicer: S,
+        request_timeout: std::time::Duration,
+    ) -> Self {
         Self {
             base_url: base_url.trim_end_matches('/').to_owned(),
             api_key,
             slicer,
             client: reqwest::Client::new(),
+            request_timeout,
         }
     }
 }
@@ -164,14 +183,18 @@ where
                 failure_code: "audio_invalid".to_owned(),
                 message: error.to_string(),
             })?;
-        let mut texts = Vec::with_capacity(slices.len());
-        for slice in &slices {
-            texts.push(self.transcribe_slice(&input, slice).await?);
+        let result: Result<TranscriptionOutput, EngineFailure> = async {
+            let mut texts = Vec::with_capacity(slices.len());
+            for slice in &slices {
+                texts.push(self.transcribe_slice(&input, slice).await?);
+            }
+            Ok(TranscriptionOutput {
+                text: texts.join("\n"),
+            })
         }
+        .await;
         cleanup_generated_slices(&input.audio_path, &slices).await;
-        Ok(TranscriptionOutput {
-            text: texts.join("\n"),
-        })
+        result
     }
 }
 
@@ -368,12 +391,20 @@ impl<S> OpenAiTranscriptionEngine<S> {
             .post(format!("{}/v1/audio/transcriptions", self.base_url))
             .bearer_auth(&self.api_key)
             .multipart(form)
+            .timeout(self.request_timeout)
             .send()
             .await
-            .map_err(|error| EngineFailure::Transient {
-                failure_code: "engine_error".to_owned(),
-                message: error.to_string(),
-                retry_after_seconds: None,
+            .map_err(|error| {
+                let failure_code = if error.is_timeout() {
+                    "engine_timeout"
+                } else {
+                    "engine_error"
+                };
+                EngineFailure::Transient {
+                    failure_code: failure_code.to_owned(),
+                    message: error.to_string(),
+                    retry_after_seconds: None,
+                }
             })?;
 
         if !response.status().is_success() {
@@ -436,6 +467,61 @@ async fn classify_openai_error(response: reqwest::Response) -> EngineFailure {
     }
 }
 
+async fn run_with_processing_lease_renewal<T, F>(
+    storage: &Storage,
+    api_key_id: &str,
+    job_id: &str,
+    lease_token: &str,
+    config: &WorkerConfig,
+    work: F,
+) -> Result<T, WorkerError>
+where
+    F: Future<Output = T>,
+{
+    let renewal_interval = effective_lease_renewal_interval(config);
+    let mut renewal = tokio::time::interval_at(
+        tokio::time::Instant::now() + renewal_interval,
+        renewal_interval,
+    );
+    renewal.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    tokio::pin!(work);
+
+    loop {
+        tokio::select! {
+            biased;
+
+            result = &mut work => return Ok(result),
+            _ = renewal.tick() => {
+                let now = OffsetDateTime::now_utc();
+                let renewed = storage
+                    .renew_processing_lease(
+                        api_key_id,
+                        job_id,
+                        lease_token,
+                        now,
+                        now + config.lease_duration,
+                    )
+                    .await?;
+                if !renewed {
+                    return Err(WorkerError::LeaseLost {
+                        job_id: job_id.to_owned(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn effective_lease_renewal_interval(config: &WorkerConfig) -> std::time::Duration {
+    let configured = if config.lease_renewal_interval.is_zero() {
+        std::time::Duration::from_millis(1)
+    } else {
+        config.lease_renewal_interval
+    };
+    let half_lease_ms = (config.lease_duration.whole_milliseconds().max(1) as u64 / 2).max(1);
+    configured.min(std::time::Duration::from_millis(half_lease_ms))
+}
+
 pub async fn process_one_available_job<E, D>(
     storage: &Storage,
     engine: &E,
@@ -455,11 +541,31 @@ where
         return Ok(ProcessOutcome::NoJob);
     };
 
-    let duration_ms = match duration_probe
-        .duration_ms(&job.accepted_audio_path, &job.audio_format)
-        .await
-    {
-        Ok(duration_ms) => duration_ms,
+    let active_work = run_with_processing_lease_renewal(
+        storage,
+        &job.api_key_id,
+        &job.id,
+        &lease_token,
+        &config,
+        async {
+            let duration_ms = duration_probe
+                .duration_ms(&job.accepted_audio_path, &job.audio_format)
+                .await?;
+            let transcription = engine
+                .transcribe(TranscriptionInput {
+                    audio_path: job.accepted_audio_path.clone(),
+                    audio_format: job.audio_format.clone(),
+                    language: job.language.clone(),
+                    model: job.transcription_model.clone(),
+                })
+                .await;
+            Ok::<_, DurationProbeError>((duration_ms, transcription))
+        },
+    )
+    .await?;
+
+    let (duration_ms, transcription) = match active_work {
+        Ok(active_work) => active_work,
         Err(error) => {
             storage
                 .fail_leased_job(TerminalJobFailure {
@@ -475,15 +581,7 @@ where
             return Ok(ProcessOutcome::Failed { job_id: job.id });
         }
     };
-    let transcription = match engine
-        .transcribe(TranscriptionInput {
-            audio_path: job.accepted_audio_path.clone(),
-            audio_format: job.audio_format.clone(),
-            language: job.language.clone(),
-            model: job.transcription_model.clone(),
-        })
-        .await
-    {
+    let transcription = match transcription {
         Ok(transcription) => transcription,
         Err(EngineFailure::Transient {
             failure_code,

--- a/backend/tests/media_tools.rs
+++ b/backend/tests/media_tools.rs
@@ -1,0 +1,50 @@
+use std::process::Command;
+
+use oracy_backend::transcription_worker::{
+    AudioSlicer, DurationProbe, FfmpegAudioSlicer, FfprobeDurationProbe,
+};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn ffprobe_derives_duration_and_ffmpeg_creates_format_safe_slices() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let audio = tempdir.path().join("one-second.wav");
+    let output = Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .arg("-loglevel")
+        .arg("error")
+        .arg("-y")
+        .arg("-f")
+        .arg("lavfi")
+        .arg("-i")
+        .arg("anullsrc=r=8000:cl=mono")
+        .arg("-t")
+        .arg("1.0")
+        .arg(&audio)
+        .output()
+        .expect("run ffmpeg");
+    assert!(
+        output.status.success(),
+        "ffmpeg fixture generation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let duration_ms = FfprobeDurationProbe
+        .duration_ms(&audio, "wav")
+        .await
+        .expect("probe duration");
+    assert!((900..=1_100).contains(&duration_ms));
+
+    let slices = FfmpegAudioSlicer::with_max_slice_bytes(8_000)
+        .slices(&audio, "wav")
+        .await
+        .expect("slice audio");
+    assert!(slices.len() > 1);
+    for slice in slices {
+        assert_ne!(slice, audio);
+        assert!(slice.exists());
+        let slice_size = std::fs::metadata(slice).expect("slice metadata").len();
+        assert!(slice_size > 0);
+        assert!(slice_size <= 8_000);
+    }
+}

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -474,6 +474,7 @@ impl MetadataFixture {
         let app = build_router(AppState {
             accepted_audio_dir,
             auth_store: Arc::new(auth_store),
+            openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
         });
 

--- a/backend/tests/openai_engine.rs
+++ b/backend/tests/openai_engine.rs
@@ -1,0 +1,176 @@
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Multipart, State};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
+use oracy_backend::transcription_worker::{
+    AudioSliceError, AudioSlicer, EngineFailure, OpenAiTranscriptionEngine, TranscriptionEngine,
+    TranscriptionInput,
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn openai_engine_posts_transcription_requests_and_concatenates_slices() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let first = tempdir.path().join("first.wav");
+    let second = tempdir.path().join("second.wav");
+    tokio::fs::write(&first, b"first-audio")
+        .await
+        .expect("write first slice");
+    tokio::fs::write(&second, b"second-audio")
+        .await
+        .expect("write second slice");
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let base_url = spawn_fake_openai(observed.clone()).await;
+    let engine = OpenAiTranscriptionEngine::new(
+        base_url,
+        "test-openai-key".to_owned(),
+        FakeSlicer {
+            slices: vec![first, second],
+        },
+    );
+
+    let output = engine
+        .transcribe(TranscriptionInput {
+            audio_path: tempdir.path().join("accepted.wav"),
+            audio_format: "wav".to_owned(),
+            language: Some("en".to_owned()),
+            model: "gpt-4o-mini-transcribe".to_owned(),
+        })
+        .await
+        .expect("transcribe");
+
+    assert_eq!(output.text, "slice-1\nslice-2");
+    let observed = observed.lock().expect("observed requests");
+    assert_eq!(observed.len(), 2);
+    assert_eq!(observed[0].model, "gpt-4o-mini-transcribe");
+    assert_eq!(observed[0].language.as_deref(), Some("en"));
+    assert_eq!(observed[0].file_bytes, b"first-audio");
+    assert_eq!(observed[1].file_bytes, b"second-audio");
+}
+
+#[tokio::test]
+async fn openai_engine_preserves_retry_after_rate_limit_semantics() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let audio = tempdir.path().join("audio.wav");
+    tokio::fs::write(&audio, b"audio")
+        .await
+        .expect("write audio");
+    let app = Router::new().route("/v1/audio/transcriptions", post(rate_limited));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake openai");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve fake openai");
+    });
+    let engine = OpenAiTranscriptionEngine::new(
+        format!("http://{addr}"),
+        "test-openai-key".to_owned(),
+        FakeSlicer {
+            slices: vec![audio],
+        },
+    );
+
+    let error = engine
+        .transcribe(TranscriptionInput {
+            audio_path: tempdir.path().join("accepted.wav"),
+            audio_format: "wav".to_owned(),
+            language: None,
+            model: "gpt-4o-mini-transcribe".to_owned(),
+        })
+        .await
+        .expect_err("rate limit should be transient");
+
+    assert_eq!(
+        error,
+        EngineFailure::Transient {
+            failure_code: "engine_rate_limited".to_owned(),
+            message: "slow down".to_owned(),
+            retry_after_seconds: Some(7),
+        }
+    );
+}
+
+#[derive(Clone)]
+struct ObservedRequest {
+    model: String,
+    language: Option<String>,
+    file_bytes: Vec<u8>,
+}
+
+async fn spawn_fake_openai(observed: Arc<Mutex<Vec<ObservedRequest>>>) -> String {
+    let app = Router::new()
+        .route("/v1/audio/transcriptions", post(fake_transcription))
+        .with_state(observed);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake openai");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve fake openai");
+    });
+    format!("http://{addr}")
+}
+
+async fn fake_transcription(
+    State(observed): State<Arc<Mutex<Vec<ObservedRequest>>>>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Json<serde_json::Value> {
+    assert_eq!(
+        headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok()),
+        Some("Bearer test-openai-key")
+    );
+    let mut model = None;
+    let mut language = None;
+    let mut file_bytes = None;
+
+    while let Some(field) = multipart.next_field().await.expect("multipart field") {
+        let name = field.name().expect("field name").to_owned();
+        match name.as_str() {
+            "model" => model = Some(field.text().await.expect("model text")),
+            "language" => language = Some(field.text().await.expect("language text")),
+            "file" => file_bytes = Some(field.bytes().await.expect("file bytes").to_vec()),
+            _ => {}
+        }
+    }
+
+    let mut observed = observed.lock().expect("observed requests");
+    observed.push(ObservedRequest {
+        model: model.expect("model field"),
+        language,
+        file_bytes: file_bytes.expect("file field"),
+    });
+    Json(json!({ "text": format!("slice-{}", observed.len()) }))
+}
+
+async fn rate_limited() -> impl IntoResponse {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [("retry-after", HeaderValue::from_static("7"))],
+        "slow down",
+    )
+}
+
+#[derive(Clone)]
+struct FakeSlicer {
+    slices: Vec<PathBuf>,
+}
+
+impl AudioSlicer for FakeSlicer {
+    async fn slices(
+        &self,
+        _input: &Path,
+        _audio_format: &str,
+    ) -> Result<Vec<PathBuf>, AudioSliceError> {
+        Ok(self.slices.clone())
+    }
+}

--- a/backend/tests/openai_engine.rs
+++ b/backend/tests/openai_engine.rs
@@ -97,6 +97,70 @@ async fn openai_engine_preserves_retry_after_rate_limit_semantics() {
     );
 }
 
+#[tokio::test]
+async fn openai_engine_cleans_generated_slices_when_slice_transcription_fails() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let accepted_audio = tempdir.path().join("accepted.wav");
+    tokio::fs::write(&accepted_audio, b"accepted-audio")
+        .await
+        .expect("write accepted audio");
+    let slice_dir = tempdir.path().join(".oracy-slices-test");
+    tokio::fs::create_dir(&slice_dir)
+        .await
+        .expect("create generated slice dir");
+    let first = slice_dir.join("slice-0.wav");
+    let second = slice_dir.join("slice-1.wav");
+    tokio::fs::write(&first, b"first-audio")
+        .await
+        .expect("write first slice");
+    tokio::fs::write(&second, b"second-audio")
+        .await
+        .expect("write second slice");
+
+    let app = Router::new()
+        .route(
+            "/v1/audio/transcriptions",
+            post(fail_after_first_transcription),
+        )
+        .with_state(Arc::new(Mutex::new(0_usize)));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake openai");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve fake openai");
+    });
+    let engine = OpenAiTranscriptionEngine::new(
+        format!("http://{addr}"),
+        "test-openai-key".to_owned(),
+        FakeSlicer {
+            slices: vec![first.clone(), second.clone()],
+        },
+    );
+
+    let error = engine
+        .transcribe(TranscriptionInput {
+            audio_path: accepted_audio,
+            audio_format: "wav".to_owned(),
+            language: None,
+            model: "gpt-4o-mini-transcribe".to_owned(),
+        })
+        .await
+        .expect_err("second slice failure should be returned");
+
+    assert_eq!(
+        error,
+        EngineFailure::Transient {
+            failure_code: "engine_error".to_owned(),
+            message: "engine unavailable".to_owned(),
+            retry_after_seconds: None,
+        }
+    );
+    assert!(!first.exists());
+    assert!(!second.exists());
+    assert!(!slice_dir.exists());
+}
+
 #[derive(Clone)]
 struct ObservedRequest {
     model: String,
@@ -158,6 +222,18 @@ async fn rate_limited() -> impl IntoResponse {
         [("retry-after", HeaderValue::from_static("7"))],
         "slow down",
     )
+}
+
+async fn fail_after_first_transcription(
+    State(count): State<Arc<Mutex<usize>>>,
+) -> impl IntoResponse {
+    let mut count = count.lock().expect("transcription count");
+    *count += 1;
+    if *count == 1 {
+        Json(json!({ "text": "first slice" })).into_response()
+    } else {
+        (StatusCode::INTERNAL_SERVER_ERROR, "engine unavailable").into_response()
+    }
 }
 
 #[derive(Clone)]

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -219,6 +219,114 @@ async fn expired_processing_jobs_are_reclaimed_by_a_new_lease() {
 }
 
 #[tokio::test]
+async fn active_processing_lease_can_be_renewed_without_changing_visible_update_time() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-renew-lease").await;
+    let claimed = storage
+        .claim_next_transcription_job(
+            "active-lease",
+            datetime!(2026-04-24 18:00:00 UTC),
+            datetime!(2026-04-24 18:05:00 UTC),
+        )
+        .await
+        .expect("claim job")
+        .expect("job should be claimed");
+
+    let renewed = storage
+        .renew_processing_lease(
+            "owner-a",
+            &job.id,
+            "active-lease",
+            datetime!(2026-04-24 18:01:00 UTC),
+            datetime!(2026-04-24 18:06:00 UTC),
+        )
+        .await
+        .expect("renew lease");
+
+    assert!(renewed);
+    let after_renewal = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(
+        after_renewal.processing_lease_expires_at,
+        Some(datetime!(2026-04-24 18:06:00 UTC))
+    );
+    assert_eq!(after_renewal.updated_at, claimed.updated_at);
+
+    let stale = storage
+        .renew_processing_lease(
+            "owner-a",
+            &job.id,
+            "stale-lease",
+            datetime!(2026-04-24 18:02:00 UTC),
+            datetime!(2026-04-24 18:07:00 UTC),
+        )
+        .await
+        .expect("stale renewal");
+    assert!(!stale);
+}
+
+#[tokio::test]
+async fn chunked_jobs_are_claimed_by_finalize_order_not_open_order() {
+    let (_tempdir, storage) = storage().await;
+    let opened_first = opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-opened-first",
+        datetime!(2026-04-24 18:00:00 UTC),
+    )
+    .await;
+    let opened_second = opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-opened-second",
+        datetime!(2026-04-24 18:01:00 UTC),
+    )
+    .await;
+    store_chunk(&storage, &opened_first.id, "hash-first").await;
+    store_chunk(&storage, &opened_second.id, "hash-second").await;
+
+    finalize_open_job_at(
+        &storage,
+        &opened_second.id,
+        "accepted-hash-second",
+        datetime!(2026-04-24 18:02:00 UTC),
+    )
+    .await;
+    finalize_open_job_at(
+        &storage,
+        &opened_first.id,
+        "accepted-hash-first",
+        datetime!(2026-04-24 18:03:00 UTC),
+    )
+    .await;
+
+    let first_claim = storage
+        .claim_next_transcription_job(
+            "lease-first",
+            datetime!(2026-04-24 18:04:00 UTC),
+            datetime!(2026-04-24 18:09:00 UTC),
+        )
+        .await
+        .expect("claim first ready job")
+        .expect("first ready job should be claimed");
+    let second_claim = storage
+        .claim_next_transcription_job(
+            "lease-second",
+            datetime!(2026-04-24 18:04:01 UTC),
+            datetime!(2026-04-24 18:09:01 UTC),
+        )
+        .await
+        .expect("claim second ready job")
+        .expect("second ready job should be claimed");
+
+    assert_eq!(first_claim.id, opened_second.id);
+    assert_eq!(second_claim.id, opened_first.id);
+}
+
+#[tokio::test]
 async fn retry_waiting_jobs_are_claimed_only_after_next_attempt_at() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
@@ -368,6 +476,64 @@ async fn transient_failures_retry_until_exhaustion_then_fail_terminally() {
             assert_eq!(failed.retryable_by_client, Some(true));
         }
     }
+}
+
+#[tokio::test]
+async fn successful_retry_clears_stale_failure_classification() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    storage
+        .claim_next_transcription_job(
+            "lease-1",
+            datetime!(2026-04-24 18:00:00 UTC),
+            datetime!(2026-04-24 18:05:00 UTC),
+        )
+        .await
+        .expect("claim job");
+
+    let first = storage
+        .record_transient_job_failure(TransientJobFailure {
+            api_key_id: "owner-a".to_owned(),
+            job_id: job.id.clone(),
+            lease_token: "lease-1".to_owned(),
+            failure_code: "engine_error".to_owned(),
+            failure_message: "engine temporarily failed".to_owned(),
+            now: datetime!(2026-04-24 18:01:00 UTC),
+            next_attempt_at: datetime!(2026-04-24 18:02:00 UTC),
+        })
+        .await
+        .expect("record transient failure");
+    assert!(matches!(first, RetryOutcome::RetryWaiting(_)));
+
+    storage
+        .claim_next_transcription_job(
+            "lease-2",
+            datetime!(2026-04-24 18:02:00 UTC),
+            datetime!(2026-04-24 18:07:00 UTC),
+        )
+        .await
+        .expect("claim retry")
+        .expect("retry should be claimable");
+    storage
+        .complete_leased_job_with_voice_note(
+            "owner-a",
+            &job.id,
+            "lease-2",
+            materialization("voice-note-a"),
+        )
+        .await
+        .expect("complete retry");
+
+    let completed = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(completed.status, "succeeded");
+    assert_eq!(completed.retry_count, 1);
+    assert_eq!(completed.failure_code, None);
+    assert_eq!(completed.failure_message, None);
+    assert_eq!(completed.retryable_by_client, None);
 }
 
 #[tokio::test]
@@ -1951,6 +2117,34 @@ async fn mark_open_job_queued(storage: &Storage, job_id: &str) {
     .await
     .expect("mark open job queued");
     assert_eq!(result.rows_affected(), 1);
+}
+
+async fn store_chunk(storage: &Storage, job_id: &str, hash: &str) {
+    let outcome = storage
+        .store_chunk(accepted_chunk(job_id, hash))
+        .await
+        .expect("store chunk");
+    assert_eq!(outcome, StoreChunkOutcome::Stored);
+}
+
+async fn finalize_open_job_at(
+    storage: &Storage,
+    job_id: &str,
+    audio_sha256_hex: &str,
+    now: OffsetDateTime,
+) {
+    let outcome = storage
+        .finalize_job(
+            "owner-a",
+            job_id,
+            audio_sha256_hex,
+            std::path::Path::new("/var/lib/oracy/accepted-audio/finalized.wav"),
+            "gpt-4o-mini-transcribe",
+            now,
+        )
+        .await
+        .expect("finalize open job");
+    assert!(matches!(outcome, FinalizeJobOutcome::Accepted(_)));
 }
 
 async fn job_count_by_key(storage: &Storage, owner: &str, idempotency_key: &str) -> i64 {

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -5,16 +5,19 @@ use oracy_backend::audio_hash::{AUDIO_CONTENT_HASH_ALGORITHM_ID, compose_audio_c
 use oracy_backend::storage::{
     AcceptJobOutcome, AcceptedChunk, CreateTagOutcome, FinalizeJobOutcome, NewEmbedding,
     NewOpenTranscriptionJob, NewSegment, NewSession, NewTag, NewTranscriptionJob, NewVoiceNote,
-    NewVoiceNoteVersion, OpenJobOutcome, RenameTagOutcome, ReplaceVoiceNoteTagsOutcome, Storage,
-    StorageError, StoreChunkOutcome, VoiceNoteMaterialization,
+    NewVoiceNoteVersion, OpenJobOutcome, RenameTagOutcome, ReplaceVoiceNoteTagsOutcome,
+    RetryOutcome, Storage, StorageError, StoreChunkOutcome, TransientJobFailure,
+    VoiceNoteMaterialization,
 };
 use sqlx::Row;
+use std::time::Duration as StdDuration;
 use tempfile::TempDir;
+use time::Duration;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use time::macros::datetime;
 use tokio::sync::Barrier;
-use tokio::time::{Duration, sleep};
+use tokio::time::sleep;
 
 #[tokio::test]
 async fn accepted_jobs_replay_by_owner_and_reject_tuple_mismatches() {
@@ -132,6 +135,239 @@ async fn storage_owns_the_accepted_audio_hash_algorithm_pin() {
         created.audio_content_hash_algorithm,
         AUDIO_CONTENT_HASH_ALGORITHM_ID
     );
+}
+
+#[tokio::test]
+async fn queued_jobs_are_claimed_by_a_processing_lease() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+
+    let claimed = storage
+        .claim_next_transcription_job(
+            "worker-lease-a",
+            datetime!(2026-04-24 18:00:05 UTC),
+            datetime!(2026-04-24 18:05:05 UTC),
+        )
+        .await
+        .expect("claim next job")
+        .expect("queued job should be claimed");
+
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.status, "processing");
+    assert_eq!(
+        claimed.processing_lease_token.as_deref(),
+        Some("worker-lease-a")
+    );
+    assert_eq!(
+        claimed.processing_lease_expires_at,
+        Some(datetime!(2026-04-24 18:05:05 UTC))
+    );
+
+    assert!(
+        storage
+            .claim_next_transcription_job(
+                "worker-lease-b",
+                datetime!(2026-04-24 18:00:06 UTC),
+                datetime!(2026-04-24 18:05:06 UTC),
+            )
+            .await
+            .expect("second claim")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn expired_processing_jobs_are_reclaimed_by_a_new_lease() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    storage
+        .claim_next_transcription_job(
+            "expired-lease",
+            datetime!(2026-04-24 18:00:00 UTC),
+            datetime!(2026-04-24 18:05:00 UTC),
+        )
+        .await
+        .expect("initial claim");
+
+    assert!(
+        storage
+            .claim_next_transcription_job(
+                "too-early",
+                datetime!(2026-04-24 18:04:59 UTC),
+                datetime!(2026-04-24 18:09:59 UTC),
+            )
+            .await
+            .expect("early reclaim")
+            .is_none()
+    );
+
+    let reclaimed = storage
+        .claim_next_transcription_job(
+            "fresh-lease",
+            datetime!(2026-04-24 18:05:01 UTC),
+            datetime!(2026-04-24 18:10:01 UTC),
+        )
+        .await
+        .expect("expired reclaim")
+        .expect("expired processing job should be reclaimed");
+
+    assert_eq!(reclaimed.id, job.id);
+    assert_eq!(
+        reclaimed.processing_lease_token.as_deref(),
+        Some("fresh-lease")
+    );
+}
+
+#[tokio::test]
+async fn retry_waiting_jobs_are_claimed_only_after_next_attempt_at() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    mark_job_retry_waiting(&storage, &job.id).await;
+
+    assert!(
+        storage
+            .claim_next_transcription_job(
+                "early-lease",
+                datetime!(2026-04-24 18:04:59 UTC),
+                datetime!(2026-04-24 18:09:59 UTC),
+            )
+            .await
+            .expect("early claim")
+            .is_none()
+    );
+
+    let claimed = storage
+        .claim_next_transcription_job(
+            "due-lease",
+            datetime!(2026-04-24 18:05:00 UTC),
+            datetime!(2026-04-24 18:10:00 UTC),
+        )
+        .await
+        .expect("due claim")
+        .expect("due retry should be claimed");
+
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.status, "processing");
+    assert_eq!(claimed.next_attempt_at, None);
+}
+
+#[tokio::test]
+async fn leased_completion_requires_the_active_token_and_allows_missing_embedding() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    storage
+        .claim_next_transcription_job(
+            "active-lease",
+            datetime!(2026-04-24 18:00:00 UTC),
+            datetime!(2026-04-24 18:05:00 UTC),
+        )
+        .await
+        .expect("claim job");
+    let mut materialization = materialization("voice-note-a");
+    materialization.embedding = None;
+
+    let error = storage
+        .complete_leased_job_with_voice_note(
+            "owner-a",
+            &job.id,
+            "stale-lease",
+            materialization.clone(),
+        )
+        .await
+        .expect_err("stale lease should not complete");
+    assert!(matches!(
+        error,
+        StorageError::JobNotCompletable { job_id } if job_id == job.id
+    ));
+
+    storage
+        .complete_leased_job_with_voice_note("owner-a", &job.id, "active-lease", materialization)
+        .await
+        .expect("active lease materializes voice note");
+
+    let completed = storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(completed.status, "succeeded");
+    assert_eq!(completed.voice_note_id.as_deref(), Some("voice-note-a"));
+    assert!(
+        storage
+            .get_current_embedding("owner-a", "voice-note-a")
+            .await
+            .expect("embedding lookup")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn transient_failures_retry_until_exhaustion_then_fail_terminally() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    storage
+        .claim_next_transcription_job(
+            "lease-1",
+            datetime!(2026-04-24 18:00:00 UTC),
+            datetime!(2026-04-24 18:05:00 UTC),
+        )
+        .await
+        .expect("claim job");
+
+    let first = storage
+        .record_transient_job_failure(TransientJobFailure {
+            api_key_id: "owner-a".to_owned(),
+            job_id: job.id.clone(),
+            lease_token: "lease-1".to_owned(),
+            failure_code: "engine_error".to_owned(),
+            failure_message: "engine temporarily failed".to_owned(),
+            now: datetime!(2026-04-24 18:01:00 UTC),
+            next_attempt_at: datetime!(2026-04-24 18:02:00 UTC),
+        })
+        .await
+        .expect("record transient failure");
+    let RetryOutcome::RetryWaiting(first) = first else {
+        panic!("first transient failure should schedule retry");
+    };
+    assert_eq!(first.status, "retry_waiting");
+    assert_eq!(first.retry_count, 1);
+    assert_eq!(
+        first.next_attempt_at,
+        Some(datetime!(2026-04-24 18:02:00 UTC))
+    );
+
+    for (lease, now) in [
+        ("lease-2", datetime!(2026-04-24 18:02:00 UTC)),
+        ("lease-3", datetime!(2026-04-24 18:04:00 UTC)),
+    ] {
+        storage
+            .claim_next_transcription_job(lease, now, now + Duration::seconds(300))
+            .await
+            .expect("claim retry")
+            .expect("retry should be claimable");
+        let outcome = storage
+            .record_transient_job_failure(TransientJobFailure {
+                api_key_id: "owner-a".to_owned(),
+                job_id: job.id.clone(),
+                lease_token: lease.to_owned(),
+                failure_code: "engine_error".to_owned(),
+                failure_message: "engine temporarily failed".to_owned(),
+                now: now + Duration::seconds(30),
+                next_attempt_at: now + Duration::seconds(60),
+            })
+            .await
+            .expect("record retry failure");
+        if lease == "lease-2" {
+            assert!(matches!(outcome, RetryOutcome::RetryWaiting(_)));
+        } else {
+            let RetryOutcome::Failed(failed) = outcome else {
+                panic!("third transient failure should exhaust retries");
+            };
+            assert_eq!(failed.status, "failed");
+            assert_eq!(failed.failure_code.as_deref(), Some("engine_error"));
+            assert_eq!(failed.retryable_by_client, Some(true));
+        }
+    }
 }
 
 #[tokio::test]
@@ -1497,7 +1733,7 @@ async fn accept_while_uncommitted_row_exists(
 
     let racing_storage = storage.clone();
     let handle = tokio::spawn(async move { racing_storage.accept_job(attempted).await });
-    sleep(Duration::from_millis(100)).await;
+    sleep(StdDuration::from_millis(100)).await;
     tx.commit().await.expect("commit accepted row");
     handle.await.expect("accept task should not panic")
 }
@@ -1536,7 +1772,7 @@ async fn open_while_uncommitted_row_exists(
 
     let racing_storage = storage.clone();
     let handle = tokio::spawn(async move { racing_storage.open_job(attempted).await });
-    sleep(Duration::from_millis(100)).await;
+    sleep(StdDuration::from_millis(100)).await;
     tx.commit().await.expect("commit open row");
     handle.await.expect("open task should not panic")
 }
@@ -1551,7 +1787,7 @@ async fn store_chunk_while_uncommitted_chunk_exists(
 
     let racing_storage = storage.clone();
     let handle = tokio::spawn(async move { racing_storage.store_chunk(attempted).await });
-    sleep(Duration::from_millis(100)).await;
+    sleep(StdDuration::from_millis(100)).await;
     assert!(
         !handle.is_finished(),
         "racing chunk push should wait on the held write"
@@ -1601,7 +1837,7 @@ async fn finalize_while_uncommitted_finalize_exists(
             )
             .await
     });
-    sleep(Duration::from_millis(100)).await;
+    sleep(StdDuration::from_millis(100)).await;
     assert!(
         !handle.is_finished(),
         "racing finalize should wait on the held write"
@@ -1864,11 +2100,11 @@ fn materialization(voice_note_id: &str) -> VoiceNoteMaterialization {
                 text: "second segment".to_owned(),
             },
         ],
-        embedding: NewEmbedding {
+        embedding: Some(NewEmbedding {
             model: "embedding-v1".to_owned(),
             vector: vec![1, 2, 3],
             created_at: datetime!(2026-04-24 18:00:31 UTC),
-        },
+        }),
     }
 }
 

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -612,6 +612,7 @@ impl TranscriptionJobFixture {
         let app = build_router(AppState {
             accepted_audio_dir: accepted_audio_dir.clone(),
             auth_store: Arc::new(auth_store),
+            openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
         });
 

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -1,12 +1,21 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use axum::extract::Multipart;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
 use oracy_backend::storage::{AcceptJobOutcome, NewTranscriptionJob, Storage};
 use oracy_backend::transcription_worker::{
-    DurationProbe, DurationProbeError, EngineFailure, ProcessOutcome, TranscriptionEngine,
-    TranscriptionInput, TranscriptionOutput, WorkerConfig, process_one_available_job,
+    AudioSliceError, AudioSlicer, DurationProbe, DurationProbeError, EngineFailure,
+    OpenAiTranscriptionEngine, ProcessOutcome, TranscriptionEngine, TranscriptionInput,
+    TranscriptionOutput, WorkerConfig, process_one_available_job,
 };
+use serde_json::json;
 use tempfile::TempDir;
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
 use time::macros::datetime;
 
 #[tokio::test]
@@ -134,6 +143,128 @@ async fn worker_routes_transient_engine_failure_to_retry_waiting() {
     assert!(retrying.next_attempt_at.is_some());
 }
 
+#[tokio::test]
+async fn stalled_openai_request_records_transient_timeout_and_worker_processes_next_job() {
+    let fixture = WorkerFixture::new().await;
+    let stalled_job = fixture
+        .create_queued_job("attempt-stalled-openai", b"stalled audio")
+        .await;
+    let next_job = fixture
+        .create_queued_job("attempt-next-openai", b"next audio")
+        .await;
+    let base_url = spawn_stalling_openai().await;
+    let engine = OpenAiTranscriptionEngine::with_request_timeout(
+        base_url,
+        "test-openai-key".to_owned(),
+        PassthroughSlicer,
+        Duration::from_millis(50),
+    );
+    let probe = FakeDurationProbe::success(1_480);
+
+    let first = tokio::time::timeout(
+        Duration::from_secs(1),
+        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test()),
+    )
+    .await
+    .expect("stalled request should be bounded")
+    .expect("process stalled job");
+    assert_eq!(
+        first,
+        ProcessOutcome::RetryWaiting {
+            job_id: stalled_job.id.clone()
+        }
+    );
+    let retrying = fixture
+        .storage
+        .get_job("owner-a", &stalled_job.id)
+        .await
+        .expect("stalled job lookup")
+        .expect("stalled job exists");
+    assert_eq!(retrying.status, "retry_waiting");
+    assert_eq!(retrying.failure_code.as_deref(), Some("engine_timeout"));
+
+    let second = tokio::time::timeout(
+        Duration::from_secs(1),
+        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test()),
+    )
+    .await
+    .expect("worker should remain available after timeout")
+    .expect("process next job");
+    assert_eq!(
+        second,
+        ProcessOutcome::Succeeded {
+            job_id: next_job.id.clone()
+        }
+    );
+    let completed = fixture
+        .storage
+        .get_job("owner-a", &next_job.id)
+        .await
+        .expect("next job lookup")
+        .expect("next job exists");
+    assert_eq!(completed.status, "succeeded");
+    let voice_note = fixture
+        .storage
+        .get_voice_note(
+            "owner-a",
+            completed.voice_note_id.as_deref().expect("voice note id"),
+        )
+        .await
+        .expect("voice note lookup")
+        .expect("voice note exists");
+    assert_eq!(voice_note.text, "transcribed after timeout");
+}
+
+#[tokio::test]
+async fn worker_renews_processing_lease_while_transcription_outlives_initial_lease() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-long-transcription", b"long audio")
+        .await;
+    let storage_for_worker = fixture.storage.clone();
+    let engine = SlowEngine::new(Duration::from_millis(140), "long transcription");
+    let probe = FakeDurationProbe::success(1_480);
+    let config = WorkerConfig {
+        lease_duration: TimeDuration::milliseconds(50),
+        lease_renewal_interval: Duration::from_millis(10),
+        idle_sleep: Duration::from_millis(10),
+        error_sleep: Duration::from_millis(10),
+    };
+
+    let handle = tokio::spawn(async move {
+        process_one_available_job(&storage_for_worker, &engine, &probe, config).await
+    });
+    tokio::time::sleep(Duration::from_millis(75)).await;
+
+    assert!(
+        fixture
+            .storage
+            .claim_next_transcription_job(
+                "competing-lease",
+                OffsetDateTime::now_utc(),
+                OffsetDateTime::now_utc() + TimeDuration::milliseconds(50),
+            )
+            .await
+            .expect("competing claim")
+            .is_none()
+    );
+
+    let outcome = handle.await.expect("worker task").expect("process job");
+    assert_eq!(
+        outcome,
+        ProcessOutcome::Succeeded {
+            job_id: job.id.clone()
+        }
+    );
+    let completed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(completed.status, "succeeded");
+}
+
 struct WorkerFixture {
     _tempdir: TempDir,
     accepted_audio_dir: PathBuf,
@@ -230,6 +361,33 @@ impl TranscriptionEngine for FakeEngine {
 }
 
 #[derive(Clone)]
+struct SlowEngine {
+    delay: Duration,
+    text: String,
+}
+
+impl SlowEngine {
+    fn new(delay: Duration, text: &str) -> Self {
+        Self {
+            delay,
+            text: text.to_owned(),
+        }
+    }
+}
+
+impl TranscriptionEngine for SlowEngine {
+    async fn transcribe(
+        &self,
+        _input: TranscriptionInput,
+    ) -> Result<TranscriptionOutput, EngineFailure> {
+        tokio::time::sleep(self.delay).await;
+        Ok(TranscriptionOutput {
+            text: self.text.clone(),
+        })
+    }
+}
+
+#[derive(Clone)]
 struct FakeDurationProbe {
     result: Result<i64, DurationProbeError>,
 }
@@ -256,4 +414,44 @@ impl DurationProbe for FakeDurationProbe {
     ) -> Result<i64, DurationProbeError> {
         self.result.clone()
     }
+}
+
+#[derive(Clone)]
+struct PassthroughSlicer;
+
+impl AudioSlicer for PassthroughSlicer {
+    async fn slices(
+        &self,
+        input: &std::path::Path,
+        _audio_format: &str,
+    ) -> Result<Vec<PathBuf>, AudioSliceError> {
+        Ok(vec![input.to_path_buf()])
+    }
+}
+
+async fn spawn_stalling_openai() -> String {
+    let app = Router::new().route("/v1/audio/transcriptions", post(stalling_transcription));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake openai");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve fake openai");
+    });
+    format!("http://{addr}")
+}
+
+async fn stalling_transcription(mut multipart: Multipart) -> impl IntoResponse {
+    let mut file_bytes = Vec::new();
+    while let Some(field) = multipart.next_field().await.expect("multipart field") {
+        if field.name() == Some("file") {
+            file_bytes = field.bytes().await.expect("file bytes").to_vec();
+        }
+    }
+
+    if file_bytes == b"stalled audio" {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    }
+
+    Json(json!({ "text": "transcribed after timeout" }))
 }

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -1,0 +1,259 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use oracy_backend::storage::{AcceptJobOutcome, NewTranscriptionJob, Storage};
+use oracy_backend::transcription_worker::{
+    DurationProbe, DurationProbeError, EngineFailure, ProcessOutcome, TranscriptionEngine,
+    TranscriptionInput, TranscriptionOutput, WorkerConfig, process_one_available_job,
+};
+use tempfile::TempDir;
+use time::macros::datetime;
+
+#[tokio::test]
+async fn worker_materializes_a_queued_job_with_a_fake_engine() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture.create_queued_job("attempt-1", b"hello audio").await;
+    let engine = FakeEngine::success("transcribed text");
+    let probe = FakeDurationProbe::success(1_480);
+
+    let outcome =
+        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test())
+            .await
+            .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::Succeeded {
+            job_id: job.id.clone()
+        }
+    );
+    assert_eq!(engine.inputs.lock().expect("inputs").len(), 1);
+    assert_eq!(
+        engine.inputs.lock().expect("inputs")[0].model,
+        "gpt-4o-mini-transcribe"
+    );
+    let completed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(completed.status, "succeeded");
+    let voice_note = fixture
+        .storage
+        .get_voice_note(
+            "owner-a",
+            completed.voice_note_id.as_deref().expect("voice note id"),
+        )
+        .await
+        .expect("voice note lookup")
+        .expect("voice note exists");
+    assert_eq!(voice_note.text, "transcribed text");
+    assert_eq!(voice_note.audio_duration_seconds, 1.48);
+    assert_eq!(voice_note.model, "gpt-4o-mini-transcribe");
+    assert!(
+        fixture
+            .storage
+            .get_current_embedding("owner-a", &voice_note.id)
+            .await
+            .expect("embedding lookup")
+            .is_none()
+    );
+    let segments = fixture
+        .storage
+        .list_segments("owner-a", &voice_note.id)
+        .await
+        .expect("segments");
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].start_ms, 0);
+    assert_eq!(segments[0].end_ms, 1_480);
+    assert_eq!(segments[0].text, "transcribed text");
+}
+
+#[tokio::test]
+async fn worker_marks_duration_probe_failure_as_audio_invalid() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-invalid-audio", b"not audio")
+        .await;
+    let engine = FakeEngine::success("unused");
+    let probe = FakeDurationProbe::invalid_audio();
+
+    let outcome =
+        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test())
+            .await
+            .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::Failed {
+            job_id: job.id.clone()
+        }
+    );
+    let failed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(failed.status, "failed");
+    assert_eq!(failed.failure_code.as_deref(), Some("audio_invalid"));
+    assert_eq!(failed.retryable_by_client, Some(false));
+    assert_eq!(failed.voice_note_id, None);
+}
+
+#[tokio::test]
+async fn worker_routes_transient_engine_failure_to_retry_waiting() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-transient-engine", b"hello audio")
+        .await;
+    let engine = FakeEngine::transient("engine_error", "temporary engine failure", Some(30));
+    let probe = FakeDurationProbe::success(1_480);
+
+    let outcome =
+        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test())
+            .await
+            .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::RetryWaiting {
+            job_id: job.id.clone()
+        }
+    );
+    let retrying = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(retrying.status, "retry_waiting");
+    assert_eq!(retrying.retry_count, 1);
+    assert_eq!(retrying.failure_code.as_deref(), Some("engine_error"));
+    assert!(retrying.next_attempt_at.is_some());
+}
+
+struct WorkerFixture {
+    _tempdir: TempDir,
+    accepted_audio_dir: PathBuf,
+    storage: Storage,
+}
+
+impl WorkerFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let database_path = tempdir.path().join("oracy.sqlite");
+        let accepted_audio_dir = tempdir.path().join("accepted-audio");
+        tokio::fs::create_dir(&accepted_audio_dir)
+            .await
+            .expect("create accepted audio dir");
+        let storage = Storage::connect(&database_path)
+            .await
+            .expect("connect storage");
+        Self {
+            _tempdir: tempdir,
+            accepted_audio_dir,
+            storage,
+        }
+    }
+
+    async fn create_queued_job(
+        &self,
+        idempotency_key: &str,
+        audio: &[u8],
+    ) -> oracy_backend::storage::TranscriptionJobRecord {
+        let path = self
+            .accepted_audio_dir
+            .join(format!("{idempotency_key}.wav"));
+        tokio::fs::write(&path, audio)
+            .await
+            .expect("write accepted audio");
+        match self
+            .storage
+            .accept_job(NewTranscriptionJob {
+                api_key_id: "owner-a".to_owned(),
+                idempotency_key: idempotency_key.to_owned(),
+                audio_sha256_hex: "hash-a".to_owned(),
+                recorded_at: datetime!(2026-04-24 17:59:00 UTC),
+                session_id: None,
+                language: Some("en".to_owned()),
+                accepted_audio_path: path,
+                max_retries: 3,
+                now: datetime!(2026-04-24 18:00:00 UTC),
+            })
+            .await
+            .expect("accept job")
+        {
+            AcceptJobOutcome::Created(job) => job,
+            other => panic!("expected created job, got {other:?}"),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct FakeEngine {
+    output: Result<TranscriptionOutput, EngineFailure>,
+    inputs: Arc<Mutex<Vec<TranscriptionInput>>>,
+}
+
+impl FakeEngine {
+    fn success(text: &str) -> Self {
+        Self {
+            output: Ok(TranscriptionOutput {
+                text: text.to_owned(),
+            }),
+            inputs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn transient(failure_code: &str, message: &str, retry_after_seconds: Option<i64>) -> Self {
+        Self {
+            output: Err(EngineFailure::Transient {
+                failure_code: failure_code.to_owned(),
+                message: message.to_owned(),
+                retry_after_seconds,
+            }),
+            inputs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl TranscriptionEngine for FakeEngine {
+    async fn transcribe(
+        &self,
+        input: TranscriptionInput,
+    ) -> Result<TranscriptionOutput, EngineFailure> {
+        self.inputs.lock().expect("inputs").push(input);
+        self.output.clone()
+    }
+}
+
+#[derive(Clone)]
+struct FakeDurationProbe {
+    result: Result<i64, DurationProbeError>,
+}
+
+impl FakeDurationProbe {
+    fn success(duration_ms: i64) -> Self {
+        Self {
+            result: Ok(duration_ms),
+        }
+    }
+
+    fn invalid_audio() -> Self {
+        Self {
+            result: Err(DurationProbeError::InvalidAudio),
+        }
+    }
+}
+
+impl DurationProbe for FakeDurationProbe {
+    async fn duration_ms(
+        &self,
+        _input: &std::path::Path,
+        _audio_format: &str,
+    ) -> Result<i64, DurationProbeError> {
+        self.result.clone()
+    }
+}

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -918,6 +918,7 @@ impl VoiceNoteFixture {
         let app = build_router(AppState {
             accepted_audio_dir,
             auth_store: Arc::new(auth_store),
+            openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
         });
 

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -968,6 +968,15 @@ Fields:
   start of the composed audio
 - `text`: segment text captured from the transcription result
 
+Semantics:
+
+- `v0.1.0` transcription engines do not produce per-utterance timing.
+  Voice notes created by the v0.1.0 processing pipeline carry one
+  coarse segment with `position=0`, `start_ms=0`, and
+  `end_ms=audio_duration_ms`.
+- The segment resource shape supports richer per-utterance timing for
+  future engine extensions without changing the contract.
+
 ### `Tag`
 
 ```json

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -430,9 +430,10 @@ Semantics:
 - Segments are stored as first-class rows joined to the voice note,
   not as a blob embedded in voice-note text.
 - Segment ordering is ascending by `position`.
-- `start_ms` and `end_ms` are measured from the start of the composed
-  audio and represent engine-ground-truth timing. Segments are not
-  user-editable in `v0.1.0`.
+- `v0.1.0` stores one coarse segment for each generated voice note:
+  `position=0`, `start_ms=0`, and `end_ms=audio_duration_ms`. The
+  segment shape remains compatible with future engines that expose
+  per-utterance timing. Segments are not user-editable in `v0.1.0`.
 - Segments remain anchored to the voice note across voice-note text
   edits.
 - Speaker diarization is out of scope. No `speaker_label` field

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -99,6 +99,13 @@ carry the credential. The value should not be exposed in version control,
 shared logs, copied configuration, shell history, or diagnostic output produced
 by provisioning and deployment tooling outside the backend.
 
+## Media Tools
+
+The backend uses FFmpeg tooling for audio duration probing and format-safe
+splitting before OpenAI transcription requests. Operators must provide
+`ffmpeg` and `ffprobe` on `PATH` for the backend process. Startup fails if
+either tool is missing or cannot execute.
+
 ## Worked Example
 
 `tesserine/ops` documents one concrete deployment pattern in


### PR DESCRIPTION
## Summary

- Implements the backend transcription-job processing pipeline from durable `queued` jobs through leased worker processing to terminal `succeeded` or `failed` states.
- Adds OpenAI transcription integration behind testable traits, with FFmpeg-backed request slicing, ffprobe duration probing, and local fake-server tests instead of live OpenAI calls.
- Materializes voice notes with initial versions and one coarse v0.1.0 segment, while documenting the temporary no-embedding release-blocker deviation until #27 lands.

## Changes

- Adds processing lease columns and storage transitions for claim, reclaim, retry wait, retry exhaustion, terminal failure, and leased voice-note completion.
- Adds `transcription_worker` with worker/engine/media/duration seams, production OpenAI and FFmpeg/ffprobe adapters, and binary startup wiring.
- Updates API/deployment/backend docs and changelog for coarse segment semantics, required media tools, and the tracked embedding deviation.

## GitHub Issue(s)

Closes #58
Refs #27

## Test plan

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
