### PR TITLE
feat(transcription-jobs): audio retention lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Release retained transcription audio when jobs reach `succeeded` or `failed`,
+  retry cleanup after transient release failures, and surface per-artifact
+  cleanup outcomes through structured logs and retention metrics.
 - Add an operator-only Prometheus metrics listener with initial worker,
   retention-cleanup, retained-audio capacity metrics, and overlapping bind
   validation.

--- a/backend/migrations/20260503010000_retention_cleanup_attempts.sql
+++ b/backend/migrations/20260503010000_retention_cleanup_attempts.sql
@@ -1,0 +1,11 @@
+ALTER TABLE transcription_jobs
+ADD COLUMN accepted_audio_cleanup_attempts INTEGER NOT NULL DEFAULT 0 CHECK (accepted_audio_cleanup_attempts >= 0);
+
+ALTER TABLE transcription_job_chunks
+ADD COLUMN cleanup_attempts INTEGER NOT NULL DEFAULT 0 CHECK (cleanup_attempts >= 0);
+
+CREATE INDEX transcription_jobs_terminal_retained_audio_idx
+    ON transcription_jobs (status, accepted_audio_path);
+
+CREATE INDEX transcription_job_chunks_retained_audio_idx
+    ON transcription_job_chunks (chunk_path);

--- a/backend/src/audio_durability.rs
+++ b/backend/src/audio_durability.rs
@@ -1,0 +1,70 @@
+use std::io;
+use std::path::{Component, Path};
+
+pub(crate) fn sync_directory(path: &Path) -> io::Result<()> {
+    std::fs::File::open(path)?.sync_all()
+}
+
+pub(crate) fn sync_directory_chain(root: &Path, leaf: &Path) -> io::Result<()> {
+    let relative_leaf = leaf.strip_prefix(root).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "directory sync leaf must be under the durable root",
+        )
+    })?;
+
+    sync_directory(root)?;
+    let mut path = root.to_path_buf();
+    for component in relative_leaf.components() {
+        match component {
+            Component::Normal(name) => {
+                path.push(name);
+                sync_directory(&path)?;
+            }
+            Component::CurDir => {}
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "directory sync leaf must not traverse outside the durable root",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn sync_parent_after_entry_removal(path: &Path) -> io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "removed entry must have a parent directory",
+        ));
+    };
+
+    match sync_directory(parent) {
+        Ok(()) => Ok(()),
+        // If another cleaner has already removed the parent directory, the
+        // retained file's absence is stronger than a synced parent entry.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sync_directory_chain;
+
+    #[test]
+    fn sync_directory_chain_rejects_leaf_outside_root() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let root = tempdir.path().join("accepted-audio");
+        let other = tempdir.path().join("other").join("chunks");
+        std::fs::create_dir(&root).expect("create accepted audio dir");
+        std::fs::create_dir_all(&other).expect("create outside leaf");
+
+        let error = sync_directory_chain(&root, &other).expect_err("outside leaf should fail");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+}

--- a/backend/src/audio_store.rs
+++ b/backend/src/audio_store.rs
@@ -1,8 +1,9 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use tokio::io::{AsyncWriteExt, BufReader};
 use ulid::Ulid;
 
+use crate::audio_durability::sync_directory_chain;
 use crate::storage::ChunkRecord;
 
 pub const MAX_CHUNK_BYTES: usize = 26_214_400;
@@ -60,55 +61,4 @@ pub async fn compose_chunks(
     tokio::fs::rename(&temp_path, &final_path).await?;
     sync_directory_chain(accepted_audio_dir, &job_dir)?;
     Ok(final_path)
-}
-
-fn sync_directory(path: &Path) -> std::io::Result<()> {
-    std::fs::File::open(path)?.sync_all()
-}
-
-fn sync_directory_chain(root: &Path, leaf: &Path) -> std::io::Result<()> {
-    let relative_leaf = leaf.strip_prefix(root).map_err(|_| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "directory sync leaf must be under the durable root",
-        )
-    })?;
-
-    sync_directory(root)?;
-    let mut path = root.to_path_buf();
-    for component in relative_leaf.components() {
-        match component {
-            Component::Normal(name) => {
-                path.push(name);
-                sync_directory(&path)?;
-            }
-            Component::CurDir => {}
-            _ => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "directory sync leaf must not traverse outside the durable root",
-                ));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::sync_directory_chain;
-
-    #[test]
-    fn sync_directory_chain_rejects_leaf_outside_root() {
-        let tempdir = tempfile::TempDir::new().expect("tempdir");
-        let root = tempdir.path().join("accepted-audio");
-        let other = tempdir.path().join("other").join("chunks");
-        std::fs::create_dir(&root).expect("create accepted audio dir");
-        std::fs::create_dir_all(&other).expect("create outside leaf");
-
-        let error = sync_directory_chain(&root, &other).expect_err("outside leaf should fail");
-
-        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
-    }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,6 +10,7 @@ pub mod errors;
 pub mod json;
 pub mod metadata;
 pub mod metrics;
+pub mod retention_cleanup;
 pub mod router;
 pub mod settings;
 pub mod state;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(unix)]
 
+mod audio_durability;
 pub mod audio_hash;
 pub mod audio_store;
 pub mod auth;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use oracy_backend::bootstrap::load_runtime_from_env;
+use oracy_backend::retention_cleanup::{RetentionCleanupConfig, run_retention_cleanup_loop};
 use oracy_backend::router::{build_operator_router, build_router};
 use oracy_backend::transcription_worker::{
     FfmpegAudioSlicer, FfprobeDurationProbe, OpenAiTranscriptionEngine, WorkerConfig,
@@ -27,8 +28,15 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         state.openai_api_key.clone(),
         FfmpegAudioSlicer::openai_limit(),
     );
