### PR TITLE
feat(observability): operator metrics endpoint and initial metric set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Add an operator-only Prometheus metrics listener with initial worker,
-  retention-cleanup, and retained-audio capacity metrics.
+  retention-cleanup, retained-audio capacity metrics, and overlapping bind
+  validation.
 - Harden transcription worker reliability so stalled OpenAI requests enter the
   backend retry path, processing leases renew during long transcriptions,
   successful retries expose no stale failure metadata, failed sliced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add an operator-only Prometheus metrics listener with initial worker,
+  retention-cleanup, and retained-audio capacity metrics.
 - Harden transcription worker reliability so stalled OpenAI requests enter the
   backend retry path, processing leases renew during long transcriptions,
   successful retries expose no stale failure metadata, failed sliced

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -369,6 +369,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1068,7 @@ dependencies = [
  "base64",
  "caseless",
  "form_urlencoded",
+ "prometheus",
  "reqwest",
  "serde",
  "serde_json",
@@ -1069,7 +1076,7 @@ dependencies = [
  "sqlx",
  "subtle",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "toml",
@@ -1207,6 +1214,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,7 +1262,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1241,7 +1283,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1744,7 +1786,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1823,7 +1865,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -1860,7 +1902,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -1884,7 +1926,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -1958,11 +2000,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,6 +11,7 @@ axum = { version = "0.8.9", features = ["multipart"] }
 base64 = "0.22"
 caseless = "0.2.2"
 form_urlencoded = "1.2"
+prometheus = "0.14.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/backend/README.md
+++ b/backend/README.md
@@ -32,4 +32,5 @@ case-insensitive, and missing or invalid keys return the shared JSON
 Operator metrics are exposed separately from the public API listener. Scrape
 `GET /metrics` from `operator_listen_addr`; the default is loopback
 `127.0.0.1:9090`. Startup rejects configurations where `operator_listen_addr`
-equals `listen_addr`. The public listener does not expose `/metrics`.
+overlaps the public `listen_addr` bind set. The public listener does not expose
+`/metrics`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,7 @@ Run the service with `ORACY_CONFIG` set to a TOML configuration file and
 
 ```toml
 listen_addr = "127.0.0.1:8080"
+operator_listen_addr = "127.0.0.1:9090"
 accepted_audio_dir = "/var/lib/oracy/accepted-audio"
 database_path = "/var/lib/oracy/oracy.sqlite"
 
@@ -27,3 +28,8 @@ paths resolve from the real configuration file directory.
 Every API route requires `Authorization: Bearer <api_key>`. The bearer scheme is
 case-insensitive, and missing or invalid keys return the shared JSON
 `ErrorResponse` with `401 Unauthorized`.
+
+Operator metrics are exposed separately from the public API listener. Scrape
+`GET /metrics` from `operator_listen_addr`; the default is loopback
+`127.0.0.1:9090`. Startup rejects configurations where `operator_listen_addr`
+equals `listen_addr`. The public listener does not expose `/metrics`.

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -53,7 +54,7 @@ pub enum BootstrapError {
     Storage(#[from] StorageError),
 }
 
-pub async fn load_runtime_from_env() -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
+pub async fn load_runtime_from_env() -> Result<(SocketAddr, AppState), BootstrapError> {
     let config_path = std::env::var_os(CONFIG_ENV_VAR).ok_or(BootstrapError::MissingConfigEnv)?;
     let openai_api_key =
         std::env::var_os(OPENAI_API_KEY_ENV_VAR).ok_or(BootstrapError::MissingOpenAiApiKeyEnv)?;
@@ -67,7 +68,7 @@ pub async fn load_runtime_from_env() -> Result<(std::net::SocketAddr, AppState),
 
 pub async fn load_runtime_from_path(
     config_path: &Path,
-) -> Result<(std::net::SocketAddr, AppState), BootstrapError> {
+) -> Result<(SocketAddr, AppState), BootstrapError> {
     load_runtime_from_path_with_openai_key(config_path, "test-openai-key".to_owned()).await
 }
 
@@ -171,12 +172,29 @@ fn validate_settings(settings: &Settings) -> Result<(), BootstrapError> {
             "at least one api_keys entry is required".to_owned(),
         ));
     }
-    if settings.listen_addr == settings.operator_listen_addr {
+    if listener_binds_overlap(settings.listen_addr, settings.operator_listen_addr) {
         return Err(BootstrapError::InvalidConfiguration(
-            "operator_listen_addr must differ from listen_addr".to_owned(),
+            "operator_listen_addr must not overlap listen_addr".to_owned(),
         ));
     }
     Ok(())
+}
+
+fn listener_binds_overlap(left: SocketAddr, right: SocketAddr) -> bool {
+    left.port() == right.port() && bind_addresses_overlap(left.ip(), right.ip())
+}
+
+fn bind_addresses_overlap(left: IpAddr, right: IpAddr) -> bool {
+    match (left, right) {
+        (IpAddr::V4(left), IpAddr::V4(right)) => {
+            left.is_unspecified() || right.is_unspecified() || left == right
+        }
+        (IpAddr::V6(left), IpAddr::V6(right)) => {
+            left.is_unspecified() || right.is_unspecified() || left == right
+        }
+        (IpAddr::V6(left), IpAddr::V4(_)) => left.is_unspecified(),
+        (IpAddr::V4(_), IpAddr::V6(right)) => right.is_unspecified(),
+    }
 }
 
 fn ensure_writable_directory(path: &Path) -> Result<(), BootstrapError> {

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -185,6 +185,9 @@ fn listener_binds_overlap(left: SocketAddr, right: SocketAddr) -> bool {
 }
 
 fn bind_addresses_overlap(left: IpAddr, right: IpAddr) -> bool {
+    let left = normalize_bind_ip(left);
+    let right = normalize_bind_ip(right);
+
     match (left, right) {
         (IpAddr::V4(left), IpAddr::V4(right)) => {
             left.is_unspecified() || right.is_unspecified() || left == right
@@ -194,6 +197,16 @@ fn bind_addresses_overlap(left: IpAddr, right: IpAddr) -> bool {
         }
         (IpAddr::V6(left), IpAddr::V4(_)) => left.is_unspecified(),
         (IpAddr::V4(_), IpAddr::V6(right)) => right.is_unspecified(),
+    }
+}
+
+fn normalize_bind_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V4(_) => ip,
+        IpAddr::V6(addr) => addr
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(addr)),
     }
 }
 

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -8,6 +8,7 @@ use tracing::info;
 
 use crate::auth::AuthStore;
 use crate::config::Settings;
+use crate::metrics::Metrics;
 use crate::state::AppState;
 use crate::storage::{Storage, StorageError};
 
@@ -107,6 +108,8 @@ async fn load_runtime_from_path_with_openai_key(
     let state = AppState {
         accepted_audio_dir: settings.accepted_audio_dir.clone(),
         auth_store: Arc::new(auth_store),
+        metrics: Metrics::new(),
+        operator_listen_addr: settings.operator_listen_addr,
         openai_api_key,
         storage,
     };
@@ -168,7 +171,11 @@ fn validate_settings(settings: &Settings) -> Result<(), BootstrapError> {
             "at least one api_keys entry is required".to_owned(),
         ));
     }
-
+    if settings.listen_addr == settings.operator_listen_addr {
+        return Err(BootstrapError::InvalidConfiguration(
+            "operator_listen_addr must differ from listen_addr".to_owned(),
+        ));
+    }
     Ok(())
 }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -9,11 +9,19 @@ fn default_listen_addr() -> SocketAddr {
         .expect("default listen addr is valid")
 }
 
+fn default_operator_listen_addr() -> SocketAddr {
+    "127.0.0.1:9090"
+        .parse()
+        .expect("default operator listen addr is valid")
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Settings {
     #[serde(default = "default_listen_addr")]
     pub listen_addr: SocketAddr,
+    #[serde(default = "default_operator_listen_addr")]
+    pub operator_listen_addr: SocketAddr,
     pub accepted_audio_dir: PathBuf,
     pub database_path: PathBuf,
     pub api_keys: Vec<ApiKeyConfig>,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod errors;
 pub mod json;
 pub mod metadata;
+pub mod metrics;
 pub mod router;
 pub mod settings;
 pub mod state;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use oracy_backend::bootstrap::load_runtime_from_env;
-use oracy_backend::router::build_router;
+use oracy_backend::router::{build_operator_router, build_router};
 use oracy_backend::transcription_worker::{
     FfmpegAudioSlicer, FfprobeDurationProbe, OpenAiTranscriptionEngine, WorkerConfig,
     run_worker_loop,
@@ -20,6 +20,7 @@ async fn main() {
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let (listen_addr, state) = load_runtime_from_env().await?;
+    let operator_listen_addr = state.operator_listen_addr;
     let worker_storage = state.storage.clone();
     let worker_engine = OpenAiTranscriptionEngine::new(
         "https://api.openai.com".to_owned(),
@@ -31,8 +32,28 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         worker_engine,
         FfprobeDurationProbe,
         WorkerConfig::default(),
+        state.metrics.clone(),
     ));
-    serve(listen_addr, build_router(state)).await
+    serve_public_and_operator(
+        listen_addr,
+        build_router(state.clone()),
+        operator_listen_addr,
+        build_operator_router(state),
+    )
+    .await
+}
+
+async fn serve_public_and_operator(
+    listen_addr: SocketAddr,
+    app: axum::Router,
+    operator_listen_addr: SocketAddr,
+    operator_app: axum::Router,
+) -> Result<(), Box<dyn std::error::Error>> {
+    tokio::try_join!(
+        serve(listen_addr, app),
+        serve(operator_listen_addr, operator_app),
+    )?;
+    Ok(())
 }
 
 async fn serve(

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -1,0 +1,225 @@
+use std::io;
+use std::path::Path;
+
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::response::IntoResponse;
+use prometheus::{IntCounterVec, IntGauge, Opts, Registry, TextEncoder, core::Collector};
+
+use crate::state::AppState;
+
+const PROMETHEUS_TEXT_FORMAT: &str = "text/plain; version=0.0.4; charset=utf-8";
+const WORKER_OUTCOME: &str = "outcome";
+const FAILURE_CLASS: &str = "failure_class";
+const CLEANUP_OUTCOME: &str = "outcome";
+const ARTIFACT: &str = "artifact";
+
+#[derive(Clone)]
+pub struct Metrics {
+    registry: Registry,
+    worker_jobs_total: IntCounterVec,
+    retention_cleanup_artifacts_total: IntCounterVec,
+    retained_audio_bytes: IntGauge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetentionArtifact {
+    Chunk,
+    ComposedAudio,
+}
+
+impl RetentionArtifact {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Chunk => "chunk",
+            Self::ComposedAudio => "composed_audio",
+        }
+    }
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let registry = Registry::new();
+        let worker_jobs_total = IntCounterVec::new(
+            Opts::new(
+                "oracy_transcription_worker_jobs_total",
+                "Transcription worker job outcomes.",
+            ),
+            &[WORKER_OUTCOME, FAILURE_CLASS],
+        )
+        .expect("worker metric definition is valid");
+        let retention_cleanup_artifacts_total = IntCounterVec::new(
+            Opts::new(
+                "oracy_retention_cleanup_artifacts_total",
+                "Retention cleanup artifact outcomes.",
+            ),
+            &[CLEANUP_OUTCOME, ARTIFACT],
+        )
+        .expect("retention cleanup metric definition is valid");
+        let retained_audio_bytes = IntGauge::new(
+            "oracy_retained_audio_bytes",
+            "Current retained accepted-audio bytes.",
+        )
+        .expect("retained audio metric definition is valid");
+
+        register(&registry, worker_jobs_total.clone());
+        register(&registry, retention_cleanup_artifacts_total.clone());
+        register(&registry, retained_audio_bytes.clone());
+
+        let metrics = Self {
+            registry,
+            worker_jobs_total,
+            retention_cleanup_artifacts_total,
+            retained_audio_bytes,
+        };
+        metrics.initialize_series();
+        metrics
+    }
+
+    pub fn record_worker_succeeded(&self) {
+        self.worker_jobs_total
+            .with_label_values(&["succeeded", "none"])
+            .inc();
+    }
+
+    pub fn record_worker_retry_waiting(&self, failure_code: &str) {
+        self.worker_jobs_total
+            .with_label_values(&["retry_waiting", bounded_failure_class(failure_code)])
+            .inc();
+    }
+
+    pub fn record_worker_failed(&self, failure_code: &str) {
+        self.worker_jobs_total
+            .with_label_values(&["failed", bounded_failure_class(failure_code)])
+            .inc();
+    }
+
+    pub fn record_retention_cleanup_succeeded(&self, artifact: RetentionArtifact) {
+        self.retention_cleanup_artifacts_total
+            .with_label_values(&["succeeded", artifact.as_label()])
+            .inc();
+    }
+
+    pub fn record_retention_cleanup_failed(&self, artifact: RetentionArtifact) {
+        self.retention_cleanup_artifacts_total
+            .with_label_values(&["failed", artifact.as_label()])
+            .inc();
+    }
+
+    fn refresh_retained_audio_bytes(&self, accepted_audio_dir: &Path) -> io::Result<()> {
+        // v0.1.0 favors scrape-time filesystem truth over maintaining a second
+        // byte ledger. If scrape latency matters later, this metric can be
+        // moved behind a cached walk without changing the exposition contract.
+        self.retained_audio_bytes
+            .set(retained_audio_bytes(accepted_audio_dir)?);
+        Ok(())
+    }
+
+    fn encode(&self) -> Result<String, prometheus::Error> {
+        let encoder = TextEncoder::new();
+        let metric_families = self.registry.gather();
+        let mut output = String::new();
+        encoder.encode_utf8(&metric_families, &mut output)?;
+        Ok(output)
+    }
+
+    fn initialize_series(&self) {
+        for (outcome, failure_class) in [
+            ("succeeded", "none"),
+            ("retry_waiting", "engine_timeout"),
+            ("retry_waiting", "engine_rate_limited"),
+            ("retry_waiting", "engine_error"),
+            ("failed", "audio_invalid"),
+            ("failed", "engine_timeout"),
+            ("failed", "engine_rate_limited"),
+            ("failed", "engine_error"),
+            ("failed", "storage_error"),
+            ("failed", "internal_error"),
+        ] {
+            let _ = self
+                .worker_jobs_total
+                .get_metric_with_label_values(&[outcome, failure_class])
+                .expect("initialized worker metric label values are valid");
+        }
+
+        for (outcome, artifact) in [
+            ("succeeded", "chunk"),
+            ("succeeded", "composed_audio"),
+            ("failed", "chunk"),
+            ("failed", "composed_audio"),
+        ] {
+            let _ = self
+                .retention_cleanup_artifacts_total
+                .get_metric_with_label_values(&[outcome, artifact])
+                .expect("initialized retention metric label values are valid");
+        }
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub async fn prometheus_metrics(State(state): State<AppState>) -> impl IntoResponse {
+    if state
+        .metrics
+        .refresh_retained_audio_bytes(&state.accepted_audio_dir)
+        .is_err()
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            "failed to collect metrics\n".to_owned(),
+        );
+    }
+
+    match state.metrics.encode() {
+        Ok(body) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, PROMETHEUS_TEXT_FORMAT)],
+            body,
+        ),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            "failed to encode metrics\n".to_owned(),
+        ),
+    }
+}
+
+fn bounded_failure_class(failure_code: &str) -> &'static str {
+    match failure_code {
+        "audio_invalid" => "audio_invalid",
+        "engine_timeout" => "engine_timeout",
+        "engine_rate_limited" => "engine_rate_limited",
+        "engine_error" => "engine_error",
+        "storage_error" => "storage_error",
+        "internal_error" => "internal_error",
+        _ => "internal_error",
+    }
+}
+
+fn register<C>(registry: &Registry, collector: C)
+where
+    C: Collector + Clone + 'static,
+{
+    registry
+        .register(Box::new(collector))
+        .expect("metric registration is valid");
+}
+
+fn retained_audio_bytes(path: &Path) -> io::Result<i64> {
+    let mut total = 0_i64;
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_dir() {
+            total += retained_audio_bytes(&entry.path())?;
+        } else if metadata.is_file() {
+            total += metadata.len() as i64;
+        }
+    }
+    Ok(total)
+}

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -110,6 +110,8 @@ impl Metrics {
         // v0.1.0 favors scrape-time filesystem truth over maintaining a second
         // byte ledger. If scrape latency matters later, this metric can be
         // moved behind a cached walk without changing the exposition contract.
+        // Concurrent mutation during the walk is normal; missing entries are
+        // skipped silently.
         self.retained_audio_bytes
             .set(retained_audio_bytes(accepted_audio_dir)?);
         Ok(())
@@ -210,16 +212,142 @@ where
         .expect("metric registration is valid");
 }
 
-fn retained_audio_bytes(path: &Path) -> io::Result<i64> {
-    let mut total = 0_i64;
-    for entry in std::fs::read_dir(path)? {
-        let entry = entry?;
-        let metadata = entry.metadata()?;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetainedAudioEntryMetadata {
+    Directory,
+    File { len: u64 },
+    Other,
+}
+
+trait RetainedAudioFilesystem {
+    fn read_dir_paths(&self, path: &Path) -> io::Result<Vec<std::path::PathBuf>>;
+
+    fn metadata(&self, path: &Path) -> io::Result<RetainedAudioEntryMetadata>;
+}
+
+struct StdRetainedAudioFilesystem;
+
+impl RetainedAudioFilesystem for StdRetainedAudioFilesystem {
+    fn read_dir_paths(&self, path: &Path) -> io::Result<Vec<std::path::PathBuf>> {
+        std::fs::read_dir(path)?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect()
+    }
+
+    fn metadata(&self, path: &Path) -> io::Result<RetainedAudioEntryMetadata> {
+        let metadata = std::fs::symlink_metadata(path)?;
         if metadata.is_dir() {
-            total += retained_audio_bytes(&entry.path())?;
+            Ok(RetainedAudioEntryMetadata::Directory)
         } else if metadata.is_file() {
-            total += metadata.len() as i64;
+            Ok(RetainedAudioEntryMetadata::File {
+                len: metadata.len(),
+            })
+        } else {
+            Ok(RetainedAudioEntryMetadata::Other)
         }
     }
+}
+
+fn retained_audio_bytes(path: &Path) -> io::Result<i64> {
+    retained_audio_bytes_in(path, &StdRetainedAudioFilesystem)
+}
+
+fn retained_audio_bytes_in(
+    path: &Path,
+    filesystem: &impl RetainedAudioFilesystem,
+) -> io::Result<i64> {
+    let mut total = 0_i64;
+    for entry_path in filesystem.read_dir_paths(path)? {
+        total += retained_audio_entry_bytes_in(&entry_path, filesystem)?;
+    }
     Ok(total)
+}
+
+#[cfg(test)]
+fn retained_audio_entry_bytes(path: &Path) -> io::Result<i64> {
+    retained_audio_entry_bytes_in(path, &StdRetainedAudioFilesystem)
+}
+
+fn retained_audio_entry_bytes_in(
+    path: &Path,
+    filesystem: &impl RetainedAudioFilesystem,
+) -> io::Result<i64> {
+    let metadata = match filesystem.metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+
+    match metadata {
+        RetainedAudioEntryMetadata::Directory => match retained_audio_bytes_in(path, filesystem) {
+            Ok(bytes) => Ok(bytes),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(0),
+            Err(error) => Err(error),
+        },
+        RetainedAudioEntryMetadata::File { len } => Ok(len as i64),
+        RetainedAudioEntryMetadata::Other => Ok(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::path::{Path, PathBuf};
+
+    use super::{
+        RetainedAudioEntryMetadata, RetainedAudioFilesystem, retained_audio_bytes_in,
+        retained_audio_entry_bytes,
+    };
+
+    struct MockRetainedAudioFilesystem {
+        root: PathBuf,
+        remaining: PathBuf,
+        vanished: PathBuf,
+    }
+
+    impl RetainedAudioFilesystem for MockRetainedAudioFilesystem {
+        fn read_dir_paths(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
+            if path == self.root {
+                Ok(vec![self.remaining.clone(), self.vanished.clone()])
+            } else {
+                panic!("unexpected read_dir path: {}", path.display());
+            }
+        }
+
+        fn metadata(&self, path: &Path) -> io::Result<RetainedAudioEntryMetadata> {
+            if path == self.remaining {
+                Ok(RetainedAudioEntryMetadata::File { len: 5 })
+            } else if path == self.vanished {
+                Err(io::Error::new(io::ErrorKind::NotFound, "vanished"))
+            } else {
+                panic!("unexpected metadata path: {}", path.display());
+            }
+        }
+    }
+
+    #[test]
+    fn retained_audio_entry_bytes_skips_entries_removed_before_metadata_read() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let vanished = tempdir.path().join("vanished.wav");
+
+        let bytes = retained_audio_entry_bytes(&vanished).expect("vanished entry is ignored");
+
+        assert_eq!(bytes, 0);
+    }
+
+    #[test]
+    fn retained_audio_bytes_skips_entries_removed_after_directory_snapshot() {
+        let root = PathBuf::from("/accepted-audio");
+        let remaining = root.join("remaining.wav");
+        let vanished = root.join("vanished.wav");
+        let filesystem = MockRetainedAudioFilesystem {
+            root: root.clone(),
+            remaining,
+            vanished,
+        };
+
+        let bytes = retained_audio_bytes_in(&root, &filesystem).expect("walk should succeed");
+
+        assert_eq!(bytes, 5);
+    }
 }

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -6,6 +6,7 @@ use crate::metadata::{
     create_session, create_tag, delete_session, delete_tag, get_session, get_tag, list_sessions,
     list_tags, patch_session, patch_tag,
 };
+use crate::metrics::prometheus_metrics;
 use crate::settings::{get_settings, patch_settings};
 use crate::state::AppState;
 use crate::transcription_jobs;
@@ -44,5 +45,11 @@ pub fn build_router(state: AppState) -> Router {
         )
         .fallback(|| async { Err::<(), _>(ApiError::not_found("Resource not found.")) })
         .method_not_allowed_fallback(|| async { Err::<(), _>(ApiError::method_not_allowed()) })
+        .with_state(state)
+}
+
+pub fn build_operator_router(state: AppState) -> Router {
+    Router::new()
+        .route("/metrics", get(prometheus_metrics))
         .with_state(state)
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{fmt, fmt::Debug};
@@ -5,12 +6,15 @@ use std::{fmt, fmt::Debug};
 use axum::extract::FromRef;
 
 use crate::auth::AuthStore;
+use crate::metrics::Metrics;
 use crate::storage::Storage;
 
 #[derive(Clone)]
 pub struct AppState {
     pub accepted_audio_dir: PathBuf,
     pub auth_store: Arc<AuthStore>,
+    pub metrics: Metrics,
+    pub operator_listen_addr: SocketAddr,
     pub openai_api_key: String,
     pub storage: Storage,
 }
@@ -21,6 +25,8 @@ impl Debug for AppState {
             .debug_struct("AppState")
             .field("accepted_audio_dir", &self.accepted_audio_dir)
             .field("auth_store", &self.auth_store)
+            .field("metrics", &"<metrics>")
+            .field("operator_listen_addr", &self.operator_listen_addr)
             .field("openai_api_key", &"<redacted>")
             .field("storage", &self.storage)
             .finish()

--- a/backend/src/transcription_worker.rs
+++ b/backend/src/transcription_worker.rs
@@ -10,6 +10,7 @@ use time::{Duration, OffsetDateTime};
 use tokio::process::Command;
 use ulid::Ulid;
 
+use crate::metrics::Metrics;
 use crate::storage::{
     NewSegment, NewVoiceNote, NewVoiceNoteVersion, RetryOutcome, Storage, StorageError,
     TerminalJobFailure, TransientJobFailure, VoiceNoteMaterialization,
@@ -527,6 +528,7 @@ pub async fn process_one_available_job<E, D>(
     engine: &E,
     duration_probe: &D,
     config: WorkerConfig,
+    metrics: &Metrics,
 ) -> Result<ProcessOutcome, WorkerError>
 where
     E: TranscriptionEngine,
@@ -578,6 +580,7 @@ where
                     now: OffsetDateTime::now_utc(),
                 })
                 .await?;
+            metrics.record_worker_failed("audio_invalid");
             return Ok(ProcessOutcome::Failed { job_id: job.id });
         }
     };
@@ -588,6 +591,7 @@ where
             message,
             retry_after_seconds,
         }) => {
+            let metric_failure_code = failure_code.clone();
             let now = OffsetDateTime::now_utc();
             let next_attempt_at = now + Duration::seconds(retry_after_seconds.unwrap_or(60).max(1));
             let outcome = storage
@@ -603,15 +607,20 @@ where
                 .await?;
             return match outcome {
                 RetryOutcome::RetryWaiting(job) => {
+                    metrics.record_worker_retry_waiting(&metric_failure_code);
                     Ok(ProcessOutcome::RetryWaiting { job_id: job.id })
                 }
-                RetryOutcome::Failed(job) => Ok(ProcessOutcome::Failed { job_id: job.id }),
+                RetryOutcome::Failed(job) => {
+                    metrics.record_worker_failed(&metric_failure_code);
+                    Ok(ProcessOutcome::Failed { job_id: job.id })
+                }
             };
         }
         Err(EngineFailure::Terminal {
             failure_code,
             message,
         }) => {
+            let metric_failure_code = failure_code.clone();
             storage
                 .fail_leased_job(TerminalJobFailure {
                     api_key_id: job.api_key_id.clone(),
@@ -623,6 +632,7 @@ where
                     now: OffsetDateTime::now_utc(),
                 })
                 .await?;
+            metrics.record_worker_failed(&metric_failure_code);
             return Ok(ProcessOutcome::Failed { job_id: job.id });
         }
     };
@@ -668,6 +678,7 @@ where
         )
         .await?;
 
+    metrics.record_worker_succeeded();
     Ok(ProcessOutcome::Succeeded { job_id: job.id })
 }
 
@@ -676,12 +687,21 @@ pub async fn run_worker_loop<E, D>(
     engine: E,
     duration_probe: D,
     config: WorkerConfig,
+    metrics: Metrics,
 ) where
     E: TranscriptionEngine + Sync,
     D: DurationProbe + Sync,
 {
     loop {
-        match process_one_available_job(&storage, &engine, &duration_probe, config.clone()).await {
+        match process_one_available_job(
+            &storage,
+            &engine,
+            &duration_probe,
+            config.clone(),
+            &metrics,
+        )
+        .await
+        {
             Ok(ProcessOutcome::NoJob) => tokio::time::sleep(config.idle_sleep).await,
             Ok(_) => {}
             Err(error) => {

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -474,6 +474,8 @@ impl MetadataFixture {
         let app = build_router(AppState {
             accepted_audio_dir,
             auth_store: Arc::new(auth_store),
+            metrics: oracy_backend::metrics::Metrics::new(),
+            operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
         });

--- a/backend/tests/metrics.rs
+++ b/backend/tests/metrics.rs
@@ -1,0 +1,171 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use oracy_backend::bootstrap::load_runtime_from_path;
+use oracy_backend::metrics::RetentionArtifact;
+use oracy_backend::router::{build_operator_router, build_router};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+#[tokio::test]
+async fn operator_metrics_endpoint_exposes_initial_prometheus_series() {
+    let fixture = MetricsFixture::new().await;
+    tokio::fs::create_dir(fixture.accepted_audio_dir.join("job-a"))
+        .await
+        .expect("create retained audio dir");
+    tokio::fs::write(
+        fixture
+            .accepted_audio_dir
+            .join("job-a")
+            .join("accepted.wav"),
+        b"audio",
+    )
+    .await
+    .expect("write retained audio");
+
+    let response = build_operator_router(fixture.state.clone())
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content type"),
+        "text/plain; version=0.0.4; charset=utf-8"
+    );
+    let body = body_text(response).await;
+
+    assert!(body.contains("# HELP oracy_transcription_worker_jobs_total"));
+    assert!(body.contains("# TYPE oracy_transcription_worker_jobs_total counter"));
+    assert!(body.contains("oracy_transcription_worker_jobs_total"));
+    assert!(body.contains(r#"outcome="succeeded""#));
+    assert!(body.contains(r#"failure_class="none""#));
+    assert!(body.contains("oracy_retention_cleanup_artifacts_total"));
+    assert!(body.contains(r#"artifact="chunk""#));
+    assert!(body.contains("# HELP oracy_retained_audio_bytes"));
+    assert!(body.contains("# TYPE oracy_retained_audio_bytes gauge"));
+    assert!(body.contains("oracy_retained_audio_bytes 5"));
+}
+
+#[tokio::test]
+async fn public_api_does_not_expose_metrics_endpoint() {
+    let fixture = MetricsFixture::new().await;
+
+    let response = build_router(fixture.state)
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn retention_cleanup_metrics_increment_with_bounded_artifact_labels() {
+    let fixture = MetricsFixture::new().await;
+    fixture
+        .state
+        .metrics
+        .record_retention_cleanup_succeeded(RetentionArtifact::Chunk);
+    fixture
+        .state
+        .metrics
+        .record_retention_cleanup_failed(RetentionArtifact::ComposedAudio);
+
+    let response = build_operator_router(fixture.state.clone())
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let body = body_text(response).await;
+
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_retention_cleanup_artifacts_total",
+        &[r#"outcome="succeeded""#, r#"artifact="chunk""#],
+        "1",
+    );
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_retention_cleanup_artifacts_total",
+        &[r#"outcome="failed""#, r#"artifact="composed_audio""#],
+        "1",
+    );
+}
+
+struct MetricsFixture {
+    _tempdir: TempDir,
+    accepted_audio_dir: std::path::PathBuf,
+    state: oracy_backend::state::AppState,
+}
+
+impl MetricsFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let accepted_audio_dir = tempdir.path().join("accepted-audio");
+        tokio::fs::create_dir(&accepted_audio_dir)
+            .await
+            .expect("create accepted audio dir");
+        let config_path = tempdir.path().join("oracy.toml");
+        tokio::fs::write(
+            &config_path,
+            format!(
+                r#"
+accepted_audio_dir = "{}"
+database_path = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "alpha-secret"
+"#,
+                accepted_audio_dir.display(),
+                tempdir.path().join("oracy.sqlite").display()
+            )
+            .trim_start(),
+        )
+        .await
+        .expect("write config");
+        let (_, state) = load_runtime_from_path(&config_path)
+            .await
+            .expect("valid runtime");
+
+        Self {
+            _tempdir: tempdir,
+            accepted_audio_dir,
+            state,
+        }
+    }
+}
+
+async fn body_text(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    String::from_utf8(bytes.to_vec()).expect("utf8 body")
+}
+
+fn assert_metric_sample_has_value(body: &str, name: &str, labels: &[&str], value: &str) {
+    assert!(
+        body.lines().any(|line| {
+            line.starts_with(name)
+                && labels.iter().all(|label| line.contains(label))
+                && line.ends_with(&format!(" {value}"))
+        }),
+        "expected {name} with labels {labels:?} and value {value} in:\n{body}"
+    );
+}

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -198,8 +198,29 @@ async fn startup_rejects_ipv6_wildcard_listener_that_overlaps_ipv4_operator_list
 }
 
 #[tokio::test]
+async fn startup_rejects_ipv4_mapped_ipv6_listener_that_overlaps_ipv4_listener() {
+    assert_listener_pair_rejected("[::ffff:127.0.0.1]:8080", "127.0.0.1:8080").await;
+    assert_listener_pair_rejected("127.0.0.1:8080", "[::ffff:127.0.0.1]:8080").await;
+}
+
+#[tokio::test]
+async fn startup_rejects_ipv4_mapped_ipv6_wildcard_listener_that_overlaps_ipv4_wildcard_listener() {
+    assert_listener_pair_rejected("[::ffff:0.0.0.0]:8080", "0.0.0.0:8080").await;
+}
+
+#[tokio::test]
 async fn startup_accepts_ipv4_wildcard_and_ipv6_concrete_listeners_on_same_port() {
     assert_listener_pair_accepted("0.0.0.0:8080", "[::1]:8080").await;
+}
+
+#[tokio::test]
+async fn startup_accepts_ipv4_mapped_ipv6_and_ipv4_listeners_on_different_ports() {
+    assert_listener_pair_accepted("[::ffff:127.0.0.1]:8080", "127.0.0.1:8081").await;
+}
+
+#[tokio::test]
+async fn startup_accepts_ipv4_mapped_ipv6_and_ipv6_loopback_listeners_on_same_port() {
+    assert_listener_pair_accepted("[::ffff:127.0.0.1]:8080", "[::1]:8080").await;
 }
 
 #[tokio::test]

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -179,13 +179,74 @@ key = "key-one"
 
 #[tokio::test]
 async fn startup_rejects_operator_listener_that_collides_with_public_listener() {
+    assert_listener_pair_rejected("127.0.0.1:8088", "127.0.0.1:8088").await;
+}
+
+#[tokio::test]
+async fn startup_rejects_ipv4_wildcard_listener_that_overlaps_concrete_operator_listener() {
+    assert_listener_pair_rejected("0.0.0.0:8080", "127.0.0.1:8080").await;
+}
+
+#[tokio::test]
+async fn startup_rejects_ipv6_wildcard_listener_that_overlaps_concrete_operator_listener() {
+    assert_listener_pair_rejected("[::]:8080", "[::1]:8080").await;
+}
+
+#[tokio::test]
+async fn startup_rejects_ipv6_wildcard_listener_that_overlaps_ipv4_operator_listener() {
+    assert_listener_pair_rejected("[::]:8080", "127.0.0.1:8080").await;
+}
+
+#[tokio::test]
+async fn startup_accepts_ipv4_wildcard_and_ipv6_concrete_listeners_on_same_port() {
+    assert_listener_pair_accepted("0.0.0.0:8080", "[::1]:8080").await;
+}
+
+#[tokio::test]
+async fn startup_accepts_loopback_listeners_on_different_ports() {
+    assert_listener_pair_accepted("127.0.0.1:8080", "127.0.0.1:8081").await;
+}
+
+#[tokio::test]
+async fn startup_accepts_wildcard_listeners_on_different_ports() {
+    assert_listener_pair_accepted("0.0.0.0:8080", "0.0.0.0:8081").await;
+}
+
+async fn assert_listener_pair_rejected(listen_addr: &str, operator_listen_addr: &str) {
     let tempdir = TempDir::new().expect("tempdir");
-    let config_path = write_config(
-        &tempdir,
+    let config_path = write_listener_config(&tempdir, listen_addr, operator_listen_addr);
+
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("overlapping public and operator listeners should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("operator_listen_addr must not overlap listen_addr")
+    );
+}
+
+async fn assert_listener_pair_accepted(listen_addr: &str, operator_listen_addr: &str) {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_listener_config(&tempdir, listen_addr, operator_listen_addr);
+
+    load_runtime_from_path(&config_path)
+        .await
+        .expect("non-overlapping public and operator listeners should be accepted");
+}
+
+fn write_listener_config(
+    tempdir: &TempDir,
+    listen_addr: &str,
+    operator_listen_addr: &str,
+) -> std::path::PathBuf {
+    write_config(
+        tempdir,
         format!(
             r#"
-listen_addr = "127.0.0.1:8088"
-operator_listen_addr = "127.0.0.1:8088"
+listen_addr = "{listen_addr}"
+operator_listen_addr = "{operator_listen_addr}"
 accepted_audio_dir = "{}"
 
 [[api_keys]]
@@ -194,17 +255,7 @@ key = "key-one"
 "#,
             tempdir.path().display()
         ),
-    );
-
-    let error = load_runtime_from_path(&config_path)
-        .await
-        .expect_err("colliding public and operator listeners should fail");
-
-    assert!(
-        error
-            .to_string()
-            .contains("operator_listen_addr must differ from listen_addr")
-    );
+    )
 }
 
 #[tokio::test]

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -123,6 +123,91 @@ key = "key-one"
 }
 
 #[tokio::test]
+async fn startup_defaults_operator_listener_to_loopback_metrics_port() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display()
+        ),
+    );
+
+    let (_, state) = load_runtime_from_path(&config_path)
+        .await
+        .expect("valid runtime");
+
+    assert_eq!(
+        state.operator_listen_addr,
+        "127.0.0.1:9090".parse().expect("valid socket address")
+    );
+}
+
+#[tokio::test]
+async fn startup_accepts_custom_operator_listener() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+operator_listen_addr = "127.0.0.1:9099"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display()
+        ),
+    );
+
+    let (_, state) = load_runtime_from_path(&config_path)
+        .await
+        .expect("valid runtime");
+
+    assert_eq!(
+        state.operator_listen_addr,
+        "127.0.0.1:9099".parse().expect("valid socket address")
+    );
+}
+
+#[tokio::test]
+async fn startup_rejects_operator_listener_that_collides_with_public_listener() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+listen_addr = "127.0.0.1:8088"
+operator_listen_addr = "127.0.0.1:8088"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            tempdir.path().display()
+        ),
+    );
+
+    let error = load_runtime_from_path(&config_path)
+        .await
+        .expect_err("colliding public and operator listeners should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("operator_listen_addr must differ from listen_addr")
+    );
+}
+
+#[tokio::test]
 #[ignore = "helper subprocess only"]
 async fn startup_accepts_non_empty_openai_api_key_env_helper() {
     load_runtime_from_env()

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -612,6 +612,8 @@ impl TranscriptionJobFixture {
         let app = build_router(AppState {
             accepted_audio_dir: accepted_audio_dir.clone(),
             auth_store: Arc::new(auth_store),
+            metrics: oracy_backend::metrics::Metrics::new(),
+            operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
         });

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -2,10 +2,17 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use axum::body::Body;
 use axum::extract::Multipart;
+use axum::http::Request;
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Json, Router};
+use oracy_backend::auth::AuthStore;
+use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::metrics::Metrics;
+use oracy_backend::router::build_operator_router;
+use oracy_backend::state::AppState;
 use oracy_backend::storage::{AcceptJobOutcome, NewTranscriptionJob, Storage};
 use oracy_backend::transcription_worker::{
     AudioSliceError, AudioSlicer, DurationProbe, DurationProbeError, EngineFailure,
@@ -17,6 +24,7 @@ use tempfile::TempDir;
 use time::Duration as TimeDuration;
 use time::OffsetDateTime;
 use time::macros::datetime;
+use tower::util::ServiceExt;
 
 #[tokio::test]
 async fn worker_materializes_a_queued_job_with_a_fake_engine() {
@@ -25,10 +33,15 @@ async fn worker_materializes_a_queued_job_with_a_fake_engine() {
     let engine = FakeEngine::success("transcribed text");
     let probe = FakeDurationProbe::success(1_480);
 
-    let outcome =
-        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test())
-            .await
-            .expect("process one job");
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &Metrics::new(),
+    )
+    .await
+    .expect("process one job");
 
     assert_eq!(
         outcome,
@@ -80,6 +93,99 @@ async fn worker_materializes_a_queued_job_with_a_fake_engine() {
 }
 
 #[tokio::test]
+async fn worker_success_increments_operator_success_counter() {
+    let fixture = WorkerFixture::new().await;
+    fixture
+        .create_queued_job("attempt-metrics", b"hello audio")
+        .await;
+    let engine = FakeEngine::success("transcribed text");
+    let probe = FakeDurationProbe::success(1_480);
+    let metrics = Metrics::new();
+
+    process_one_available_job(
+        &fixture.storage,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &metrics,
+    )
+    .await
+    .expect("process one job");
+
+    let body = operator_metrics_text(&fixture, metrics).await;
+
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_transcription_worker_jobs_total",
+        &[r#"outcome="succeeded""#, r#"failure_class="none""#],
+        "1",
+    );
+}
+
+#[tokio::test]
+async fn worker_retry_increments_operator_retry_counter_with_failure_class() {
+    let fixture = WorkerFixture::new().await;
+    fixture
+        .create_queued_job("attempt-metrics-retry", b"hello audio")
+        .await;
+    let engine = FakeEngine::transient("engine_error", "temporary engine failure", Some(30));
+    let probe = FakeDurationProbe::success(1_480);
+    let metrics = Metrics::new();
+
+    process_one_available_job(
+        &fixture.storage,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &metrics,
+    )
+    .await
+    .expect("process one job");
+
+    let body = operator_metrics_text(&fixture, metrics).await;
+
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_transcription_worker_jobs_total",
+        &[
+            r#"outcome="retry_waiting""#,
+            r#"failure_class="engine_error""#,
+        ],
+        "1",
+    );
+}
+
+#[tokio::test]
+async fn worker_terminal_failure_increments_operator_failure_counter_with_failure_class() {
+    let fixture = WorkerFixture::new().await;
+    fixture
+        .create_queued_job("attempt-metrics-failure", b"not audio")
+        .await;
+    let engine = FakeEngine::success("unused");
+    let probe = FakeDurationProbe::invalid_audio();
+    let metrics = Metrics::new();
+
+    process_one_available_job(
+        &fixture.storage,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &metrics,
+    )
+    .await
+    .expect("process one job");
+
+    let body = operator_metrics_text(&fixture, metrics).await;
+
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_transcription_worker_jobs_total",
+        &[r#"outcome="failed""#, r#"failure_class="audio_invalid""#],
+        "1",
+    );
+}
+
+#[tokio::test]
 async fn worker_marks_duration_probe_failure_as_audio_invalid() {
     let fixture = WorkerFixture::new().await;
     let job = fixture
@@ -88,10 +194,15 @@ async fn worker_marks_duration_probe_failure_as_audio_invalid() {
     let engine = FakeEngine::success("unused");
     let probe = FakeDurationProbe::invalid_audio();
 
-    let outcome =
-        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test())
-            .await
-            .expect("process one job");
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &Metrics::new(),
+    )
+    .await
+    .expect("process one job");
 
     assert_eq!(
         outcome,
@@ -120,10 +231,15 @@ async fn worker_routes_transient_engine_failure_to_retry_waiting() {
     let engine = FakeEngine::transient("engine_error", "temporary engine failure", Some(30));
     let probe = FakeDurationProbe::success(1_480);
 
-    let outcome =
-        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test())
-            .await
-            .expect("process one job");
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &Metrics::new(),
+    )
+    .await
+    .expect("process one job");
 
     assert_eq!(
         outcome,
@@ -163,7 +279,13 @@ async fn stalled_openai_request_records_transient_timeout_and_worker_processes_n
 
     let first = tokio::time::timeout(
         Duration::from_secs(1),
-        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test()),
+        process_one_available_job(
+            &fixture.storage,
+            &engine,
+            &probe,
+            WorkerConfig::test(),
+            &Metrics::new(),
+        ),
     )
     .await
     .expect("stalled request should be bounded")
@@ -185,7 +307,13 @@ async fn stalled_openai_request_records_transient_timeout_and_worker_processes_n
 
     let second = tokio::time::timeout(
         Duration::from_secs(1),
-        process_one_available_job(&fixture.storage, &engine, &probe, WorkerConfig::test()),
+        process_one_available_job(
+            &fixture.storage,
+            &engine,
+            &probe,
+            WorkerConfig::test(),
+            &Metrics::new(),
+        ),
     )
     .await
     .expect("worker should remain available after timeout")
@@ -232,7 +360,14 @@ async fn worker_renews_processing_lease_while_transcription_outlives_initial_lea
     };
 
     let handle = tokio::spawn(async move {
-        process_one_available_job(&storage_for_worker, &engine, &probe, config).await
+        process_one_available_job(
+            &storage_for_worker,
+            &engine,
+            &probe,
+            config,
+            &Metrics::new(),
+        )
+        .await
     });
     tokio::time::sleep(Duration::from_millis(75)).await;
 
@@ -320,6 +455,46 @@ impl WorkerFixture {
             other => panic!("expected created job, got {other:?}"),
         }
     }
+}
+
+async fn operator_metrics_text(fixture: &WorkerFixture, metrics: Metrics) -> String {
+    let auth_store = AuthStore::try_from_configs(&[ApiKeyConfig {
+        api_key_id: "owner-a".to_owned(),
+        key: "owner-secret".to_owned(),
+    }])
+    .expect("auth config");
+    let state = AppState {
+        accepted_audio_dir: fixture.accepted_audio_dir.clone(),
+        auth_store: Arc::new(auth_store),
+        metrics,
+        operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
+        openai_api_key: "test-openai-key".to_owned(),
+        storage: fixture.storage.clone(),
+    };
+    let response = build_operator_router(state)
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    String::from_utf8(bytes.to_vec()).expect("utf8 body")
+}
+
+fn assert_metric_sample_has_value(body: &str, name: &str, labels: &[&str], value: &str) {
+    assert!(
+        body.lines().any(|line| {
+            line.starts_with(name)
+                && labels.iter().all(|label| line.contains(label))
+                && line.ends_with(&format!(" {value}"))
+        }),
+        "expected {name} with labels {labels:?} and value {value} in:\n{body}"
+    );
 }
 
 #[derive(Clone)]

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -918,6 +918,8 @@ impl VoiceNoteFixture {
         let app = build_router(AppState {
             accepted_audio_dir,
             auth_store: Arc::new(auth_store),
+            metrics: oracy_backend::metrics::Metrics::new(),
+            operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
         });

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -80,7 +80,7 @@ required, not optional.
   public API listener.
 - The default operator listener is `127.0.0.1:9090`; operators may
   override it with `operator_listen_addr`.
-- `operator_listen_addr` must not equal the public `listen_addr`.
+- `operator_listen_addr` must not overlap the public `listen_addr` bind set.
 - `GET /metrics` on the operator listener returns Prometheus text
   exposition format version `0.0.4`.
 - `/metrics` is not part of the public API surface and must not be

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -74,6 +74,35 @@ required, not optional.
   shell history, and diagnostics produced by deployment tooling
   outside the backend.
 
+### Operator Metrics
+
+- The backend exposes operator metrics on a listener separate from the
+  public API listener.
+- The default operator listener is `127.0.0.1:9090`; operators may
+  override it with `operator_listen_addr`.
+- `operator_listen_addr` must not equal the public `listen_addr`.
+- `GET /metrics` on the operator listener returns Prometheus text
+  exposition format version `0.0.4`.
+- `/metrics` is not part of the public API surface and must not be
+  reachable through the public listener.
+- v0.1.0 operator metrics rely on network placement as their access
+  boundary. The backend does not require a separate metrics scrape
+  token.
+- Metric names use the Oracy product prefix and Prometheus naming
+  rules: counters end in `_total`, byte gauges end in `_bytes`, and
+  base units are encoded in the metric name when units exist.
+- Metric label values must be bounded enumerations. Safe dimensions
+  include outcome, failure class, artifact type, and documented engine
+  identifiers. Job IDs, API key IDs, idempotency keys, filesystem
+  paths, user content, and free-form error text must not appear as
+  labels.
+- The initial metric set includes transcription-worker job counters
+  for success, retry, and terminal failure outcomes; retention-cleanup
+  artifact counters for success and failure outcomes; and a retained-
+  audio byte gauge for current accepted-audio capacity tracking.
+- Every metric exposed by `/metrics` carries a `# HELP` line and a
+  `# TYPE` line.
+
 ## Constraints
 
 ### Authentication and Ownership
@@ -655,6 +684,9 @@ following are true:
 - Audio retention semantics are explicit: chunks and composed audio
   are released promptly once the originating job reaches `succeeded`
   or `failed`.
+- Operator metrics are exposed only on the operator listener, use the
+  documented naming and cardinality policy, and include the initial
+  worker, retention-cleanup, and retained-audio capacity metrics.
 - Supported audio formats, per-chunk size ceiling, language-hint
   semantics, pagination shape, and error-envelope semantics are
   named concretely.

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -118,7 +118,7 @@ Operators must provision the operator listener with these properties:
 - The default address is `127.0.0.1:9090`.
 - `operator_listen_addr` may override the default when the scraper runs
   outside the backend host namespace.
-- `operator_listen_addr` must differ from public `listen_addr`.
+- `operator_listen_addr` must not overlap the public `listen_addr` bind set.
 - The scrape path is `GET /metrics`.
 - The exposition format is Prometheus text format version `0.0.4`.
 - The recommended scrape interval is `15s`.

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -106,6 +106,28 @@ splitting before OpenAI transcription requests. Operators must provide
 `ffmpeg` and `ffprobe` on `PATH` for the backend process. Startup fails if
 either tool is missing or cannot execute.
 
+## Operator Metrics
+
+The backend exposes Prometheus-compatible metrics from an operator listener
+separate from the public API listener.
+
+Operators must provision the operator listener with these properties:
+
+- The listener is reachable by the Prometheus scraper.
+- The listener is not exposed as an internet-facing public API surface.
+- The default address is `127.0.0.1:9090`.
+- `operator_listen_addr` may override the default when the scraper runs
+  outside the backend host namespace.
+- `operator_listen_addr` must differ from public `listen_addr`.
+- The scrape path is `GET /metrics`.
+- The exposition format is Prometheus text format version `0.0.4`.
+- The recommended scrape interval is `15s`.
+
+Access control for v0.1.0 is network placement. The backend does not require
+an application-level scrape token for `/metrics`; operators protect the surface
+through loopback binding, firewall policy, reverse-proxy policy, or equivalent
+deployment controls.
+
 ## Worked Example
 
 `tesserine/ops` documents one concrete deployment pattern in


### PR DESCRIPTION
## Summary

- Adds a separate operator listener for Prometheus metrics, defaulting to `127.0.0.1:9090`.
- Exposes initial worker, retention-cleanup, and retained-audio capacity metrics with bounded labels.
- Documents the operator metrics contract and links the ecosystem convention companion PR.

## Changes

- Adds `operator_listen_addr`, rejects public/operator listener collisions, and serves `/metrics` only from the operator router.
- Adds the Oracy metrics registry using the direct `prometheus` crate, including initialized series and scrape-time retained-audio byte collection.
- Instruments transcription worker success, retry, and terminal failure outcomes.
- Updates backend README, backend requirements, deployment docs, and changelog.

## GitHub Issue(s)

Refs #66

Companion ADR PR: https://github.com/tesserine/commons/pull/18

## Test plan

- `cargo fmt --check`
- `cargo test` (158 passed, 0 failed, 5 ignored)
- `git diff --check` in both Oracy and commons
