### PR TITLE
feat(transcription-jobs): add abandonment sweeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a transcription-job abandonment sweeper that fails stale
+  `accepting_chunks` jobs with `submission_abandoned` and reports swept jobs
+  through operator logs and metrics.
 - Release retained transcription audio when jobs reach `succeeded` or `failed`,
   retry cleanup after transient release failures, and surface per-artifact
   cleanup outcomes through structured logs and retention metrics.

--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,8 @@ case-insensitive, and missing or invalid keys return the shared JSON
 
 Operator metrics are exposed separately from the public API listener. Scrape
 `GET /metrics` from `operator_listen_addr`; the default is loopback
-`127.0.0.1:9090`. Startup rejects configurations where `operator_listen_addr`
-overlaps the public `listen_addr` bind set. The public listener does not expose
-`/metrics`.
+`127.0.0.1:9090`. The metric set covers transcription worker outcomes,
+abandoned pre-finalize transcription jobs, retention-cleanup outcomes, and
+retained-audio capacity. Startup rejects configurations where
+`operator_listen_addr` overlaps the public `listen_addr` bind set. The public
+listener does not expose `/metrics`.

--- a/backend/migrations/20260503020000_abandonment_sweeper_index.sql
+++ b/backend/migrations/20260503020000_abandonment_sweeper_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX transcription_jobs_abandonment_idx
+    ON transcription_jobs (status, created_at, id);