+    tokio::spawn(run_retention_cleanup_loop(
+        state.storage.clone(),
+        state.accepted_audio_dir.clone(),
+        state.metrics.clone(),
+        RetentionCleanupConfig::default(),
+    ));
     tokio::spawn(run_worker_loop(
         worker_storage,
+        state.accepted_audio_dir.clone(),
         worker_engine,
         FfprobeDurationProbe,
         WorkerConfig::default(),

--- a/backend/src/retention_cleanup.rs
+++ b/backend/src/retention_cleanup.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
@@ -158,16 +159,18 @@ where
     for artifact in artifacts {
         match releaser.release(&artifact).await {
             Ok(()) => {
-                storage
+                let released = storage
                     .mark_retained_audio_artifact_released(&artifact)
                     .await?;
-                metrics.record_retention_cleanup_succeeded(metric_artifact(&artifact));
-                tracing::info!(
-                    job_id = %artifact.job_id,
-                    artifact_kind = artifact_label(&artifact),
-                    artifact_path = %artifact.path.display(),
-                    "retention cleanup released artifact"
-                );
+                if released {
+                    metrics.record_retention_cleanup_succeeded(metric_artifact(&artifact));
+                    tracing::info!(
+                        job_id = %artifact.job_id,
+                        artifact_kind = artifact_label(&artifact),
+                        artifact_path = %artifact.path.display(),
+                        "retention cleanup released artifact"
+                    );
+                }
             }
             Err(error) => {
                 let failure_reason = error.to_string();
@@ -204,9 +207,7 @@ async fn safe_retained_audio_path(
     } else {
         accepted_audio_dir.join(path)
     };
-    if has_parent_component(&target) {
-        return Err(RetentionCleanupError::UnsafePath(target));
-    }
+    let target = lexically_normalize_path(&target);
 
     match tokio::fs::canonicalize(&target).await {
         Ok(canonical_target) => {
@@ -216,14 +217,18 @@ async fn safe_retained_audio_path(
                 Err(RetentionCleanupError::UnsafePath(target))
             }
         }
-        Err(error)
-            if error.kind() == io::ErrorKind::NotFound
-                && (target.starts_with(accepted_audio_dir) || target.starts_with(&root)) =>
-        {
-            Ok(target)
-        }
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            Err(RetentionCleanupError::UnsafePath(target))
+            let resolved_target = resolve_missing_path(&target).await.map_err(|source| {
+                RetentionCleanupError::Inspect {
+                    path: target.clone(),
+                    source,
+                }
+            })?;
+            if resolved_target.starts_with(&root) {
+                Ok(target)
+            } else {
+                Err(RetentionCleanupError::UnsafePath(target))
+            }
         }
         Err(source) => Err(RetentionCleanupError::Inspect {
             path: target,
@@ -232,9 +237,62 @@ async fn safe_retained_audio_path(
     }
 }
 
-fn has_parent_component(path: &Path) -> bool {
-    path.components()
-        .any(|component| matches!(component, Component::ParentDir))
+fn lexically_normalize_path(path: &Path) -> PathBuf {
+    let mut parts = Vec::new();
+    let mut has_root = false;
+
+    for component in path.components() {
+        match component {
+            Component::RootDir => {
+                has_root = true;
+                parts.clear();
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if parts.pop().is_none() && !has_root {
+                    parts.push(OsString::from(".."));
+                }
+            }
+            Component::Normal(part) => parts.push(part.to_os_string()),
+            Component::Prefix(_) => {}
+        }
+    }
+
+    let mut normalized = if has_root {
+        PathBuf::from("/")
+    } else {
+        PathBuf::new()
+    };
+    for part in parts {
+        normalized.push(part);
+    }
+    normalized
+}
+
+async fn resolve_missing_path(path: &Path) -> io::Result<PathBuf> {
+    let mut ancestor = path.to_path_buf();
+    let mut missing = Vec::new();
+
+    loop {
+        match tokio::fs::canonicalize(&ancestor).await {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let Some(file_name) = ancestor.file_name() else {
+                    return Err(error);
+                };
+                missing.push(file_name.to_os_string());
+                if !ancestor.pop() {
+                    return Err(error);
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 async fn cleanup_empty_parent_dirs(root: &Path, parent: Option<&Path>) {

--- a/backend/src/retention_cleanup.rs
+++ b/backend/src/retention_cleanup.rs
@@ -1,7 +1,9 @@
 use std::ffi::OsString;
 use std::io;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
+use crate::audio_durability::sync_parent_after_entry_removal;
 use crate::metrics::{Metrics, RetentionArtifact};
 use crate::storage::{RetainedAudioArtifact, RetainedAudioArtifactKind, Storage, StorageError};
 use thiserror::Error;
@@ -45,6 +47,12 @@ pub enum RetentionCleanupError {
         #[source]
         source: io::Error,
     },
+    #[error("failed to sync retained audio deletion parent for {path}: {source}")]
+    SyncDeletion {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
     #[error("{0}")]
     Storage(#[from] StorageError),
 }
@@ -52,16 +60,46 @@ pub enum RetentionCleanupError {
 #[allow(async_fn_in_trait)]
 pub trait RetainedAudioReleaser {
     async fn release(&self, artifact: &RetainedAudioArtifact) -> Result<(), RetentionCleanupError>;
+
+    async fn after_release_recorded(&self, _artifact: &RetainedAudioArtifact) {}
 }
 
-#[derive(Debug, Clone)]
+trait RetainedAudioDeletionSync: Send + Sync {
+    fn sync_parent_after_entry_removal(&self, target: &Path) -> io::Result<()>;
+}
+
+#[derive(Debug)]
+struct PosixRetainedAudioDeletionSync;
+
+impl RetainedAudioDeletionSync for PosixRetainedAudioDeletionSync {
+    fn sync_parent_after_entry_removal(&self, target: &Path) -> io::Result<()> {
+        sync_parent_after_entry_removal(target)
+    }
+}
+
+#[derive(Clone)]
 pub struct FileRetainedAudioReleaser {
     accepted_audio_dir: PathBuf,
+    deletion_sync: Arc<dyn RetainedAudioDeletionSync>,
 }
 
 impl FileRetainedAudioReleaser {
     pub fn new(accepted_audio_dir: PathBuf) -> Self {
-        Self { accepted_audio_dir }
+        Self {
+            accepted_audio_dir,
+            deletion_sync: Arc::new(PosixRetainedAudioDeletionSync),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_deletion_sync(
+        accepted_audio_dir: PathBuf,
+        deletion_sync: Arc<dyn RetainedAudioDeletionSync>,
+    ) -> Self {
+        Self {
+            accepted_audio_dir,
+            deletion_sync,
+        }
     }
 }
 
@@ -70,14 +108,34 @@ impl RetainedAudioReleaser for FileRetainedAudioReleaser {
         let target = safe_retained_audio_path(&self.accepted_audio_dir, &artifact.path).await?;
         match tokio::fs::remove_file(&target).await {
             Ok(()) => {
-                cleanup_empty_parent_dirs(&self.accepted_audio_dir, target.parent()).await;
+                self.deletion_sync
+                    .sync_parent_after_entry_removal(&target)
+                    .map_err(|source| RetentionCleanupError::SyncDeletion {
+                        path: target,
+                        source,
+                    })?;
                 Ok(())
             }
-            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                self.deletion_sync
+                    .sync_parent_after_entry_removal(&target)
+                    .map_err(|source| RetentionCleanupError::SyncDeletion {
+                        path: target,
+                        source,
+                    })?;
+                Ok(())
+            }
             Err(source) => Err(RetentionCleanupError::Remove {
                 path: target,
                 source,
             }),
+        }
+    }
+
+    async fn after_release_recorded(&self, artifact: &RetainedAudioArtifact) {
+        if let Ok(target) = safe_retained_audio_path(&self.accepted_audio_dir, &artifact.path).await
+        {
+            cleanup_empty_parent_dirs(&self.accepted_audio_dir, target.parent()).await;
         }
     }
 }
@@ -163,6 +221,7 @@ where
                     .mark_retained_audio_artifact_released(&artifact)
                     .await?;
                 if released {
+                    releaser.after_release_recorded(&artifact).await;
                     metrics.record_retention_cleanup_succeeded(metric_artifact(&artifact));
                     tracing::info!(
                         job_id = %artifact.job_id,
@@ -325,5 +384,263 @@ fn metric_artifact(artifact: &RetainedAudioArtifact) -> RetentionArtifact {
     match artifact.kind {
         RetainedAudioArtifactKind::Chunk => RetentionArtifact::Chunk,
         RetainedAudioArtifactKind::ComposedAudio => RetentionArtifact::ComposedAudio,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
+
+    use tempfile::TempDir;
+    use time::macros::datetime;
+
+    use super::*;
+    use crate::metrics::Metrics;
+    use crate::storage::{AcceptJobOutcome, NewTranscriptionJob};
+
+    #[tokio::test]
+    async fn cleanup_records_release_after_releaser_reports_durable_absence() {
+        let fixture = RetentionCleanupFixture::new().await;
+        let artifact_path = fixture
+            .create_terminal_retained_audio_job("durable-ordering")
+            .await;
+        let artifact = fixture.retained_artifacts().await.remove(0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let releaser = RecordingReleaser {
+            events: Arc::clone(&events),
+            storage: fixture.storage.clone(),
+        };
+
+        cleanup_artifacts(&fixture.storage, &Metrics::new(), &releaser, vec![artifact])
+            .await
+            .expect("cleanup artifacts");
+
+        assert_eq!(
+            events.lock().expect("events").as_slice(),
+            ["remove_file", "sync_parent_dir", "db_release_recorded"]
+        );
+        assert_eq!(fixture.retained_artifact_count().await, 0);
+        assert!(
+            tokio::fs::try_exists(&artifact_path)
+                .await
+                .expect("artifact existence check"),
+            "recording releaser does not remove the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn parent_directory_sync_failure_keeps_retained_audio_retryable() {
+        let fixture = RetentionCleanupFixture::new().await;
+        let artifact_path = fixture
+            .create_terminal_retained_audio_job("sync-failure")
+            .await;
+        let releaser = FileRetainedAudioReleaser::new_with_deletion_sync(
+            fixture.accepted_audio_dir.clone(),
+            Arc::new(FailingDeletionSync),
+        );
+
+        cleanup_retained_audio_once_with_releaser(&fixture.storage, &Metrics::new(), &releaser)
+            .await
+            .expect("cleanup failure is recorded internally");
+
+        assert!(
+            !tokio::fs::try_exists(&artifact_path)
+                .await
+                .expect("artifact existence check"),
+            "unlink happens before the failed parent-directory sync"
+        );
+        assert_eq!(fixture.retained_artifact_count().await, 1);
+        assert_eq!(fixture.composed_cleanup_attempts().await, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_retries_after_sync_failure_when_retained_audio_file_is_already_absent() {
+        let fixture = RetentionCleanupFixture::new().await;
+        let artifact_path = fixture
+            .create_terminal_retained_audio_job("sync-failure-retry")
+            .await;
+        let failing_releaser = FileRetainedAudioReleaser::new_with_deletion_sync(
+            fixture.accepted_audio_dir.clone(),
+            Arc::new(FailingDeletionSync),
+        );
+        cleanup_retained_audio_once_with_releaser(
+            &fixture.storage,
+            &Metrics::new(),
+            &failing_releaser,
+        )
+        .await
+        .expect("initial cleanup failure is recorded internally");
+
+        let retry_releaser = FileRetainedAudioReleaser::new_with_deletion_sync(
+            fixture.accepted_audio_dir.clone(),
+            Arc::new(RecordingDeletionSync::default()),
+        );
+        cleanup_retained_audio_once_with_releaser(
+            &fixture.storage,
+            &Metrics::new(),
+            &retry_releaser,
+        )
+        .await
+        .expect("retry cleanup");
+
+        assert!(
+            !tokio::fs::try_exists(&artifact_path)
+                .await
+                .expect("artifact existence check"),
+            "retry observes the retained file is already gone"
+        );
+        assert_eq!(fixture.retained_artifact_count().await, 0);
+        assert_eq!(fixture.composed_cleanup_attempts().await, 1);
+    }
+
+    #[derive(Default)]
+    struct RecordingDeletionSync;
+
+    impl RetainedAudioDeletionSync for RecordingDeletionSync {
+        fn sync_parent_after_entry_removal(&self, _target: &Path) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailingDeletionSync;
+
+    impl RetainedAudioDeletionSync for FailingDeletionSync {
+        fn sync_parent_after_entry_removal(&self, _target: &Path) -> io::Result<()> {
+            Err(io::Error::other("simulated parent-directory sync failure"))
+        }
+    }
+
+    struct RecordingReleaser {
+        events: Arc<Mutex<Vec<&'static str>>>,
+        storage: Storage,
+    }
+
+    impl RetainedAudioReleaser for RecordingReleaser {
+        async fn release(
+            &self,
+            _artifact: &RetainedAudioArtifact,
+        ) -> Result<(), RetentionCleanupError> {
+            self.events.lock().expect("events").push("remove_file");
+            self.events.lock().expect("events").push("sync_parent_dir");
+            Ok(())
+        }
+
+        async fn after_release_recorded(&self, _artifact: &RetainedAudioArtifact) {
+            assert!(
+                self.storage
+                    .retained_audio_artifacts_for_terminal_jobs()
+                    .await
+                    .expect("retained artifacts")
+                    .is_empty(),
+                "storage row is cleared before post-recorded release hook"
+            );
+            self.events
+                .lock()
+                .expect("events")
+                .push("db_release_recorded");
+        }
+    }
+
+    struct RetentionCleanupFixture {
+        _tempdir: TempDir,
+        accepted_audio_dir: PathBuf,
+        storage: Storage,
+    }
+
+    impl RetentionCleanupFixture {
+        async fn new() -> Self {
+            let tempdir = TempDir::new().expect("tempdir");
+            let accepted_audio_dir = tempdir.path().join("accepted-audio");
+            tokio::fs::create_dir(&accepted_audio_dir)
+                .await
+                .expect("create accepted audio dir");
+            let storage = Storage::connect(&tempdir.path().join("oracy.sqlite"))
+                .await
+                .expect("connect storage");
+            Self {
+                _tempdir: tempdir,
+                accepted_audio_dir,
+                storage,
+            }
+        }
+
+        async fn create_terminal_retained_audio_job(&self, idempotency_key: &str) -> PathBuf {
+            let artifact_path = self
+                .accepted_audio_dir
+                .join(format!("{idempotency_key}.wav"));
+            tokio::fs::write(&artifact_path, b"retained audio")
+                .await
+                .expect("write retained audio");
+            let job = match self
+                .storage
+                .accept_job(NewTranscriptionJob {
+                    api_key_id: "owner-a".to_owned(),
+                    idempotency_key: idempotency_key.to_owned(),
+                    audio_sha256_hex: "audio-hash".to_owned(),
+                    recorded_at: datetime!(2026-04-24 17:59:00 UTC),
+                    session_id: None,
+                    language: Some("en".to_owned()),
+                    accepted_audio_path: artifact_path.clone(),
+                    max_retries: 3,
+                    now: datetime!(2026-04-24 18:00:00 UTC),
+                })
+                .await
+                .expect("accept job")
+            {
+                AcceptJobOutcome::Created(job) => job,
+                other => panic!("expected created job, got {other:?}"),
+            };
+            let result = sqlx::query(
+                r#"
+                UPDATE transcription_jobs
+                SET status = 'failed',
+                    failure_code = 'engine_error',
+                    failure_message = 'terminal failure',
+                    retryable_by_client = 1
+                WHERE api_key_id = 'owner-a' AND id = ?
+                "#,
+            )
+            .bind(&job.id)
+            .execute(self.storage.pool())
+            .await
+            .expect("mark job failed");
+            assert_eq!(result.rows_affected(), 1);
+            artifact_path
+        }
+
+        async fn retained_artifacts(&self) -> Vec<RetainedAudioArtifact> {
+            self.storage
+                .retained_audio_artifacts_for_terminal_jobs()
+                .await
+                .expect("retained artifacts")
+        }
+
+        async fn retained_artifact_count(&self) -> i64 {
+            sqlx::query_scalar(
+                r#"
+                SELECT COUNT(*)
+                FROM transcription_jobs
+                WHERE api_key_id = 'owner-a' AND accepted_audio_path <> ''
+                "#,
+            )
+            .fetch_one(self.storage.pool())
+            .await
+            .expect("retained artifact count")
+        }
+
+        async fn composed_cleanup_attempts(&self) -> i64 {
+            sqlx::query_scalar(
+                r#"
+                SELECT accepted_audio_cleanup_attempts
+                FROM transcription_jobs
+                WHERE api_key_id = 'owner-a'
+                "#,
+            )
+            .fetch_one(self.storage.pool())
+            .await
+            .expect("cleanup attempts")
+        }
     }
 }

--- a/backend/src/retention_cleanup.rs
+++ b/backend/src/retention_cleanup.rs
@@ -1,0 +1,271 @@
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use crate::metrics::{Metrics, RetentionArtifact};
+use crate::storage::{RetainedAudioArtifact, RetainedAudioArtifactKind, Storage, StorageError};
+use thiserror::Error;
+
+const DEFAULT_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+#[derive(Debug, Clone)]
+pub struct RetentionCleanupConfig {
+    pub interval: std::time::Duration,
+}
+
+impl Default for RetentionCleanupConfig {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_CLEANUP_INTERVAL,
+        }
+    }
+}
+
+impl RetentionCleanupConfig {
+    pub fn test() -> Self {
+        Self {
+            interval: std::time::Duration::from_millis(10),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RetentionCleanupError {
+    #[error("retained audio path is outside accepted audio directory: {0}")]
+    UnsafePath(PathBuf),
+    #[error("failed to inspect retained audio path {path}: {source}")]
+    Inspect {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to remove retained audio path {path}: {source}")]
+    Remove {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("{0}")]
+    Storage(#[from] StorageError),
+}
+
+#[allow(async_fn_in_trait)]
+pub trait RetainedAudioReleaser {
+    async fn release(&self, artifact: &RetainedAudioArtifact) -> Result<(), RetentionCleanupError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FileRetainedAudioReleaser {
+    accepted_audio_dir: PathBuf,
+}
+
+impl FileRetainedAudioReleaser {
+    pub fn new(accepted_audio_dir: PathBuf) -> Self {
+        Self { accepted_audio_dir }
+    }
+}
+
+impl RetainedAudioReleaser for FileRetainedAudioReleaser {
+    async fn release(&self, artifact: &RetainedAudioArtifact) -> Result<(), RetentionCleanupError> {
+        let target = safe_retained_audio_path(&self.accepted_audio_dir, &artifact.path).await?;
+        match tokio::fs::remove_file(&target).await {
+            Ok(()) => {
+                cleanup_empty_parent_dirs(&self.accepted_audio_dir, target.parent()).await;
+                Ok(())
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(RetentionCleanupError::Remove {
+                path: target,
+                source,
+            }),
+        }
+    }
+}
+
+pub async fn cleanup_retained_audio_for_job(
+    storage: &Storage,
+    accepted_audio_dir: &Path,
+    api_key_id: &str,
+    job_id: &str,
+    metrics: &Metrics,
+) -> Result<(), RetentionCleanupError> {
+    let releaser = FileRetainedAudioReleaser::new(accepted_audio_dir.to_path_buf());
+    cleanup_retained_audio_for_job_with_releaser(storage, api_key_id, job_id, metrics, &releaser)
+        .await
+}
+
+pub async fn cleanup_retained_audio_for_job_with_releaser<R>(
+    storage: &Storage,
+    api_key_id: &str,
+    job_id: &str,
+    metrics: &Metrics,
+    releaser: &R,
+) -> Result<(), RetentionCleanupError>
+where
+    R: RetainedAudioReleaser,
+{
+    let artifacts = storage
+        .retained_audio_artifacts_for_job(api_key_id, job_id)
+        .await?;
+    cleanup_artifacts(storage, metrics, releaser, artifacts).await
+}
+
+pub async fn cleanup_retained_audio_once(
+    storage: &Storage,
+    accepted_audio_dir: &Path,
+    metrics: &Metrics,
+) -> Result<(), RetentionCleanupError> {
+    let releaser = FileRetainedAudioReleaser::new(accepted_audio_dir.to_path_buf());
+    cleanup_retained_audio_once_with_releaser(storage, metrics, &releaser).await
+}
+
+pub async fn cleanup_retained_audio_once_with_releaser<R>(
+    storage: &Storage,
+    metrics: &Metrics,
+    releaser: &R,
+) -> Result<(), RetentionCleanupError>
+where
+    R: RetainedAudioReleaser,
+{
+    let artifacts = storage.retained_audio_artifacts_for_terminal_jobs().await?;
+    cleanup_artifacts(storage, metrics, releaser, artifacts).await
+}
+
+pub async fn run_retention_cleanup_loop(
+    storage: Storage,
+    accepted_audio_dir: PathBuf,
+    metrics: Metrics,
+    config: RetentionCleanupConfig,
+) {
+    loop {
+        if let Err(error) =
+            cleanup_retained_audio_once(&storage, &accepted_audio_dir, &metrics).await
+        {
+            tracing::error!("retention cleanup sweep failed: {error}");
+        }
+        tokio::time::sleep(config.interval).await;
+    }
+}
+
+async fn cleanup_artifacts<R>(
+    storage: &Storage,
+    metrics: &Metrics,
+    releaser: &R,
+    artifacts: Vec<RetainedAudioArtifact>,
+) -> Result<(), RetentionCleanupError>
+where
+    R: RetainedAudioReleaser,
+{
+    for artifact in artifacts {
+        match releaser.release(&artifact).await {
+            Ok(()) => {
+                storage
+                    .mark_retained_audio_artifact_released(&artifact)
+                    .await?;
+                metrics.record_retention_cleanup_succeeded(metric_artifact(&artifact));
+                tracing::info!(
+                    job_id = %artifact.job_id,
+                    artifact_kind = artifact_label(&artifact),
+                    artifact_path = %artifact.path.display(),
+                    "retention cleanup released artifact"
+                );
+            }
+            Err(error) => {
+                let failure_reason = error.to_string();
+                let attempt_count = storage
+                    .record_retained_audio_artifact_cleanup_failure(&artifact)
+                    .await?;
+                metrics.record_retention_cleanup_failed(metric_artifact(&artifact));
+                tracing::error!(
+                    job_id = %artifact.job_id,
+                    artifact_kind = artifact_label(&artifact),
+                    artifact_path = %artifact.path.display(),
+                    failure_reason = %failure_reason,
+                    attempt_count,
+                    "retention cleanup failed to release artifact"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn safe_retained_audio_path(
+    accepted_audio_dir: &Path,
+    path: &Path,
+) -> Result<PathBuf, RetentionCleanupError> {
+    let root = tokio::fs::canonicalize(accepted_audio_dir)
+        .await
+        .map_err(|source| RetentionCleanupError::Inspect {
+            path: accepted_audio_dir.to_path_buf(),
+            source,
+        })?;
+    let target = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        accepted_audio_dir.join(path)
+    };
+    if has_parent_component(&target) {
+        return Err(RetentionCleanupError::UnsafePath(target));
+    }
+
+    match tokio::fs::canonicalize(&target).await {
+        Ok(canonical_target) => {
+            if canonical_target.starts_with(&root) {
+                Ok(target)
+            } else {
+                Err(RetentionCleanupError::UnsafePath(target))
+            }
+        }
+        Err(error)
+            if error.kind() == io::ErrorKind::NotFound
+                && (target.starts_with(accepted_audio_dir) || target.starts_with(&root)) =>
+        {
+            Ok(target)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            Err(RetentionCleanupError::UnsafePath(target))
+        }
+        Err(source) => Err(RetentionCleanupError::Inspect {
+            path: target,
+            source,
+        }),
+    }
+}
+
+fn has_parent_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+async fn cleanup_empty_parent_dirs(root: &Path, parent: Option<&Path>) {
+    let Some(parent) = parent else {
+        return;
+    };
+    let Ok(root) = tokio::fs::canonicalize(root).await else {
+        return;
+    };
+    let mut current = parent.to_path_buf();
+    while current.starts_with(&root) && current != root {
+        if tokio::fs::remove_dir(&current).await.is_err() {
+            break;
+        }
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent.to_path_buf();
+    }
+}
+
+fn artifact_label(artifact: &RetainedAudioArtifact) -> &'static str {
+    match artifact.kind {
+        RetainedAudioArtifactKind::Chunk => "chunk",
+        RetainedAudioArtifactKind::ComposedAudio => "composed_audio",
+    }
+}
+
+fn metric_artifact(artifact: &RetainedAudioArtifact) -> RetentionArtifact {
+    match artifact.kind {
+        RetainedAudioArtifactKind::Chunk => RetentionArtifact::Chunk,
+        RetainedAudioArtifactKind::ComposedAudio => RetentionArtifact::ComposedAudio,
+    }
+}

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -1416,9 +1416,9 @@ impl Storage {
     pub async fn mark_retained_audio_artifact_released(
         &self,
         artifact: &RetainedAudioArtifact,
-    ) -> Result<(), StorageError> {
+    ) -> Result<bool, StorageError> {
         let path = artifact.path.to_string_lossy().into_owned();
-        match artifact.kind {
+        let result = match artifact.kind {
             RetainedAudioArtifactKind::ComposedAudio => {
                 sqlx::query(
                     r#"
@@ -1433,7 +1433,7 @@ impl Storage {
                 .bind(&artifact.job_id)
                 .bind(path)
                 .execute(&self.pool)
-                .await?;
+                .await?
             }
             RetainedAudioArtifactKind::Chunk => {
                 sqlx::query(
@@ -1451,10 +1451,10 @@ impl Storage {
                 .bind(artifact.chunk_index.expect("chunk artifact has index"))
                 .bind(path)
                 .execute(&self.pool)
-                .await?;
+                .await?
             }
-        }
-        Ok(())
+        };
+        Ok(result.rows_affected() == 1)
     }
 
     pub async fn record_retained_audio_artifact_cleanup_failure(

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -255,6 +255,22 @@ pub struct ChunkRecord {
     pub chunk_size_bytes: i64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetainedAudioArtifactKind {
+    Chunk,
+    ComposedAudio,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetainedAudioArtifact {
+    pub api_key_id: String,
+    pub job_id: String,
+    pub kind: RetainedAudioArtifactKind,
+    pub chunk_index: Option<i64>,
+    pub path: PathBuf,
+    pub attempt_count: i64,
+}
+
 #[derive(Debug, Clone)]
 pub struct VoiceNoteMaterialization {
     pub voice_note: NewVoiceNote,
@@ -1257,6 +1273,235 @@ impl Storage {
             .expect("failed job remains visible");
         tx.commit().await?;
         Ok(failed)
+    }
+
+    pub async fn retained_audio_artifacts_for_job(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+    ) -> Result<Vec<RetainedAudioArtifact>, StorageError> {
+        let mut artifacts = Vec::new();
+        if let Some(row) = sqlx::query(
+            r#"
+            SELECT id, accepted_audio_path, accepted_audio_cleanup_attempts
+            FROM transcription_jobs
+            WHERE api_key_id = ?
+                AND id = ?
+                AND status IN ('succeeded', 'failed')
+                AND accepted_audio_path <> ''
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            artifacts.push(RetainedAudioArtifact {
+                api_key_id: api_key_id.to_owned(),
+                job_id: row.try_get("id")?,
+                kind: RetainedAudioArtifactKind::ComposedAudio,
+                chunk_index: None,
+                path: PathBuf::from(row.try_get::<String, _>("accepted_audio_path")?),
+                attempt_count: row.try_get("accepted_audio_cleanup_attempts")?,
+            });
+        }
+
+        let chunk_rows = sqlx::query(
+            r#"
+            SELECT
+                transcription_job_chunks.chunk_index,
+                transcription_job_chunks.chunk_path,
+                transcription_job_chunks.cleanup_attempts
+            FROM transcription_job_chunks
+            JOIN transcription_jobs
+                ON transcription_jobs.api_key_id = transcription_job_chunks.api_key_id
+                AND transcription_jobs.id = transcription_job_chunks.job_id
+            WHERE transcription_job_chunks.api_key_id = ?
+                AND transcription_job_chunks.job_id = ?
+                AND transcription_jobs.status IN ('succeeded', 'failed')
+                AND transcription_job_chunks.chunk_path <> ''
+            ORDER BY transcription_job_chunks.chunk_index ASC
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(job_id)
+        .fetch_all(&self.pool)
+        .await?;
+        artifacts.extend(
+            chunk_rows
+                .into_iter()
+                .map(|row| {
+                    Ok(RetainedAudioArtifact {
+                        api_key_id: api_key_id.to_owned(),
+                        job_id: job_id.to_owned(),
+                        kind: RetainedAudioArtifactKind::Chunk,
+                        chunk_index: Some(row.try_get("chunk_index")?),
+                        path: PathBuf::from(row.try_get::<String, _>("chunk_path")?),
+                        attempt_count: row.try_get("cleanup_attempts")?,
+                    })
+                })
+                .collect::<Result<Vec<_>, StorageError>>()?,
+        );
+        Ok(artifacts)
+    }
+
+    pub async fn retained_audio_artifacts_for_terminal_jobs(
+        &self,
+    ) -> Result<Vec<RetainedAudioArtifact>, StorageError> {
+        let mut artifacts = Vec::new();
+        let composed_rows = sqlx::query(
+            r#"
+            SELECT api_key_id, id, accepted_audio_path, accepted_audio_cleanup_attempts
+            FROM transcription_jobs
+            WHERE status IN ('succeeded', 'failed')
+                AND accepted_audio_path <> ''
+            ORDER BY updated_at ASC, id ASC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        artifacts.extend(
+            composed_rows
+                .into_iter()
+                .map(|row| {
+                    Ok(RetainedAudioArtifact {
+                        api_key_id: row.try_get("api_key_id")?,
+                        job_id: row.try_get("id")?,
+                        kind: RetainedAudioArtifactKind::ComposedAudio,
+                        chunk_index: None,
+                        path: PathBuf::from(row.try_get::<String, _>("accepted_audio_path")?),
+                        attempt_count: row.try_get("accepted_audio_cleanup_attempts")?,
+                    })
+                })
+                .collect::<Result<Vec<_>, StorageError>>()?,
+        );
+
+        let chunk_rows = sqlx::query(
+            r#"
+            SELECT
+                transcription_job_chunks.api_key_id,
+                transcription_job_chunks.job_id,
+                transcription_job_chunks.chunk_index,
+                transcription_job_chunks.chunk_path,
+                transcription_job_chunks.cleanup_attempts
+            FROM transcription_job_chunks
+            JOIN transcription_jobs
+                ON transcription_jobs.api_key_id = transcription_job_chunks.api_key_id
+                AND transcription_jobs.id = transcription_job_chunks.job_id
+            WHERE transcription_jobs.status IN ('succeeded', 'failed')
+                AND transcription_job_chunks.chunk_path <> ''
+            ORDER BY transcription_jobs.updated_at ASC, transcription_job_chunks.job_id ASC, transcription_job_chunks.chunk_index ASC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        artifacts.extend(
+            chunk_rows
+                .into_iter()
+                .map(|row| {
+                    Ok(RetainedAudioArtifact {
+                        api_key_id: row.try_get("api_key_id")?,
+                        job_id: row.try_get("job_id")?,
+                        kind: RetainedAudioArtifactKind::Chunk,
+                        chunk_index: Some(row.try_get("chunk_index")?),
+                        path: PathBuf::from(row.try_get::<String, _>("chunk_path")?),
+                        attempt_count: row.try_get("cleanup_attempts")?,
+                    })
+                })
+                .collect::<Result<Vec<_>, StorageError>>()?,
+        );
+        Ok(artifacts)
+    }
+
+    pub async fn mark_retained_audio_artifact_released(
+        &self,
+        artifact: &RetainedAudioArtifact,
+    ) -> Result<(), StorageError> {
+        let path = artifact.path.to_string_lossy().into_owned();
+        match artifact.kind {
+            RetainedAudioArtifactKind::ComposedAudio => {
+                sqlx::query(
+                    r#"
+                    UPDATE transcription_jobs
+                    SET accepted_audio_path = ''
+                    WHERE api_key_id = ?
+                        AND id = ?
+                        AND accepted_audio_path = ?
+                    "#,
+                )
+                .bind(&artifact.api_key_id)
+                .bind(&artifact.job_id)
+                .bind(path)
+                .execute(&self.pool)
+                .await?;
+            }
+            RetainedAudioArtifactKind::Chunk => {
+                sqlx::query(
+                    r#"
+                    UPDATE transcription_job_chunks
+                    SET chunk_path = ''
+                    WHERE api_key_id = ?
+                        AND job_id = ?
+                        AND chunk_index = ?
+                        AND chunk_path = ?
+                    "#,
+                )
+                .bind(&artifact.api_key_id)
+                .bind(&artifact.job_id)
+                .bind(artifact.chunk_index.expect("chunk artifact has index"))
+                .bind(path)
+                .execute(&self.pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn record_retained_audio_artifact_cleanup_failure(
+        &self,
+        artifact: &RetainedAudioArtifact,
+    ) -> Result<i64, StorageError> {
+        let path = artifact.path.to_string_lossy().into_owned();
+        match artifact.kind {
+            RetainedAudioArtifactKind::ComposedAudio => {
+                let attempt_count = sqlx::query_scalar(
+                    r#"
+                    UPDATE transcription_jobs
+                    SET accepted_audio_cleanup_attempts = accepted_audio_cleanup_attempts + 1
+                    WHERE api_key_id = ?
+                        AND id = ?
+                        AND accepted_audio_path = ?
+                    RETURNING accepted_audio_cleanup_attempts
+                    "#,
+                )
+                .bind(&artifact.api_key_id)
+                .bind(&artifact.job_id)
+                .bind(path)
+                .fetch_optional(&self.pool)
+                .await?;
+                Ok(attempt_count.unwrap_or(artifact.attempt_count))
+            }
+            RetainedAudioArtifactKind::Chunk => {
+                let attempt_count = sqlx::query_scalar(
+                    r#"
+                    UPDATE transcription_job_chunks
+                    SET cleanup_attempts = cleanup_attempts + 1
+                    WHERE api_key_id = ?
+                        AND job_id = ?
+                        AND chunk_index = ?
+                        AND chunk_path = ?
+                    RETURNING cleanup_attempts
+                    "#,
+                )
+                .bind(&artifact.api_key_id)
+                .bind(&artifact.job_id)
+                .bind(artifact.chunk_index.expect("chunk artifact has index"))
+                .bind(path)
+                .fetch_optional(&self.pool)
+                .await?;
+                Ok(attempt_count.unwrap_or(artifact.attempt_count))
+            }
+        }
     }
 
     pub async fn get_voice_note(

--- a/backend/src/transcription_worker.rs
+++ b/backend/src/transcription_worker.rs
@@ -11,6 +11,7 @@ use tokio::process::Command;
 use ulid::Ulid;
 
 use crate::metrics::Metrics;
+use crate::retention_cleanup::cleanup_retained_audio_for_job;
 use crate::storage::{
     NewSegment, NewVoiceNote, NewVoiceNoteVersion, RetryOutcome, Storage, StorageError,
     TerminalJobFailure, TransientJobFailure, VoiceNoteMaterialization,
@@ -525,6 +526,7 @@ fn effective_lease_renewal_interval(config: &WorkerConfig) -> std::time::Duratio
 
 pub async fn process_one_available_job<E, D>(
     storage: &Storage,
+    accepted_audio_dir: &Path,
     engine: &E,
     duration_probe: &D,
     config: WorkerConfig,
@@ -569,7 +571,7 @@ where
     let (duration_ms, transcription) = match active_work {
         Ok(active_work) => active_work,
         Err(error) => {
-            storage
+            let failed = storage
                 .fail_leased_job(TerminalJobFailure {
                     api_key_id: job.api_key_id.clone(),
                     job_id: job.id.clone(),
@@ -581,6 +583,14 @@ where
                 })
                 .await?;
             metrics.record_worker_failed("audio_invalid");
+            cleanup_terminal_job_audio(
+                storage,
+                accepted_audio_dir,
+                &failed.api_key_id,
+                &failed.id,
+                metrics,
+            )
+            .await;
             return Ok(ProcessOutcome::Failed { job_id: job.id });
         }
     };
@@ -612,6 +622,14 @@ where
                 }
                 RetryOutcome::Failed(job) => {
                     metrics.record_worker_failed(&metric_failure_code);
+                    cleanup_terminal_job_audio(
+                        storage,
+                        accepted_audio_dir,
+                        &job.api_key_id,
+                        &job.id,
+                        metrics,
+                    )
+                    .await;
                     Ok(ProcessOutcome::Failed { job_id: job.id })
                 }
             };
@@ -621,7 +639,7 @@ where
             message,
         }) => {
             let metric_failure_code = failure_code.clone();
-            storage
+            let failed = storage
                 .fail_leased_job(TerminalJobFailure {
                     api_key_id: job.api_key_id.clone(),
                     job_id: job.id.clone(),
@@ -633,6 +651,14 @@ where
                 })
                 .await?;
             metrics.record_worker_failed(&metric_failure_code);
+            cleanup_terminal_job_audio(
+                storage,
+                accepted_audio_dir,
+                &failed.api_key_id,
+                &failed.id,
+                metrics,
+            )
+            .await;
             return Ok(ProcessOutcome::Failed { job_id: job.id });
         }
     };
@@ -679,11 +705,35 @@ where
         .await?;
 
     metrics.record_worker_succeeded();
+    cleanup_terminal_job_audio(
+        storage,
+        accepted_audio_dir,
+        &job.api_key_id,
+        &job.id,
+        metrics,
+    )
+    .await;
     Ok(ProcessOutcome::Succeeded { job_id: job.id })
+}
+
+async fn cleanup_terminal_job_audio(
+    storage: &Storage,
+    accepted_audio_dir: &Path,
+    api_key_id: &str,
+    job_id: &str,
+    metrics: &Metrics,
+) {
+    if let Err(error) =
+        cleanup_retained_audio_for_job(storage, accepted_audio_dir, api_key_id, job_id, metrics)
+            .await
+    {
+        tracing::error!(job_id = %job_id, "retention cleanup invocation failed: {error}");
+    }
 }
 
 pub async fn run_worker_loop<E, D>(
     storage: Storage,
+    accepted_audio_dir: PathBuf,
     engine: E,
     duration_probe: D,
     config: WorkerConfig,
@@ -695,6 +745,7 @@ pub async fn run_worker_loop<E, D>(
     loop {
         match process_one_available_job(
             &storage,
+            &accepted_audio_dir,
             &engine,
             &duration_probe,
             config.clone(),

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use axum::body::Body;
@@ -32,6 +32,7 @@ use tempfile::TempDir;
 use time::Duration as TimeDuration;
 use time::OffsetDateTime;
 use time::macros::datetime;
+use tokio::sync::Barrier;
 use tower::util::ServiceExt;
 use tracing::Subscriber;
 use tracing::field::{Field, Visit};
@@ -285,6 +286,148 @@ async fn retained_terminal_audio_is_released_by_restart_sweep() {
         ("job_id", &job.id),
         ("artifact_kind", "composed_audio"),
     ]));
+}
+
+#[tokio::test]
+async fn cleanup_releases_audio_when_accepted_audio_dir_contains_parent_components() {
+    let fixture = WorkerFixture::new_with_parent_component_accepted_audio_dir().await;
+    let job = fixture
+        .create_queued_job("attempt-parent-component-cleanup", b"hello audio")
+        .await;
+    fixture.mark_job_failed(&job.id).await;
+    let artifacts = fixture.retained_artifact_paths(&job.id).await;
+
+    cleanup_retained_audio_once(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &Metrics::new(),
+    )
+    .await
+    .expect("cleanup sweep");
+
+    for artifact in &artifacts {
+        assert!(
+            !tokio::fs::try_exists(artifact)
+                .await
+                .expect("artifact existence check"),
+            "expected retained artifact released from parent-component root: {}",
+            artifact.display()
+        );
+    }
+    assert_eq!(fixture.retained_artifact_count(&job.id).await, 0);
+}
+
+#[tokio::test]
+async fn cleanup_rejects_lexical_escape_from_accepted_audio_dir() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-lexical-escape-cleanup", b"hello audio")
+        .await;
+    fixture.mark_job_failed(&job.id).await;
+    let escape_path = fixture
+        .accepted_audio_dir
+        .join("..")
+        .join("outside")
+        .join("missing.wav");
+    fixture
+        .set_composed_retained_path(&job.id, &escape_path)
+        .await;
+
+    cleanup_retained_audio_once(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &Metrics::new(),
+    )
+    .await
+    .expect("unsafe cleanup is recorded internally");
+
+    assert_eq!(fixture.retained_artifact_count(&job.id).await, 1);
+    assert_eq!(fixture.composed_cleanup_attempts(&job.id).await, 1);
+}
+
+#[tokio::test]
+async fn cleanup_rejects_symlink_escape_from_accepted_audio_dir() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-symlink-escape-cleanup", b"hello audio")
+        .await;
+    fixture.mark_job_failed(&job.id).await;
+
+    let outside_dir = fixture
+        .accepted_audio_dir
+        .parent()
+        .expect("accepted audio dir has parent")
+        .join("outside");
+    tokio::fs::create_dir(&outside_dir)
+        .await
+        .expect("create outside dir");
+    let outside_artifact = outside_dir.join("escaped.wav");
+    tokio::fs::write(&outside_artifact, b"outside audio")
+        .await
+        .expect("write outside artifact");
+    let symlink_path = fixture.accepted_audio_dir.join("outside-link");
+    symlink(&outside_dir, &symlink_path).expect("create outside symlink");
+    let retained_path = symlink_path.join("escaped.wav");
+    fixture
+        .set_composed_retained_path(&job.id, &retained_path)
+        .await;
+
+    cleanup_retained_audio_once(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &Metrics::new(),
+    )
+    .await
+    .expect("unsafe cleanup is recorded internally");
+
+    assert!(
+        tokio::fs::try_exists(&outside_artifact)
+            .await
+            .expect("outside artifact existence check"),
+        "symlink escape target should not be removed"
+    );
+    assert_eq!(fixture.retained_artifact_count(&job.id).await, 1);
+    assert_eq!(fixture.composed_cleanup_attempts(&job.id).await, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn overlapping_cleaners_record_success_once_for_one_retained_artifact() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-overlapping-cleanup", b"hello audio")
+        .await;
+    fixture.mark_job_failed(&job.id).await;
+    let metrics = Metrics::new();
+    let events = global_captured_events();
+    let releaser = BarrierReleaser {
+        barrier: Arc::new(Barrier::new(2)),
+    };
+    let other_releaser = releaser.clone();
+
+    let (first, second) = tokio::join!(
+        cleanup_retained_audio_once_with_releaser(&fixture.storage, &metrics, &releaser),
+        cleanup_retained_audio_once_with_releaser(&fixture.storage, &metrics, &other_releaser),
+    );
+    first.expect("first cleanup");
+    second.expect("second cleanup");
+
+    let body = operator_metrics_text(&fixture, metrics).await;
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_retention_cleanup_artifacts_total",
+        &[r#"outcome="succeeded""#, r#"artifact="composed_audio""#],
+        "1",
+    );
+    assert_eq!(
+        events.count_fields(&[
+            ("message", "retention cleanup released artifact"),
+            ("job_id", &job.id),
+            ("artifact_kind", "composed_audio"),
+        ]),
+        1
+    );
 }
 
 #[tokio::test]
@@ -732,6 +875,28 @@ impl WorkerFixture {
         }
     }
 
+    async fn new_with_parent_component_accepted_audio_dir() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let database_path = tempdir.path().join("oracy.sqlite");
+        let config_dir = tempdir.path().join("config");
+        tokio::fs::create_dir(&config_dir)
+            .await
+            .expect("create config dir");
+        let canonical_accepted_audio_dir = tempdir.path().join("accepted-audio");
+        tokio::fs::create_dir(&canonical_accepted_audio_dir)
+            .await
+            .expect("create accepted audio dir");
+        let accepted_audio_dir = config_dir.join("../accepted-audio");
+        let storage = Storage::connect(&database_path)
+            .await
+            .expect("connect storage");
+        Self {
+            _tempdir: tempdir,
+            accepted_audio_dir,
+            storage,
+        }
+    }
+
     async fn create_queued_job(
         &self,
         idempotency_key: &str,
@@ -881,6 +1046,48 @@ impl WorkerFixture {
         paths
     }
 
+    async fn retained_artifact_count(&self, job_id: &str) -> i64 {
+        let composed_count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM transcription_jobs
+            WHERE api_key_id = 'owner-a' AND id = ? AND accepted_audio_path <> ''
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("composed retained artifact count");
+        let chunk_count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM transcription_job_chunks
+            WHERE api_key_id = 'owner-a' AND job_id = ? AND chunk_path <> ''
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("chunk retained artifact count");
+        composed_count + chunk_count
+    }
+
+    async fn set_composed_retained_path(&self, job_id: &str, path: &std::path::Path) {
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET accepted_audio_path = ?
+            WHERE api_key_id = 'owner-a' AND id = ?
+            "#,
+        )
+        .bind(path.to_string_lossy().into_owned())
+        .bind(job_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("set composed retained path");
+        assert_eq!(result.rows_affected(), 1);
+    }
+
     async fn chunk_row_count(&self, job_id: &str) -> i64 {
         sqlx::query_scalar(
             r#"
@@ -980,9 +1187,37 @@ impl RetainedAudioReleaser for FailingReleaser {
     }
 }
 
+#[derive(Clone)]
+struct BarrierReleaser {
+    barrier: Arc<Barrier>,
+}
+
+impl RetainedAudioReleaser for BarrierReleaser {
+    async fn release(
+        &self,
+        _artifact: &oracy_backend::storage::RetainedAudioArtifact,
+    ) -> Result<(), RetentionCleanupError> {
+        self.barrier.wait().await;
+        Ok(())
+    }
+}
+
 #[derive(Clone, Default)]
 struct CapturedEvents {
     events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+static GLOBAL_CAPTURED_EVENTS: OnceLock<CapturedEvents> = OnceLock::new();
+
+fn global_captured_events() -> CapturedEvents {
+    GLOBAL_CAPTURED_EVENTS
+        .get_or_init(|| {
+            let events = CapturedEvents::default();
+            tracing::subscriber::set_global_default(Registry::default().with(events.clone()))
+                .expect("global tracing subscriber");
+            events
+        })
+        .clone()
 }
 
 impl CapturedEvents {
@@ -995,6 +1230,22 @@ impl CapturedEvents {
                     .any(|(name, actual)| name == field && actual.contains(value))
             })
         })
+    }
+
+    fn count_fields(&self, expected: &[(&str, &str)]) -> usize {
+        self.events
+            .lock()
+            .expect("events")
+            .iter()
+            .filter(|event| {
+                expected.iter().all(|(field, value)| {
+                    event
+                        .fields
+                        .iter()
+                        .any(|(name, actual)| name == field && actual.contains(value))
+                })
+            })
+            .count()
     }
 }
 

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -241,7 +241,7 @@ async fn worker_releases_chunks_and_composed_audio_after_failure() {
     assert_eq!(failed.chunks_received, 1);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn retained_terminal_audio_is_released_by_restart_sweep() {
     let fixture = WorkerFixture::new().await;
     let job = fixture
@@ -430,7 +430,7 @@ async fn overlapping_cleaners_record_success_once_for_one_retained_artifact() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn cleanup_failures_retry_without_changing_terminal_state_and_log_attempt_count() {
     let fixture = WorkerFixture::new().await;
     let job = fixture

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -11,20 +11,32 @@ use axum::{Json, Router};
 use oracy_backend::auth::AuthStore;
 use oracy_backend::config::ApiKeyConfig;
 use oracy_backend::metrics::Metrics;
+use oracy_backend::retention_cleanup::{
+    RetainedAudioReleaser, RetentionCleanupError, cleanup_retained_audio_once,
+    cleanup_retained_audio_once_with_releaser,
+};
 use oracy_backend::router::build_operator_router;
 use oracy_backend::state::AppState;
-use oracy_backend::storage::{AcceptJobOutcome, NewTranscriptionJob, Storage};
+use oracy_backend::storage::{
+    AcceptJobOutcome, AcceptedChunk, FinalizeJobOutcome, NewOpenTranscriptionJob,
+    NewTranscriptionJob, OpenJobOutcome, Storage, StoreChunkOutcome,
+};
 use oracy_backend::transcription_worker::{
     AudioSliceError, AudioSlicer, DurationProbe, DurationProbeError, EngineFailure,
     OpenAiTranscriptionEngine, ProcessOutcome, TranscriptionEngine, TranscriptionInput,
     TranscriptionOutput, WorkerConfig, process_one_available_job,
 };
 use serde_json::json;
+use sqlx::Row;
 use tempfile::TempDir;
 use time::Duration as TimeDuration;
 use time::OffsetDateTime;
 use time::macros::datetime;
 use tower::util::ServiceExt;
+use tracing::Subscriber;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::{Layer, Registry};
 
 #[tokio::test]
 async fn worker_materializes_a_queued_job_with_a_fake_engine() {
@@ -35,6 +47,7 @@ async fn worker_materializes_a_queued_job_with_a_fake_engine() {
 
     let outcome = process_one_available_job(
         &fixture.storage,
+        &fixture.accepted_audio_dir,
         &engine,
         &probe,
         WorkerConfig::test(),
@@ -93,6 +106,244 @@ async fn worker_materializes_a_queued_job_with_a_fake_engine() {
 }
 
 #[tokio::test]
+async fn worker_releases_chunks_and_composed_audio_after_success() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_chunked_queued_job(
+            "attempt-success-cleanup",
+            &[b"first audio", b"second audio"],
+        )
+        .await;
+    let artifacts = fixture.retained_artifact_paths(&job.id).await;
+    for artifact in &artifacts {
+        assert!(
+            tokio::fs::try_exists(artifact)
+                .await
+                .expect("artifact existence check"),
+            "expected retained artifact before processing: {}",
+            artifact.display()
+        );
+    }
+    let engine = FakeEngine::success("transcribed text");
+    let probe = FakeDurationProbe::success(1_480);
+
+    let metrics = Metrics::new();
+
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &metrics,
+    )
+    .await
+    .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::Succeeded {
+            job_id: job.id.clone()
+        }
+    );
+    for artifact in &artifacts {
+        assert!(
+            !tokio::fs::try_exists(artifact)
+                .await
+                .expect("artifact existence check"),
+            "expected retained artifact released after success: {}",
+            artifact.display()
+        );
+    }
+    assert_eq!(fixture.chunk_row_count(&job.id).await, 2);
+    let completed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(completed.status, "succeeded");
+    assert_eq!(completed.chunks_received, 2);
+    let voice_note = fixture
+        .storage
+        .get_voice_note(
+            "owner-a",
+            completed.voice_note_id.as_deref().expect("voice note id"),
+        )
+        .await
+        .expect("voice note lookup")
+        .expect("voice note exists");
+    assert_eq!(voice_note.audio_duration_seconds, 1.48);
+    assert_eq!(voice_note.audio_format, "wav");
+    assert_eq!(voice_note.audio_size_bytes, 23);
+
+    let body = operator_metrics_text(&fixture, metrics).await;
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_retention_cleanup_artifacts_total",
+        &[r#"outcome="succeeded""#, r#"artifact="chunk""#],
+        "2",
+    );
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_retention_cleanup_artifacts_total",
+        &[r#"outcome="succeeded""#, r#"artifact="composed_audio""#],
+        "1",
+    );
+}
+
+#[tokio::test]
+async fn worker_releases_chunks_and_composed_audio_after_failure() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_chunked_queued_job("attempt-failed-cleanup", &[b"bad audio"])
+        .await;
+    let artifacts = fixture.retained_artifact_paths(&job.id).await;
+    let engine = FakeEngine::success("unused");
+    let probe = FakeDurationProbe::invalid_audio();
+
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &Metrics::new(),
+    )
+    .await
+    .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::Failed {
+            job_id: job.id.clone()
+        }
+    );
+    for artifact in &artifacts {
+        assert!(
+            !tokio::fs::try_exists(artifact)
+                .await
+                .expect("artifact existence check"),
+            "expected retained artifact released after failure: {}",
+            artifact.display()
+        );
+    }
+    let failed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(failed.status, "failed");
+    assert_eq!(failed.failure_code.as_deref(), Some("audio_invalid"));
+    assert_eq!(failed.retryable_by_client, Some(false));
+    assert_eq!(failed.chunks_received, 1);
+}
+
+#[tokio::test]
+async fn retained_terminal_audio_is_released_by_restart_sweep() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_chunked_queued_job("attempt-restart-cleanup", &[b"first", b"second"])
+        .await;
+    fixture.mark_job_failed(&job.id).await;
+    let artifacts = fixture.retained_artifact_paths(&job.id).await;
+    let events = CapturedEvents::default();
+    let _guard = tracing::subscriber::set_default(Registry::default().with(events.clone()));
+
+    cleanup_retained_audio_once(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &Metrics::new(),
+    )
+    .await
+    .expect("cleanup sweep");
+
+    for artifact in &artifacts {
+        assert!(
+            !tokio::fs::try_exists(artifact)
+                .await
+                .expect("artifact existence check"),
+            "expected retained artifact released by sweep: {}",
+            artifact.display()
+        );
+    }
+    let failed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(failed.status, "failed");
+    assert!(events.contains_fields(&[
+        ("message", "retention cleanup released artifact"),
+        ("job_id", &job.id),
+        ("artifact_kind", "chunk"),
+    ]));
+    assert!(events.contains_fields(&[
+        ("message", "retention cleanup released artifact"),
+        ("job_id", &job.id),
+        ("artifact_kind", "composed_audio"),
+    ]));
+}
+
+#[tokio::test]
+async fn cleanup_failures_retry_without_changing_terminal_state_and_log_attempt_count() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_chunked_queued_job("attempt-cleanup-retry", &[b"first"])
+        .await;
+    fixture.mark_job_failed(&job.id).await;
+    let artifacts = fixture.retained_artifact_paths(&job.id).await;
+    let metrics = Metrics::new();
+    let events = CapturedEvents::default();
+    let _guard = tracing::subscriber::set_default(Registry::default().with(events.clone()));
+
+    cleanup_retained_audio_once_with_releaser(&fixture.storage, &metrics, &FailingReleaser)
+        .await
+        .expect("cleanup failure is recorded internally");
+
+    for artifact in &artifacts {
+        assert!(
+            tokio::fs::try_exists(artifact)
+                .await
+                .expect("artifact existence check"),
+            "failed cleanup should leave artifact for retry: {}",
+            artifact.display()
+        );
+    }
+    assert_eq!(fixture.composed_cleanup_attempts(&job.id).await, 1);
+    assert_eq!(fixture.chunk_cleanup_attempts(&job.id, 0).await, 1);
+    let failed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(failed.status, "failed");
+
+    let body = operator_metrics_text(&fixture, metrics).await;
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_retention_cleanup_artifacts_total",
+        &[r#"outcome="failed""#, r#"artifact="chunk""#],
+        "1",
+    );
+    assert_metric_sample_has_value(
+        &body,
+        "oracy_retention_cleanup_artifacts_total",
+        &[r#"outcome="failed""#, r#"artifact="composed_audio""#],
+        "1",
+    );
+    assert!(events.contains_fields(&[
+        ("message", "retention cleanup failed to release artifact"),
+        ("job_id", &job.id),
+        ("artifact_kind", "chunk"),
+        ("attempt_count", "1"),
+    ]));
+}
+
+#[tokio::test]
 async fn worker_success_increments_operator_success_counter() {
     let fixture = WorkerFixture::new().await;
     fixture
@@ -104,6 +355,7 @@ async fn worker_success_increments_operator_success_counter() {
 
     process_one_available_job(
         &fixture.storage,
+        &fixture.accepted_audio_dir,
         &engine,
         &probe,
         WorkerConfig::test(),
@@ -134,6 +386,7 @@ async fn worker_retry_increments_operator_retry_counter_with_failure_class() {
 
     process_one_available_job(
         &fixture.storage,
+        &fixture.accepted_audio_dir,
         &engine,
         &probe,
         WorkerConfig::test(),
@@ -167,6 +420,7 @@ async fn worker_terminal_failure_increments_operator_failure_counter_with_failur
 
     process_one_available_job(
         &fixture.storage,
+        &fixture.accepted_audio_dir,
         &engine,
         &probe,
         WorkerConfig::test(),
@@ -196,6 +450,7 @@ async fn worker_marks_duration_probe_failure_as_audio_invalid() {
 
     let outcome = process_one_available_job(
         &fixture.storage,
+        &fixture.accepted_audio_dir,
         &engine,
         &probe,
         WorkerConfig::test(),
@@ -233,6 +488,7 @@ async fn worker_routes_transient_engine_failure_to_retry_waiting() {
 
     let outcome = process_one_available_job(
         &fixture.storage,
+        &fixture.accepted_audio_dir,
         &engine,
         &probe,
         WorkerConfig::test(),
@@ -260,6 +516,54 @@ async fn worker_routes_transient_engine_failure_to_retry_waiting() {
 }
 
 #[tokio::test]
+async fn worker_releases_retained_audio_when_retry_exhaustion_fails_the_job() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_chunked_queued_job("attempt-retry-exhaustion-cleanup", &[b"hello audio"])
+        .await;
+    fixture.set_retry_count(&job.id, 2).await;
+    let artifacts = fixture.retained_artifact_paths(&job.id).await;
+    let engine = FakeEngine::transient("engine_error", "temporary engine failure", Some(30));
+    let probe = FakeDurationProbe::success(1_480);
+
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &engine,
+        &probe,
+        WorkerConfig::test(),
+        &Metrics::new(),
+    )
+    .await
+    .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::Failed {
+            job_id: job.id.clone()
+        }
+    );
+    for artifact in &artifacts {
+        assert!(
+            !tokio::fs::try_exists(artifact)
+                .await
+                .expect("artifact existence check"),
+            "expected retained artifact released after retry exhaustion: {}",
+            artifact.display()
+        );
+    }
+    let failed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(failed.status, "failed");
+    assert_eq!(failed.retry_count, 3);
+    assert_eq!(failed.failure_code.as_deref(), Some("engine_error"));
+}
+
+#[tokio::test]
 async fn stalled_openai_request_records_transient_timeout_and_worker_processes_next_job() {
     let fixture = WorkerFixture::new().await;
     let stalled_job = fixture
@@ -281,6 +585,7 @@ async fn stalled_openai_request_records_transient_timeout_and_worker_processes_n
         Duration::from_secs(1),
         process_one_available_job(
             &fixture.storage,
+            &fixture.accepted_audio_dir,
             &engine,
             &probe,
             WorkerConfig::test(),
@@ -309,6 +614,7 @@ async fn stalled_openai_request_records_transient_timeout_and_worker_processes_n
         Duration::from_secs(1),
         process_one_available_job(
             &fixture.storage,
+            &fixture.accepted_audio_dir,
             &engine,
             &probe,
             WorkerConfig::test(),
@@ -359,9 +665,11 @@ async fn worker_renews_processing_lease_while_transcription_outlives_initial_lea
         error_sleep: Duration::from_millis(10),
     };
 
+    let accepted_audio_dir = fixture.accepted_audio_dir.clone();
     let handle = tokio::spawn(async move {
         process_one_available_job(
             &storage_for_worker,
+            &accepted_audio_dir,
             &engine,
             &probe,
             config,
@@ -454,6 +762,283 @@ impl WorkerFixture {
             AcceptJobOutcome::Created(job) => job,
             other => panic!("expected created job, got {other:?}"),
         }
+    }
+
+    async fn create_chunked_queued_job(
+        &self,
+        idempotency_key: &str,
+        chunks: &[&[u8]],
+    ) -> oracy_backend::storage::TranscriptionJobRecord {
+        let opened = match self
+            .storage
+            .open_job(NewOpenTranscriptionJob {
+                api_key_id: "owner-a".to_owned(),
+                idempotency_key: idempotency_key.to_owned(),
+                recorded_at: datetime!(2026-04-24 17:59:00 UTC),
+                session_id: None,
+                language: Some("en".to_owned()),
+                chunk_count: chunks.len() as i64,
+                audio_format: "wav".to_owned(),
+                max_retries: 3,
+                now: datetime!(2026-04-24 18:00:00 UTC),
+            })
+            .await
+            .expect("open job")
+        {
+            OpenJobOutcome::Created(job) => job,
+            other => panic!("expected opened job, got {other:?}"),
+        };
+
+        for (index, bytes) in chunks.iter().enumerate() {
+            let chunk_path = self
+                .accepted_audio_dir
+                .join(&opened.id)
+                .join("chunks")
+                .join(format!("{index}.chunk"));
+            tokio::fs::create_dir_all(chunk_path.parent().expect("chunk parent"))
+                .await
+                .expect("create chunk directory");
+            tokio::fs::write(&chunk_path, bytes)
+                .await
+                .expect("write chunk");
+            let outcome = self
+                .storage
+                .store_chunk(AcceptedChunk {
+                    api_key_id: "owner-a".to_owned(),
+                    job_id: opened.id.clone(),
+                    chunk_index: index as i64,
+                    chunk_sha256_hex: sha256_hex(bytes),
+                    chunk_path,
+                    chunk_size_bytes: bytes.len() as i64,
+                    accepted_at: datetime!(2026-04-24 18:00:01 UTC),
+                })
+                .await
+                .expect("store chunk");
+            assert_eq!(outcome, StoreChunkOutcome::Stored);
+        }
+
+        let composed_path = self
+            .accepted_audio_dir
+            .join(&opened.id)
+            .join("accepted.wav");
+        let mut composed = Vec::new();
+        for bytes in chunks {
+            composed.extend_from_slice(bytes);
+        }
+        tokio::fs::write(&composed_path, composed)
+            .await
+            .expect("write composed audio");
+
+        match self
+            .storage
+            .finalize_job(
+                "owner-a",
+                &opened.id,
+                "composed-hash",
+                &composed_path,
+                "gpt-4o-mini-transcribe",
+                datetime!(2026-04-24 18:00:02 UTC),
+            )
+            .await
+            .expect("finalize job")
+        {
+            FinalizeJobOutcome::Accepted(job) => job,
+            other => panic!("expected finalized job, got {other:?}"),
+        }
+    }
+
+    async fn retained_artifact_paths(&self, job_id: &str) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        let accepted_audio_path: String = sqlx::query_scalar(
+            r#"
+            SELECT accepted_audio_path
+            FROM transcription_jobs
+            WHERE api_key_id = 'owner-a' AND id = ?
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("accepted audio path");
+        paths.push(PathBuf::from(accepted_audio_path));
+
+        let rows = sqlx::query(
+            r#"
+            SELECT chunk_path
+            FROM transcription_job_chunks
+            WHERE api_key_id = 'owner-a' AND job_id = ?
+            ORDER BY chunk_index ASC
+            "#,
+        )
+        .bind(job_id)
+        .fetch_all(self.storage.pool())
+        .await
+        .expect("chunk paths");
+        paths.extend(
+            rows.into_iter()
+                .map(|row| PathBuf::from(row.get::<String, _>("chunk_path"))),
+        );
+        paths
+    }
+
+    async fn chunk_row_count(&self, job_id: &str) -> i64 {
+        sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM transcription_job_chunks
+            WHERE api_key_id = 'owner-a' AND job_id = ?
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("chunk row count")
+    }
+
+    async fn mark_job_failed(&self, job_id: &str) {
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'failed',
+                failure_code = 'engine_error',
+                failure_message = 'terminal failure',
+                retryable_by_client = 1
+            WHERE api_key_id = 'owner-a' AND id = ?
+            "#,
+        )
+        .bind(job_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("mark job failed");
+        assert_eq!(result.rows_affected(), 1);
+    }
+
+    async fn set_retry_count(&self, job_id: &str, retry_count: i64) {
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET retry_count = ?
+            WHERE api_key_id = 'owner-a' AND id = ?
+            "#,
+        )
+        .bind(retry_count)
+        .bind(job_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("set retry count");
+        assert_eq!(result.rows_affected(), 1);
+    }
+
+    async fn composed_cleanup_attempts(&self, job_id: &str) -> i64 {
+        sqlx::query_scalar(
+            r#"
+            SELECT accepted_audio_cleanup_attempts
+            FROM transcription_jobs
+            WHERE api_key_id = 'owner-a' AND id = ?
+            "#,
+        )
+        .bind(job_id)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("composed cleanup attempts")
+    }
+
+    async fn chunk_cleanup_attempts(&self, job_id: &str, chunk_index: i64) -> i64 {
+        sqlx::query_scalar(
+            r#"
+            SELECT cleanup_attempts
+            FROM transcription_job_chunks
+            WHERE api_key_id = 'owner-a' AND job_id = ? AND chunk_index = ?
+            "#,
+        )
+        .bind(job_id)
+        .bind(chunk_index)
+        .fetch_one(self.storage.pool())
+        .await
+        .expect("chunk cleanup attempts")
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+struct FailingReleaser;
+
+impl RetainedAudioReleaser for FailingReleaser {
+    async fn release(
+        &self,
+        artifact: &oracy_backend::storage::RetainedAudioArtifact,
+    ) -> Result<(), RetentionCleanupError> {
+        Err(RetentionCleanupError::Remove {
+            path: artifact.path.clone(),
+            source: std::io::Error::other("simulated cleanup failure"),
+        })
+    }
+}
+
+#[derive(Clone, Default)]
+struct CapturedEvents {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl CapturedEvents {
+    fn contains_fields(&self, expected: &[(&str, &str)]) -> bool {
+        self.events.lock().expect("events").iter().any(|event| {
+            expected.iter().all(|(field, value)| {
+                event
+                    .fields
+                    .iter()
+                    .any(|(name, actual)| name == field && actual.contains(value))
+            })
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CapturedEvent {
+    fields: Vec<(String, String)>,
+}
+
+impl<S> Layer<S> for CapturedEvents
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+        let mut visitor = EventVisitor { fields: Vec::new() };
+        event.record(&mut visitor);
+        self.events.lock().expect("events").push(CapturedEvent {
+            fields: visitor.fields,
+        });
+    }
+}
+
+struct EventVisitor {
+    fields: Vec<(String, String)>,
+}
+
+impl Visit for EventVisitor {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .push((field.name().to_owned(), value.to_owned()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .push((field.name().to_owned(), format!("{value:?}")));
     }
 }
 

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -608,6 +608,9 @@ Semantics:
   `retry_waiting`.
 - Once a job reaches `succeeded` or `failed`, the backend must
   promptly delete the retained audio chunks and composed audio.
+- Retained audio is recorded as released only after the backend has
+  made the file's absence crash-durable on the accepted-audio
+  filesystem.
 - Failure to delete retained audio does not create a new public job
   state. The job remains terminal while cleanup is retried internally
   and surfaced to operators through logs and metrics.


### PR DESCRIPTION
## Summary

- Releases accepted chunk files and composed audio when transcription jobs reach `succeeded` or `failed`.
- Retries cleanup internally with durable per-artifact attempt counters while preserving the public terminal job state.
- Surfaces cleanup outcomes through structured logs and the existing retention cleanup metrics.

## Changes

- Adds retention cleanup bookkeeping for composed audio and chunk artifacts.
- Introduces a retention cleanup subsystem with path safety checks, idempotent `NotFound` handling, success/failure logging, and metric recording.
- Wires immediate cleanup into terminal worker transitions and starts a 60-second background sweep for restart recovery.
- Expands worker integration tests for success, failure, restart sweep, retry exhaustion, cleanup retry diagnostics, logs, and metrics.
- Updates the changelog for the user/operator-visible retention behavior.

## GitHub Issue(s)

Closes #37

## Test plan

- `cargo fmt`
- `cargo test`
- `git diff --check`