--- a/backend/src/abandonment_sweeper.rs
+++ b/backend/src/abandonment_sweeper.rs
@@ -1,0 +1,90 @@
+use time::{Duration, OffsetDateTime};
+
+use crate::metrics::Metrics;
+use crate::storage::{Storage, StorageError};
+
+const DEFAULT_ABANDONMENT_WINDOW: Duration = Duration::hours(24);
+const DEFAULT_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+
+#[derive(Debug, Clone)]
+pub struct AbandonmentSweeperConfig {
+    pub window: Duration,
+    pub interval: std::time::Duration,
+}
+
+impl Default for AbandonmentSweeperConfig {
+    fn default() -> Self {
+        Self {
+            window: DEFAULT_ABANDONMENT_WINDOW,
+            interval: DEFAULT_SWEEP_INTERVAL,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AbandonmentSweepOutcome {
+    pub abandoned_count: usize,
+}
+
+pub async fn sweep_abandoned_jobs_once(
+    storage: &Storage,
+    metrics: &Metrics,
+    config: AbandonmentSweeperConfig,
+    now: OffsetDateTime,
+) -> Result<AbandonmentSweepOutcome, StorageError> {
+    let cutoff = now - config.window;
+    let candidates = storage
+        .list_accepting_chunks_jobs_eligible_for_abandonment(cutoff)
+        .await?;
+    let mut abandoned_count = 0;
+
+    for candidate in candidates {
+        if let Some(abandoned) = storage
+            .abandon_accepting_chunks_job(&candidate.api_key_id, &candidate.id, cutoff, now)
+            .await?
+        {
+            abandoned_count += 1;
+            metrics.record_transcription_abandoned();
+            tracing::info!(
+                job_id = %abandoned.id,
+                elapsed_seconds = (now - abandoned.created_at).whole_seconds(),
+                "transcription job abandoned"
+            );
+        }
+    }
+
+    Ok(AbandonmentSweepOutcome { abandoned_count })
+}
+
+pub async fn run_abandonment_sweeper_loop(
+    storage: Storage,
+    metrics: Metrics,
+    config: AbandonmentSweeperConfig,
+) {
+    tracing::info!(
+        abandonment_window_seconds = config.window.whole_seconds(),
+        sweep_interval_seconds = config.interval.as_secs(),
+        "abandonment sweeper started"
+    );
+    loop {
+        match sweep_abandoned_jobs_once(
+            &storage,
+            &metrics,
+            config.clone(),
+            OffsetDateTime::now_utc(),
+        )
+        .await
+        {
+            Ok(outcome) => {
+                tracing::info!(
+                    abandoned_count = outcome.abandoned_count,
+                    "abandonment sweeper iteration completed"
+                );
+            }
+            Err(error) => {
+                tracing::error!("abandonment sweeper iteration failed: {error}");
+            }
+        }
+        tokio::time::sleep(config.interval).await;
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(unix)]
 
+pub mod abandonment_sweeper;
 mod audio_durability;
 pub mod audio_hash;
 pub mod audio_store;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use oracy_backend::abandonment_sweeper::{AbandonmentSweeperConfig, run_abandonment_sweeper_loop};
 use oracy_backend::bootstrap::load_runtime_from_env;
 use oracy_backend::retention_cleanup::{RetentionCleanupConfig, run_retention_cleanup_loop};
 use oracy_backend::router::{build_operator_router, build_router};
@@ -33,6 +34,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         state.accepted_audio_dir.clone(),
         state.metrics.clone(),
         RetentionCleanupConfig::default(),
+    ));
+    tokio::spawn(run_abandonment_sweeper_loop(
+        state.storage.clone(),
+        state.metrics.clone(),
+        AbandonmentSweeperConfig::default(),
     ));
     tokio::spawn(run_worker_loop(
         worker_storage,

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use axum::extract::State;
 use axum::http::{StatusCode, header};
 use axum::response::IntoResponse;
-use prometheus::{IntCounterVec, IntGauge, Opts, Registry, TextEncoder, core::Collector};
+use prometheus::{
+    IntCounter, IntCounterVec, IntGauge, Opts, Registry, TextEncoder, core::Collector,
+};
 
 use crate::state::AppState;
 
@@ -19,6 +21,7 @@ pub struct Metrics {
     registry: Registry,
     worker_jobs_total: IntCounterVec,
     retention_cleanup_artifacts_total: IntCounterVec,
+    transcription_abandonments_total: IntCounter,
     retained_audio_bytes: IntGauge,
 }
 
@@ -56,6 +59,11 @@ impl Metrics {
             &[CLEANUP_OUTCOME, ARTIFACT],
         )
         .expect("retention cleanup metric definition is valid");
+        let transcription_abandonments_total = IntCounter::new(
+            "oracy_transcription_abandonments_total",
+            "Transcription jobs abandoned before finalize.",
+        )
+        .expect("abandonment metric definition is valid");
         let retained_audio_bytes = IntGauge::new(
             "oracy_retained_audio_bytes",
             "Current retained accepted-audio bytes.",
@@ -64,12 +72,14 @@ impl Metrics {
 
         register(&registry, worker_jobs_total.clone());
         register(&registry, retention_cleanup_artifacts_total.clone());
+        register(&registry, transcription_abandonments_total.clone());
         register(&registry, retained_audio_bytes.clone());
 
         let metrics = Self {
             registry,
             worker_jobs_total,
             retention_cleanup_artifacts_total,
+            transcription_abandonments_total,
             retained_audio_bytes,
         };
         metrics.initialize_series();
@@ -104,6 +114,10 @@ impl Metrics {
         self.retention_cleanup_artifacts_total
             .with_label_values(&["failed", artifact.as_label()])
             .inc();
+    }
+
+    pub fn record_transcription_abandoned(&self) {
+        self.transcription_abandonments_total.inc();
     }
 
     fn refresh_retained_audio_bytes(&self, accepted_audio_dir: &Path) -> io::Result<()> {

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -797,6 +797,52 @@ impl Storage {
         rows.into_iter().map(job_from_row).collect()
     }
 
+    pub async fn abandon_accepting_chunks_job(
+        &self,
+        api_key_id: &str,
+        job_id: &str,
+        cutoff: OffsetDateTime,
+        now: OffsetDateTime,
+    ) -> Result<Option<TranscriptionJobRecord>, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let cutoff = format_timestamp(cutoff)?;
+        let now = format_timestamp(now)?;
+        let result = sqlx::query(
+            r#"
+            UPDATE transcription_jobs
+            SET status = 'failed',
+                next_attempt_at = NULL,
+                failure_code = 'submission_abandoned',
+                failure_message = 'Submission exceeded the abandonment window before finalize.',
+                retryable_by_client = 1,
+                processing_lease_token = NULL,
+                processing_lease_expires_at = NULL,
+                updated_at = ?
+            WHERE api_key_id = ?
+                AND id = ?
+                AND status = 'accepting_chunks'
+                AND created_at < ?
+            "#,
+        )
+        .bind(&now)
+        .bind(api_key_id)
+        .bind(job_id)
+        .bind(&cutoff)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.commit().await?;
+            return Ok(None);
+        }
+
+        let abandoned = select_job_by_id(&mut tx, api_key_id, job_id)
+            .await?
+            .expect("abandoned job remains visible");
+        tx.commit().await?;
+        Ok(Some(abandoned))
+    }
+
     pub async fn finalize_job(
         &self,
         api_key_id: &str,

--- a/backend/src/transcription_jobs.rs
+++ b/backend/src/transcription_jobs.rs
@@ -270,13 +270,15 @@ async fn finalize_transcription_job(
     )
     .await
     .map_err(|_| ApiError::internal("Failed to compose accepted audio."))?;
-    let settings = state
-        .storage
-        .get_settings(&api_key_id)
-        .await
-        .map_err(|_| ApiError::internal("Failed to load settings."))?;
+    let settings = match state.storage.get_settings(&api_key_id).await {
+        Ok(settings) => settings,
+        Err(_) => {
+            discard_composed_audio_candidate(&job_id, &accepted_audio_path).await;
+            return Err(ApiError::internal("Failed to load settings."));
+        }
+    };
 
-    match state
+    let outcome = match state
         .storage
         .finalize_job(
             &api_key_id,
@@ -287,19 +289,35 @@ async fn finalize_transcription_job(
             OffsetDateTime::now_utc(),
         )
         .await
-        .map_err(|_| ApiError::internal("Failed to finalize transcription job."))?
     {
+        Ok(outcome) => outcome,
+        Err(_) => {
+            discard_composed_audio_candidate(&job_id, &accepted_audio_path).await;
+            return Err(ApiError::internal("Failed to finalize transcription job."));
+        }
+    };
+
+    match outcome {
         FinalizeJobOutcome::Accepted(job) => Ok((StatusCode::ACCEPTED, Json(job_resource(job)?))),
         FinalizeJobOutcome::Replayed(job) => Ok((StatusCode::OK, Json(job_resource(job)?))),
-        FinalizeJobOutcome::MissingChunks => Err(ApiError::conflict(
-            "Every declared chunk must be accepted before finalize.",
-            None,
-        )),
-        FinalizeJobOutcome::NotFound => Err(ApiError::not_found("Transcription job not found.")),
-        FinalizeJobOutcome::NotAcceptingChunks => Err(ApiError::conflict(
-            "Transcription job is not accepting chunks.",
-            None,
-        )),
+        FinalizeJobOutcome::MissingChunks => {
+            discard_composed_audio_candidate(&job_id, &accepted_audio_path).await;
+            Err(ApiError::conflict(
+                "Every declared chunk must be accepted before finalize.",
+                None,
+            ))
+        }
+        FinalizeJobOutcome::NotFound => {
+            discard_composed_audio_candidate(&job_id, &accepted_audio_path).await;
+            Err(ApiError::not_found("Transcription job not found."))
+        }
+        FinalizeJobOutcome::NotAcceptingChunks => {
+            discard_composed_audio_candidate(&job_id, &accepted_audio_path).await;
+            Err(ApiError::conflict(
+                "Transcription job is not accepting chunks.",
+                None,
+            ))
+        }
     }
 }
 
@@ -351,6 +369,21 @@ fn validate_open_body(body: &OpenTranscriptionJobRequest) -> Result<(), ApiError
 
 async fn discard_chunk_candidate(path: &std::path::Path) {
     let _ = tokio::fs::remove_file(path).await;
+}
+
+async fn discard_composed_audio_candidate(job_id: &str, path: &std::path::Path) {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::error!(
+                job_id = %job_id,
+                accepted_audio_path = %path.display(),
+                failure_reason = %error,
+                "failed to discard unrecorded composed audio"
+            );
+        }
+    }
 }
 
 fn idempotency_key(headers: &HeaderMap) -> Result<String, ApiError> {

--- a/backend/tests/abandonment_sweeper.rs
+++ b/backend/tests/abandonment_sweeper.rs
@@ -1,0 +1,179 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::Request;
+use oracy_backend::abandonment_sweeper::{AbandonmentSweeperConfig, sweep_abandoned_jobs_once};
+use oracy_backend::auth::AuthStore;
+use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::metrics::Metrics;
+use oracy_backend::router::build_operator_router;
+use oracy_backend::state::AppState;
+use oracy_backend::storage::{NewOpenTranscriptionJob, OpenJobOutcome, Storage};
+use tempfile::TempDir;
+use time::Duration;
+use time::macros::datetime;
+use tower::util::ServiceExt;
+
+#[tokio::test]
+async fn sweeper_fails_only_jobs_past_the_abandonment_window_and_counts_transitions() {
+    let fixture = SweeperFixture::new().await;
+    let old = fixture
+        .open_job("attempt-old", datetime!(2026-04-24 17:00:00 UTC))
+        .await;
+    let recent = fixture
+        .open_job("attempt-recent", datetime!(2026-04-25 17:30:00 UTC))
+        .await;
+    let finalized = fixture
+        .open_job("attempt-finalized", datetime!(2026-04-24 17:15:00 UTC))
+        .await;
+    mark_open_job_queued(&fixture.storage, &finalized.id).await;
+
+    let outcome = sweep_abandoned_jobs_once(
+        &fixture.storage,
+        &fixture.metrics,
+        AbandonmentSweeperConfig {
+            window: Duration::hours(24),
+            interval: std::time::Duration::from_secs(300),
+        },
+        datetime!(2026-04-25 18:00:00 UTC),
+    )
+    .await
+    .expect("sweep abandoned jobs");
+
+    assert_eq!(outcome.abandoned_count, 1);
+    assert_eq!(fixture.job_status(&old.id).await, "failed");
+    assert_eq!(
+        fixture.job_failure_code(&old.id).await.as_deref(),
+        Some("submission_abandoned")
+    );
+    assert_eq!(fixture.job_status(&recent.id).await, "accepting_chunks");
+    assert_eq!(fixture.job_status(&finalized.id).await, "queued");
+
+    let metrics = fixture.operator_metrics().await;
+    assert_metric_sample_has_value(&metrics, "oracy_transcription_abandonments_total", &[], "1");
+}
+
+struct SweeperFixture {
+    _tempdir: TempDir,
+    accepted_audio_dir: std::path::PathBuf,
+    storage: Storage,
+    metrics: Metrics,
+}
+
+impl SweeperFixture {
+    async fn new() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let accepted_audio_dir = tempdir.path().join("accepted-audio");
+        tokio::fs::create_dir(&accepted_audio_dir)
+            .await
+            .expect("create accepted audio dir");
+        let storage = Storage::connect(&tempdir.path().join("oracy.sqlite"))
+            .await
+            .expect("connect storage");
+        Self {
+            _tempdir: tempdir,
+            accepted_audio_dir,
+            storage,
+            metrics: Metrics::new(),
+        }
+    }
+
+    async fn open_job(
+        &self,
+        idempotency_key: &str,
+        now: time::OffsetDateTime,
+    ) -> oracy_backend::storage::TranscriptionJobRecord {
+        match self
+            .storage
+            .open_job(NewOpenTranscriptionJob {
+                api_key_id: "alpha".to_owned(),
+                idempotency_key: idempotency_key.to_owned(),
+                recorded_at: datetime!(2026-04-24 16:59:00 UTC),
+                session_id: None,
+                language: Some("en".to_owned()),
+                chunk_count: 1,
+                audio_format: "wav".to_owned(),
+                max_retries: 3,
+                now,
+            })
+            .await
+            .expect("open job")
+        {
+            OpenJobOutcome::Created(job) => job,
+            other => panic!("expected opened job, got {other:?}"),
+        }
+    }
+
+    async fn job_status(&self, job_id: &str) -> String {
+        sqlx::query_scalar("SELECT status FROM transcription_jobs WHERE id = ?")
+            .bind(job_id)
+            .fetch_one(self.storage.pool())
+            .await
+            .expect("job status")
+    }
+
+    async fn job_failure_code(&self, job_id: &str) -> Option<String> {
+        sqlx::query_scalar("SELECT failure_code FROM transcription_jobs WHERE id = ?")
+            .bind(job_id)
+            .fetch_one(self.storage.pool())
+            .await
+            .expect("job failure code")
+    }
+
+    async fn operator_metrics(&self) -> String {
+        let auth_store = AuthStore::try_from_configs(&[ApiKeyConfig {
+            api_key_id: "alpha".to_owned(),
+            key: "alpha-secret".to_owned(),
+        }])
+        .expect("auth config");
+        let state = AppState {
+            accepted_audio_dir: self.accepted_audio_dir.clone(),
+            auth_store: Arc::new(auth_store),
+            metrics: self.metrics.clone(),
+            operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
+            openai_api_key: "test-openai-key".to_owned(),
+            storage: self.storage.clone(),
+        };
+        let response = build_operator_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("metrics response");
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        String::from_utf8(bytes.to_vec()).expect("utf8 metrics")
+    }
+}
+
+async fn mark_open_job_queued(storage: &Storage, job_id: &str) {
+    let result = sqlx::query(
+        r#"
+        UPDATE transcription_jobs
+        SET audio_sha256_hex = 'queued-open-job-hash',
+            accepted_audio_path = '/var/lib/oracy/accepted-audio/queued-open-job.wav',
+            status = 'queued'
+        WHERE api_key_id = 'alpha' AND id = ?
+        "#,
+    )
+    .bind(job_id)
+    .execute(storage.pool())
+    .await
+    .expect("mark open job queued");
+    assert_eq!(result.rows_affected(), 1);
+}
+
+fn assert_metric_sample_has_value(body: &str, name: &str, labels: &[&str], value: &str) {
+    assert!(
+        body.lines().any(|line| {
+            line.starts_with(name)
+                && labels.iter().all(|label| line.contains(label))
+                && line.ends_with(&format!(" {value}"))
+        }),
+        "expected {name} with labels {labels:?} and value {value} in:\n{body}"
+    );
+}

--- a/backend/tests/metrics.rs
+++ b/backend/tests/metrics.rs
@@ -49,6 +49,9 @@ async fn operator_metrics_endpoint_exposes_initial_prometheus_series() {
     assert!(body.contains(r#"failure_class="none""#));
     assert!(body.contains("oracy_retention_cleanup_artifacts_total"));
     assert!(body.contains(r#"artifact="chunk""#));
+    assert!(body.contains("# HELP oracy_transcription_abandonments_total"));
+    assert!(body.contains("# TYPE oracy_transcription_abandonments_total counter"));
+    assert!(body.contains("oracy_transcription_abandonments_total 0"));
     assert!(body.contains("# HELP oracy_retained_audio_bytes"));
     assert!(body.contains("# TYPE oracy_retained_audio_bytes gauge"));
     assert!(body.contains("oracy_retained_audio_bytes 5"));

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -785,6 +785,121 @@ async fn abandonment_candidates_are_accepting_chunks_jobs_created_before_the_cut
 }
 
 #[tokio::test]
+async fn accepting_chunks_jobs_can_be_abandoned_once_with_terminal_failure_metadata() {
+    let (_tempdir, storage) = storage().await;
+    let job = opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-abandon-once",
+        datetime!(2026-04-24 17:00:00 UTC),
+    )
+    .await;
+
+    let abandoned = storage
+        .abandon_accepting_chunks_job(
+            "owner-a",
+            &job.id,
+            datetime!(2026-04-25 17:00:00 UTC),
+            datetime!(2026-04-25 18:00:00 UTC),
+        )
+        .await
+        .expect("abandon job")
+        .expect("job abandoned");
+    assert_eq!(abandoned.status, "failed");
+    assert_eq!(
+        abandoned.failure_code.as_deref(),
+        Some("submission_abandoned")
+    );
+    assert_eq!(abandoned.retryable_by_client, Some(true));
+    assert!(
+        abandoned
+            .failure_message
+            .as_deref()
+            .is_some_and(|message| { message.contains("abandonment window") })
+    );
+    assert_eq!(abandoned.updated_at, datetime!(2026-04-25 18:00:00 UTC));
+
+    let duplicate = storage
+        .abandon_accepting_chunks_job(
+            "owner-a",
+            &job.id,
+            datetime!(2026-04-25 17:01:00 UTC),
+            datetime!(2026-04-25 18:01:00 UTC),
+        )
+        .await
+        .expect("duplicate abandon");
+    assert_eq!(duplicate, None);
+}
+
+#[tokio::test]
+async fn abandonment_transition_requires_created_at_before_cutoff() {
+    let (_tempdir, storage) = storage().await;
+    let recent = opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-abandon-recent",
+        datetime!(2026-04-25 17:30:00 UTC),
+    )
+    .await;
+
+    let outcome = storage
+        .abandon_accepting_chunks_job(
+            "owner-a",
+            &recent.id,
+            datetime!(2026-04-25 17:00:00 UTC),
+            datetime!(2026-04-25 18:00:00 UTC),
+        )
+        .await
+        .expect("abandon recent job");
+
+    assert_eq!(outcome, None);
+    assert_eq!(
+        storage
+            .get_job("owner-a", &recent.id)
+            .await
+            .expect("get job")
+            .expect("job exists")
+            .status,
+        "accepting_chunks"
+    );
+}
+
+#[tokio::test]
+async fn abandoned_jobs_remain_addressable_by_idempotency_replay() {
+    let (_tempdir, storage) = storage().await;
+    let job = opened_job_at(
+        &storage,
+        "owner-a",
+        "attempt-abandoned-replay",
+        datetime!(2026-04-24 17:00:00 UTC),
+    )
+    .await;
+    storage
+        .abandon_accepting_chunks_job(
+            "owner-a",
+            &job.id,
+            datetime!(2026-04-25 17:00:00 UTC),
+            datetime!(2026-04-25 18:00:00 UTC),
+        )
+        .await
+        .expect("abandon job")
+        .expect("job abandoned");
+
+    let replay = storage
+        .open_job(new_open_job("owner-a", "attempt-abandoned-replay"))
+        .await
+        .expect("replay open");
+
+    assert!(matches!(
+        replay,
+        OpenJobOutcome::ReplayedFinalized(replayed)
+            if replayed.id == job.id
+                && replayed.status == "failed"
+                && replayed.failure_code.as_deref() == Some("submission_abandoned")
+    ));
+}
+
+#[tokio::test]
 async fn racing_same_hash_chunk_push_resolves_as_idempotent_replay() {
     let (_tempdir, storage) = storage().await;
     let job = opened_job(&storage, "owner-a", "attempt-racing-same-chunk").await;

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+use std::process::Command;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -13,6 +15,7 @@ use oracy_backend::storage::Storage;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
+use tokio::time::{Duration, sleep};
 use tower::util::ServiceExt;
 
 #[tokio::test]
@@ -493,6 +496,81 @@ async fn finalize_requires_all_chunks_and_replays_after_acceptance() {
 }
 
 #[tokio::test]
+async fn finalize_discards_composed_audio_when_abandonment_sweeper_wins_during_compose() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let (job_id, fifo_path, accepted_audio_path) = fixture
+        .create_fifo_backed_open_job("attempt-sweeper-finalize-race", b"blocked audio")
+        .await;
+
+    let finalize = {
+        let app = fixture.app.clone();
+        let job_id = job_id.clone();
+        tokio::spawn(async move { finalize_request(app, job_id).await })
+    };
+    let fifo_writer = fixture.open_fifo_writer_after_reader(&fifo_path).await;
+
+    fixture.sweep_abandoned_jobs().await;
+    fixture.write_fifo(fifo_writer, b"blocked audio");
+
+    let response = finalize.await.expect("finalize task should not panic");
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    assert!(
+        !accepted_audio_path.exists(),
+        "composed audio should be discarded after non-accepting finalize outcome"
+    );
+}
+
+#[tokio::test]
+async fn finalize_discards_composed_audio_when_chunk_rows_disappear_after_compose_starts() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let (job_id, fifo_path, accepted_audio_path) = fixture
+        .create_fifo_backed_open_job("attempt-missing-chunks-finalize-race", b"blocked audio")
+        .await;
+
+    let finalize = {
+        let app = fixture.app.clone();
+        let job_id = job_id.clone();
+        tokio::spawn(async move { finalize_request(app, job_id).await })
+    };
+    let fifo_writer = fixture.open_fifo_writer_after_reader(&fifo_path).await;
+
+    fixture.delete_chunk_row(&job_id, 0).await;
+    fixture.write_fifo(fifo_writer, b"blocked audio");
+
+    let response = finalize.await.expect("finalize task should not panic");
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    assert!(
+        !accepted_audio_path.exists(),
+        "composed audio should be discarded after missing chunks finalize outcome"
+    );
+}
+
+#[tokio::test]
+async fn finalize_discards_composed_audio_when_job_disappears_after_compose_starts() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let (job_id, fifo_path, accepted_audio_path) = fixture
+        .create_fifo_backed_open_job("attempt-not-found-finalize-race", b"blocked audio")
+        .await;
+
+    let finalize = {
+        let app = fixture.app.clone();
+        let job_id = job_id.clone();
+        tokio::spawn(async move { finalize_request(app, job_id).await })
+    };
+    let fifo_writer = fixture.open_fifo_writer_after_reader(&fifo_path).await;
+
+    fixture.delete_job_row(&job_id).await;
+    fixture.write_fifo(fifo_writer, b"blocked audio");
+
+    let response = finalize.await.expect("finalize task should not panic");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert!(
+        !accepted_audio_path.exists(),
+        "composed audio should be discarded after not found finalize outcome"
+    );
+}
+
+#[tokio::test]
 async fn finalize_captures_current_settings_and_nulls_sessions_deleted_after_open() {
     let fixture = TranscriptionJobFixture::new().await;
     let created_session = fixture
@@ -630,6 +708,7 @@ struct JsonResponse {
 
 struct TranscriptionJobFixture {
     _tempdir: TempDir,
+    accepted_audio_dir: PathBuf,
     metrics: Metrics,
     storage: Storage,
     app: axum::Router,
@@ -660,6 +739,7 @@ impl TranscriptionJobFixture {
 
         Self {
             _tempdir: tempdir,
+            accepted_audio_dir,
             metrics,
             storage,
             app,
@@ -746,6 +826,117 @@ impl TranscriptionJobFixture {
         .await
         .expect("accepted audio path");
         std::path::PathBuf::from(path)
+    }
+
+    async fn create_fifo_backed_open_job(
+        &self,
+        idempotency_key: &str,
+        bytes: &[u8],
+    ) -> (String, PathBuf, PathBuf) {
+        let opened = self
+            .json_request(
+                "POST",
+                "/api/v1/transcription-jobs",
+                Some(idempotency_key),
+                Some(json!({
+                    "recorded_at": "2026-04-24T17:59:00Z",
+                    "chunk_count": 1,
+                    "audio_format": "wav"
+                })),
+            )
+            .await;
+        assert_eq!(opened.status, StatusCode::CREATED);
+        let job_id = opened.body["id"].as_str().expect("job id").to_owned();
+        let chunk_dir = self.accepted_audio_dir.join(&job_id).join("chunks");
+        tokio::fs::create_dir_all(&chunk_dir)
+            .await
+            .expect("create chunk dir");
+        let fifo_path = chunk_dir.join("blocking.chunk");
+        let status = Command::new("mkfifo")
+            .arg(&fifo_path)
+            .status()
+            .expect("run mkfifo");
+        assert!(
+            status.success(),
+            "mkfifo should create blocking chunk source"
+        );
+
+        sqlx::query(
+            r#"
+            INSERT INTO transcription_job_chunks (
+                api_key_id, job_id, chunk_index, chunk_sha256_hex,
+                chunk_path, chunk_size_bytes, accepted_at
+            )
+            VALUES ('alpha', ?, 0, ?, ?, ?, '2026-04-24T18:00:01Z')
+            "#,
+        )
+        .bind(&job_id)
+        .bind(sha256_hex(bytes))
+        .bind(fifo_path.to_string_lossy().into_owned())
+        .bind(bytes.len() as i64)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert blocking chunk row");
+
+        let accepted_audio_path = self.accepted_audio_dir.join(&job_id).join("accepted.wav");
+        (job_id, fifo_path, accepted_audio_path)
+    }
+
+    async fn open_fifo_writer_after_reader(&self, fifo_path: &std::path::Path) -> std::fs::File {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        const O_NONBLOCK: i32 = 0o4000;
+        const ENXIO: i32 = 6;
+
+        for _ in 0..100 {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .custom_flags(O_NONBLOCK)
+                .open(fifo_path)
+            {
+                Ok(writer) => return writer,
+                Err(error) if error.raw_os_error() == Some(ENXIO) => {
+                    sleep(Duration::from_millis(10)).await;
+                }
+                Err(error) => panic!("open fifo writer: {error}"),
+            }
+        }
+        panic!("finalize did not open the fifo chunk for reading");
+    }
+
+    fn write_fifo(&self, mut fifo: std::fs::File, bytes: &[u8]) {
+        use std::io::Write;
+
+        fifo.write_all(bytes).expect("write fifo bytes");
+    }
+
+    async fn delete_chunk_row(&self, job_id: &str, chunk_index: i64) {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM transcription_job_chunks
+            WHERE api_key_id = 'alpha' AND job_id = ? AND chunk_index = ?
+            "#,
+        )
+        .bind(job_id)
+        .bind(chunk_index)
+        .execute(self.storage.pool())
+        .await
+        .expect("delete chunk row");
+        assert_eq!(result.rows_affected(), 1);
+    }
+
+    async fn delete_job_row(&self, job_id: &str) {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM transcription_jobs
+            WHERE api_key_id = 'alpha' AND id = ?
+            "#,
+        )
+        .bind(job_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("delete job row");
+        assert_eq!(result.rows_affected(), 1);
     }
 
     async fn stored_audio_hash(&self, job_id: &str) -> String {
@@ -861,6 +1052,19 @@ async fn json_body(response: axum::response::Response) -> Value {
         return Value::Null;
     }
     serde_json::from_slice(&bytes).expect("valid json")
+}
+
+async fn finalize_request(app: axum::Router, job_id: String) -> axum::response::Response {
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/v1/transcription-jobs/{job_id}/finalize"))
+            .header("Authorization", "Bearer alpha-secret")
+            .body(Body::empty())
+            .expect("finalize request"),
+    )
+    .await
+    .expect("finalize response")
 }
 
 fn multipart_body(boundary: &str, chunk_index: usize, chunk_sha256: &str, bytes: &[u8]) -> Vec<u8> {

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use oracy_backend::abandonment_sweeper::{AbandonmentSweeperConfig, sweep_abandoned_jobs_once};
 use oracy_backend::audio_store::MAX_CHUNK_BYTES;
 use oracy_backend::auth::AuthStore;
 use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::metrics::Metrics;
 use oracy_backend::router::build_router;
 use oracy_backend::state::AppState;
 use oracy_backend::storage::Storage;
@@ -585,6 +587,42 @@ async fn finalize_captures_current_settings_and_nulls_sessions_deleted_after_ope
     assert_eq!(replayed.body["status"], "queued");
 }
 
+#[tokio::test]
+async fn open_replay_returns_original_failed_job_after_abandonment_sweep() {
+    let fixture = TranscriptionJobFixture::new().await;
+    let body = json!({
+        "recorded_at": "2026-04-24T17:59:00Z",
+        "chunk_count": 1,
+        "audio_format": "wav"
+    });
+    let opened = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-abandoned-replay"),
+            Some(body.clone()),
+        )
+        .await;
+    assert_eq!(opened.status, StatusCode::CREATED);
+    let job_id = opened.body["id"].as_str().expect("job id");
+    fixture.sweep_abandoned_jobs().await;
+
+    let replayed = fixture
+        .json_request(
+            "POST",
+            "/api/v1/transcription-jobs",
+            Some("attempt-abandoned-replay"),
+            Some(body),
+        )
+        .await;
+
+    assert_eq!(replayed.status, StatusCode::OK);
+    assert_eq!(replayed.body["id"], job_id);
+    assert_eq!(replayed.body["status"], "failed");
+    assert_eq!(replayed.body["failure_code"], "submission_abandoned");
+    assert_eq!(replayed.body["retryable_by_client"], true);
+}
+
 struct JsonResponse {
     status: StatusCode,
     body: Value,
@@ -592,6 +630,7 @@ struct JsonResponse {
 
 struct TranscriptionJobFixture {
     _tempdir: TempDir,
+    metrics: Metrics,
     storage: Storage,
     app: axum::Router,
 }
@@ -609,10 +648,11 @@ impl TranscriptionJobFixture {
             key: "alpha-secret".to_owned(),
         }])
         .expect("auth config");
+        let metrics = Metrics::new();
         let app = build_router(AppState {
             accepted_audio_dir: accepted_audio_dir.clone(),
             auth_store: Arc::new(auth_store),
-            metrics: oracy_backend::metrics::Metrics::new(),
+            metrics: metrics.clone(),
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
@@ -620,6 +660,7 @@ impl TranscriptionJobFixture {
 
         Self {
             _tempdir: tempdir,
+            metrics,
             storage,
             app,
         }
@@ -769,6 +810,20 @@ impl TranscriptionJobFixture {
         .fetch_one(self.storage.pool())
         .await
         .expect("job count")
+    }
+
+    async fn sweep_abandoned_jobs(&self) {
+        sweep_abandoned_jobs_once(
+            &self.storage,
+            &self.metrics,
+            AbandonmentSweeperConfig {
+                window: time::Duration::ZERO,
+                interval: std::time::Duration::from_secs(300),
+            },
+            time::OffsetDateTime::now_utc() + time::Duration::seconds(1),
+        )
+        .await
+        .expect("sweep abandoned jobs");
     }
 
     async fn request(

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -97,7 +97,8 @@ required, not optional.
   paths, user content, and free-form error text must not appear as
   labels.
 - The initial metric set includes transcription-worker job counters
-  for success, retry, and terminal failure outcomes; retention-cleanup
+  for success, retry, and terminal failure outcomes; an abandonment
+  counter for stale pre-finalize submissions; retention-cleanup
   artifact counters for success and failure outcomes; and a retained-
   audio byte gauge for current accepted-audio capacity tracking.
 - Every metric exposed by `/metrics` carries a `# HELP` line and a
@@ -689,7 +690,8 @@ following are true:
   or `failed`.
 - Operator metrics are exposed only on the operator listener, use the
   documented naming and cardinality policy, and include the initial
-  worker, retention-cleanup, and retained-audio capacity metrics.
+  worker, abandonment, retention-cleanup, and retained-audio capacity
+  metrics.
 - Supported audio formats, per-chunk size ceiling, language-hint
   semantics, pagination shape, and error-envelope semantics are
   named concretely.


### PR DESCRIPTION
## Summary

- Adds the transcription-job abandonment sweeper for stale `accepting_chunks` jobs.
- Fails eligible jobs with `failure_code: "submission_abandoned"` and `retryable_by_client: true` using an atomic storage transition.
- Exposes abandonment activity through structured logs and the `oracy_transcription_abandonments_total` operator metric.

## Changes

- Runs a periodic abandonment sweeper in the backend binary with internal defaults: 24h window and 5m scan interval.
- Adds a storage transition that requires `status = 'accepting_chunks'` and `created_at < cutoff`, making finalize/sweeper races and duplicate sweeps no-ops.
- Adds a SQLite index for abandonment scans plus storage, sweeper, HTTP replay, and metrics coverage.
- Updates operator-facing docs and the changelog for the new metric/behavior.

## GitHub Issue(s)

Closes #59
Refs #11

## Test plan

- `cargo test`
- `git diff --check`
