### PR TITLE
feat(voice-notes): implement voice-note edits, tag replacement, and deletion semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add authenticated voice-note mutation APIs for text replacement with
+  version history, full tag-set replacement, hard deletion with cascades, and
+  edit-triggered embedding-regeneration initiation.
 - Add a transcription-job abandonment sweeper that fails stale
   `accepting_chunks` jobs with `submission_abandoned` and reports swept jobs
   through operator logs and metrics.

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -9,6 +9,7 @@ use tracing::info;
 
 use crate::auth::AuthStore;
 use crate::config::Settings;
+use crate::embedding_regeneration::NoopEmbeddingRegenerationTrigger;
 use crate::metrics::Metrics;
 use crate::state::AppState;
 use crate::storage::{Storage, StorageError};
@@ -113,6 +114,7 @@ async fn load_runtime_from_path_with_openai_key(
         operator_listen_addr: settings.operator_listen_addr,
         openai_api_key,
         storage,
+        embedding_regeneration_trigger: Arc::new(NoopEmbeddingRegenerationTrigger),
     };
 
     Ok((settings.listen_addr, state))

--- a/backend/src/embedding_regeneration.rs
+++ b/backend/src/embedding_regeneration.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingRegenerationRequest {
+    pub api_key_id: String,
+    pub voice_note_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum EmbeddingRegenerationTriggerError {
+    #[error("{0}")]
+    Failed(String),
+}
+
+pub trait EmbeddingRegenerationTrigger: Send + Sync {
+    fn initiate(
+        &self,
+        request: EmbeddingRegenerationRequest,
+    ) -> Result<(), EmbeddingRegenerationTriggerError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct NoopEmbeddingRegenerationTrigger;
+
+impl EmbeddingRegenerationTrigger for NoopEmbeddingRegenerationTrigger {
+    fn initiate(
+        &self,
+        _request: EmbeddingRegenerationRequest,
+    ) -> Result<(), EmbeddingRegenerationTriggerError> {
+        Ok(())
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod bootstrap;
 pub mod collections;
 pub mod config;
+pub mod embedding_regeneration;
 pub mod errors;
 pub mod json;
 pub mod metadata;

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -11,8 +11,8 @@ use crate::settings::{get_settings, patch_settings};
 use crate::state::AppState;
 use crate::transcription_jobs;
 use crate::voice_notes::{
-    get_voice_note, list_session_voice_notes, list_voice_note_segments, list_voice_note_versions,
-    list_voice_notes,
+    delete_voice_note, get_voice_note, list_session_voice_notes, list_voice_note_segments,
+    list_voice_note_versions, list_voice_notes, patch_voice_note, put_voice_note_tags,
 };
 
 pub fn build_router(state: AppState) -> Router {
@@ -30,7 +30,12 @@ pub fn build_router(state: AppState) -> Router {
             get(get_session).patch(patch_session).delete(delete_session),
         )
         .route("/api/v1/voice-notes", get(list_voice_notes))
-        .route("/api/v1/voice-notes/{voice_note_id}", get(get_voice_note))
+        .route(
+            "/api/v1/voice-notes/{voice_note_id}",
+            get(get_voice_note)
+                .patch(patch_voice_note)
+                .delete(delete_voice_note),
+        )
         .route(
             "/api/v1/voice-notes/{voice_note_id}/versions",
             get(list_voice_note_versions),
@@ -38,6 +43,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/api/v1/voice-notes/{voice_note_id}/segments",
             get(list_voice_note_segments),
+        )
+        .route(
+            "/api/v1/voice-notes/{voice_note_id}/tags",
+            axum::routing::put(put_voice_note_tags),
         )
         .route(
             "/api/v1/sessions/{session_id}/voice-notes",

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -6,6 +6,7 @@ use std::{fmt, fmt::Debug};
 use axum::extract::FromRef;
 
 use crate::auth::AuthStore;
+use crate::embedding_regeneration::EmbeddingRegenerationTrigger;
 use crate::metrics::Metrics;
 use crate::storage::Storage;
 
@@ -17,6 +18,7 @@ pub struct AppState {
     pub operator_listen_addr: SocketAddr,
     pub openai_api_key: String,
     pub storage: Storage,
+    pub embedding_regeneration_trigger: Arc<dyn EmbeddingRegenerationTrigger>,
 }
 
 impl Debug for AppState {
@@ -29,6 +31,7 @@ impl Debug for AppState {
             .field("operator_listen_addr", &self.operator_listen_addr)
             .field("openai_api_key", &"<redacted>")
             .field("storage", &self.storage)
+            .field("embedding_regeneration_trigger", &"<trigger>")
             .finish()
     }
 }

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -130,7 +130,7 @@ pub enum ReplaceVoiceNoteTagsOutcome {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum UpdateVoiceNoteTextOutcome {
-    Updated(VoiceNoteRecord),
+    Updated(Box<VoiceNoteRecord>),
     NotFound,
 }
 
@@ -1664,7 +1664,7 @@ impl Storage {
         let updated = voice_note_from_row(row)?;
         tx.commit().await?;
 
-        Ok(UpdateVoiceNoteTextOutcome::Updated(updated))
+        Ok(UpdateVoiceNoteTextOutcome::Updated(Box::new(updated)))
     }
 
     pub async fn list_voice_notes(

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -128,6 +128,12 @@ pub enum ReplaceVoiceNoteTagsOutcome {
     DuplicateTagIds,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateVoiceNoteTextOutcome {
+    Updated(VoiceNoteRecord),
+    NotFound,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmissionConflict {
     pub job_id: String,
@@ -1579,6 +1585,86 @@ impl Storage {
         .await?;
 
         row.map(voice_note_from_row).transpose()
+    }
+
+    pub async fn update_voice_note_text(
+        &self,
+        api_key_id: &str,
+        voice_note_id: &str,
+        text: &str,
+        created_at: OffsetDateTime,
+    ) -> Result<UpdateVoiceNoteTextOutcome, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let voice_note_exists: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT 1
+            FROM voice_notes
+            WHERE api_key_id = ? AND id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(voice_note_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if voice_note_exists.is_none() {
+            tx.commit().await?;
+            return Ok(UpdateVoiceNoteTextOutcome::NotFound);
+        }
+
+        let version_number: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COALESCE(MAX(version_number), 0) + 1
+            FROM voice_note_versions
+            WHERE api_key_id = ? AND voice_note_id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(voice_note_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO voice_note_versions (
+                id, api_key_id, voice_note_id, version_number, text, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(new_id())
+        .bind(api_key_id)
+        .bind(voice_note_id)
+        .bind(version_number)
+        .bind(text)
+        .bind(format_timestamp(created_at)?)
+        .execute(&mut *tx)
+        .await?;
+
+        let row = sqlx::query(
+            r#"
+            SELECT
+                voice_notes.*,
+                voice_note_versions.id AS current_version_id,
+                voice_note_versions.text AS current_text
+            FROM voice_notes
+            JOIN voice_note_versions
+                ON voice_note_versions.voice_note_id = voice_notes.id
+            WHERE voice_notes.api_key_id = ?
+                AND voice_notes.id = ?
+                AND voice_note_versions.version_number = (
+                    SELECT MAX(version_number)
+                    FROM voice_note_versions
+                    WHERE voice_note_id = voice_notes.id
+                )
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(voice_note_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let updated = voice_note_from_row(row)?;
+        tx.commit().await?;
+
+        Ok(UpdateVoiceNoteTextOutcome::Updated(updated))
     }
 
     pub async fn list_voice_notes(

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -1,6 +1,7 @@
 use axum::Json;
 use axum::extract::{Path, RawQuery, State};
-use serde::Serialize;
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::auth::AuthenticatedKey;
@@ -9,10 +10,13 @@ use crate::collections::{
     parse_rfc3339_field, parse_time_cursor, position_cursor, query_any, query_first, query_values,
     time_cursor, timestamp, validate_rfc3339_field, validate_ulid_field, validation_error,
 };
+use crate::embedding_regeneration::EmbeddingRegenerationRequest;
 use crate::errors::{ApiError, CollectionEnvelope};
+use crate::json::JsonBody;
 use crate::state::AppState;
 use crate::storage::{
-    SegmentRecord, TagRecord, VoiceNoteFilters, VoiceNoteRecord, VoiceNoteVersionRecord,
+    ReplaceVoiceNoteTagsOutcome, SegmentRecord, TagRecord, UpdateVoiceNoteTextOutcome,
+    VoiceNoteFilters, VoiceNoteRecord, VoiceNoteVersionRecord,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,6 +83,18 @@ pub struct TagResource {
     created_at: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VoiceNoteTextRequest {
+    text: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VoiceNoteTagsRequest {
+    tag_ids: Vec<String>,
+}
+
 pub async fn list_voice_notes(
     authenticated_key: AuthenticatedKey,
     State(state): State<AppState>,
@@ -132,6 +148,65 @@ pub async fn get_voice_note(
         .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
 
     Ok(Json(voice_note_resource(record, tags)?))
+}
+
+pub async fn patch_voice_note(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(voice_note_id): Path<String>,
+    JsonBody(body): JsonBody<VoiceNoteTextRequest>,
+) -> Result<Json<VoiceNoteResource>, ApiError> {
+    validate_ulid_field("voice_note_id", &voice_note_id)?;
+    let record = match state
+        .storage
+        .update_voice_note_text(
+            authenticated_key.api_key_id.as_str(),
+            &voice_note_id,
+            &body.text,
+            OffsetDateTime::now_utc(),
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to update voice note."))?
+    {
+        UpdateVoiceNoteTextOutcome::Updated(record) => record,
+        UpdateVoiceNoteTextOutcome::NotFound => {
+            return Err(ApiError::not_found("Voice note not found."));
+        }
+    };
+
+    if let Err(error) =
+        state
+            .embedding_regeneration_trigger
+            .initiate(EmbeddingRegenerationRequest {
+                api_key_id: authenticated_key.api_key_id.to_string(),
+                voice_note_id: voice_note_id.clone(),
+            })
+    {
+        tracing::error!(
+            voice_note_id = %voice_note_id,
+            "embedding regeneration trigger failed: {error}"
+        );
+    }
+
+    render_voice_note_resource(&state, authenticated_key.api_key_id.as_str(), record).await
+}
+
+pub async fn delete_voice_note(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(voice_note_id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    validate_ulid_field("voice_note_id", &voice_note_id)?;
+    if !state
+        .storage
+        .delete_voice_note(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to delete voice note."))?
+    {
+        return Err(ApiError::not_found("Voice note not found."));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 pub async fn list_voice_note_versions(
@@ -227,6 +302,50 @@ pub async fn list_voice_note_segments(
     Ok(Json(CollectionEnvelope { items, next_cursor }))
 }
 
+pub async fn put_voice_note_tags(
+    authenticated_key: AuthenticatedKey,
+    State(state): State<AppState>,
+    Path(voice_note_id): Path<String>,
+    JsonBody(body): JsonBody<VoiceNoteTagsRequest>,
+) -> Result<Json<VoiceNoteResource>, ApiError> {
+    validate_ulid_field("voice_note_id", &voice_note_id)?;
+    for tag_id in &body.tag_ids {
+        validate_ulid_field("tag_ids", tag_id)?;
+    }
+
+    match state
+        .storage
+        .replace_voice_note_tags(
+            authenticated_key.api_key_id.as_str(),
+            &voice_note_id,
+            &body.tag_ids,
+        )
+        .await
+        .map_err(|_| ApiError::internal("Failed to replace voice note tags."))?
+    {
+        ReplaceVoiceNoteTagsOutcome::Replaced => {}
+        ReplaceVoiceNoteTagsOutcome::NotFound => {
+            return Err(ApiError::not_found("Voice note not found."));
+        }
+        ReplaceVoiceNoteTagsOutcome::DuplicateTagIds => {
+            return Err(validation_error(
+                "tag_ids",
+                "Duplicate tag_ids are invalid.",
+            ));
+        }
+    }
+
+    let Some(record) = state
+        .storage
+        .get_voice_note(authenticated_key.api_key_id.as_str(), &voice_note_id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load voice note."))?
+    else {
+        return Err(ApiError::internal("Updated voice note was not found."));
+    };
+    render_voice_note_resource(&state, authenticated_key.api_key_id.as_str(), record).await
+}
+
 pub async fn list_session_voice_notes(
     authenticated_key: AuthenticatedKey,
     State(state): State<AppState>,
@@ -287,6 +406,20 @@ async fn ensure_voice_note_exists(
     }
 
     Ok(())
+}
+
+async fn render_voice_note_resource(
+    state: &AppState,
+    api_key_id: &str,
+    record: VoiceNoteRecord,
+) -> Result<Json<VoiceNoteResource>, ApiError> {
+    let tags = state
+        .storage
+        .list_voice_note_tags(api_key_id, &record.id)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
+
+    Ok(Json(voice_note_resource(record, tags)?))
 }
 
 async fn render_voice_note_page(

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -168,7 +168,7 @@ pub async fn patch_voice_note(
         .await
         .map_err(|_| ApiError::internal("Failed to update voice note."))?
     {
-        UpdateVoiceNoteTextOutcome::Updated(record) => record,
+        UpdateVoiceNoteTextOutcome::Updated(record) => *record,
         UpdateVoiceNoteTextOutcome::NotFound => {
             return Err(ApiError::not_found("Voice note not found."));
         }

--- a/backend/tests/abandonment_sweeper.rs
+++ b/backend/tests/abandonment_sweeper.rs
@@ -133,6 +133,9 @@ impl SweeperFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: self.storage.clone(),
+            embedding_regeneration_trigger: Arc::new(
+                oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
+            ),
         };
         let response = build_operator_router(state)
             .oneshot(

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -478,6 +478,9 @@ impl MetadataFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
+            embedding_regeneration_trigger: Arc::new(
+                oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
+            ),
         });
 
         Self {

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -7,7 +7,7 @@ use oracy_backend::storage::{
     NewOpenTranscriptionJob, NewSegment, NewSession, NewTag, NewTranscriptionJob, NewVoiceNote,
     NewVoiceNoteVersion, OpenJobOutcome, RenameTagOutcome, ReplaceVoiceNoteTagsOutcome,
     RetryOutcome, Storage, StorageError, StoreChunkOutcome, TransientJobFailure,
-    VoiceNoteMaterialization,
+    UpdateVoiceNoteTextOutcome, VoiceNoteMaterialization,
 };
 use sqlx::Row;
 use std::time::Duration as StdDuration;
@@ -1109,6 +1109,55 @@ async fn completed_voice_notes_expose_current_version_ordered_segments_and_curre
 }
 
 #[tokio::test]
+async fn voice_note_text_replacement_appends_one_current_version_without_mutating_segments() {
+    let (_tempdir, storage) = storage().await;
+    let job = created_job(&storage, "owner-a", "attempt-1").await;
+    mark_job_processing(&storage, &job.id).await;
+    storage
+        .complete_job_with_voice_note("owner-a", &job.id, materialization("voice-note-a"))
+        .await
+        .expect("materialize voice note");
+
+    let outcome = storage
+        .update_voice_note_text(
+            "owner-a",
+            "voice-note-a",
+            "edited text",
+            datetime!(2026-04-24 18:01:00 UTC),
+        )
+        .await
+        .expect("replace voice note text");
+
+    let UpdateVoiceNoteTextOutcome::Updated(updated) = outcome else {
+        panic!("expected updated voice note, got {outcome:?}");
+    };
+    assert_eq!(updated.text, "edited text");
+    assert_ne!(updated.current_version_id, "voice-note-a-version-1");
+
+    let versions = storage
+        .list_voice_note_versions("owner-a", "voice-note-a", None, 10)
+        .await
+        .expect("version history");
+    assert_eq!(versions.len(), 2);
+    assert_eq!(versions[0].id, updated.current_version_id);
+    assert_eq!(versions[0].text, "edited text");
+    assert_eq!(versions[1].id, "voice-note-a-version-1");
+    assert_eq!(versions[1].text, "initial text");
+
+    let segments = storage
+        .list_segments("owner-a", "voice-note-a")
+        .await
+        .expect("segments");
+    assert_eq!(
+        segments
+            .iter()
+            .map(|segment| (segment.position, segment.text.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(0, "first segment"), (1, "second segment")]
+    );
+}
+
+#[tokio::test]
 async fn duplicate_completion_fails_without_orphaning_materialized_rows() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
@@ -1324,6 +1373,18 @@ async fn deleting_a_voice_note_cascades_children_and_nulls_the_succeeded_job() {
         .expect("job survives");
     assert_eq!(job.status, "succeeded");
     assert_eq!(job.voice_note_id, None);
+
+    let replayed = match storage
+        .accept_job(new_job("owner-a", "attempt-1", "hash-a"))
+        .await
+        .expect("replay deleted voice note job")
+    {
+        AcceptJobOutcome::Replayed(job) => job,
+        other => panic!("expected replayed job, got {other:?}"),
+    };
+    assert_eq!(replayed.id, job.id);
+    assert_eq!(replayed.status, "succeeded");
+    assert_eq!(replayed.voice_note_id, None);
 }
 
 #[tokio::test]

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -735,6 +735,9 @@ impl TranscriptionJobFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
+            embedding_regeneration_trigger: Arc::new(
+                oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
+            ),
         });
 
         Self {

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -1306,6 +1306,9 @@ async fn operator_metrics_text(fixture: &WorkerFixture, metrics: Metrics) -> Str
         operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
         openai_api_key: "test-openai-key".to_owned(),
         storage: fixture.storage.clone(),
+        embedding_regeneration_trigger: Arc::new(
+            oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
+        ),
     };
     let response = build_operator_router(state)
         .oneshot(

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -1,9 +1,12 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use oracy_backend::auth::AuthStore;
 use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::embedding_regeneration::{
+    EmbeddingRegenerationRequest, EmbeddingRegenerationTrigger, EmbeddingRegenerationTriggerError,
+};
 use oracy_backend::router::build_router;
 use oracy_backend::state::AppState;
 use oracy_backend::storage::Storage;
@@ -272,6 +275,161 @@ async fn version_history_returns_versions_newest_first_in_shared_envelope() {
 }
 
 #[tokio::test]
+async fn patch_voice_note_text_appends_version_updates_reads_and_initiates_embedding_regeneration()
+{
+    let trigger = Arc::new(RecordingEmbeddingTrigger::failing());
+    let fixture = VoiceNoteFixture::new_with_trigger(trigger.clone()).await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "initial text",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
+    fixture
+        .insert_segment("alpha", NOTE_OLD, SEGMENT_FIRST, 0, "original segment")
+        .await;
+
+    let response = fixture
+        .json_request(
+            "PATCH",
+            &format!("/api/v1/voice-notes/{NOTE_OLD}"),
+            "alpha-secret",
+            Some(json!({"text": "edited text"})),
+        )
+        .await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body["id"], NOTE_OLD);
+    assert_eq!(response.body["text"], "edited text");
+    assert_ne!(response.body["current_version_id"], VERSION_OLD);
+    assert_eq!(
+        trigger.requests(),
+        vec![EmbeddingRegenerationRequest {
+            api_key_id: "alpha".to_owned(),
+            voice_note_id: NOTE_OLD.to_owned(),
+        }]
+    );
+
+    let versions = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/versions"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(versions["items"].as_array().expect("versions").len(), 2);
+    assert_eq!(versions["items"][0]["text"], "edited text");
+    assert_eq!(versions["items"][1]["id"], VERSION_OLD);
+
+    let detail = fixture
+        .get_json(&format!("/api/v1/voice-notes/{NOTE_OLD}"), "alpha-secret")
+        .await;
+    assert_eq!(detail["text"], "edited text");
+    assert_eq!(
+        detail["current_version_id"],
+        response.body["current_version_id"]
+    );
+    assert_eq!(detail["tags"][0]["id"], TAG_MEETING);
+
+    let segments = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/segments"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(segments["items"][0]["text"], "original segment");
+}
+
+#[tokio::test]
+async fn patch_voice_note_text_reports_contract_errors_for_invalid_requests() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "beta",
+            id: NOTE_OTHER_OWNER,
+            version_id: NOTE_OTHER_OWNER,
+            text: "hidden note",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    let malformed_path = fixture
+        .json_request(
+            "PATCH",
+            "/api/v1/voice-notes/not-a-ulid",
+            "alpha-secret",
+            Some(json!({"text": "edited"})),
+        )
+        .await;
+    assert_eq!(malformed_path.status, StatusCode::BAD_REQUEST);
+    assert_eq!(malformed_path.body["details"][0]["field"], "voice_note_id");
+
+    for voice_note_id in [NOTE_MISSING, NOTE_OTHER_OWNER] {
+        let response = fixture
+            .json_request(
+                "PATCH",
+                &format!("/api/v1/voice-notes/{voice_note_id}"),
+                "alpha-secret",
+                Some(json!({"text": "edited"})),
+            )
+            .await;
+        assert_eq!(response.status, StatusCode::NOT_FOUND);
+        assert_eq!(response.body["error_code"], "not_found");
+    }
+
+    let malformed_json = fixture
+        .request(
+            "PATCH",
+            &format!("/api/v1/voice-notes/{NOTE_MISSING}"),
+            "alpha-secret",
+            Some("{".to_owned()),
+        )
+        .await;
+    assert_eq!(malformed_json.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        json_body(malformed_json).await["error_code"],
+        "malformed_json"
+    );
+
+    let invalid_shape = fixture
+        .json_request(
+            "PATCH",
+            &format!("/api/v1/voice-notes/{NOTE_MISSING}"),
+            "alpha-secret",
+            Some(json!({"text": 1})),
+        )
+        .await;
+    assert_eq!(invalid_shape.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(invalid_shape.body["error_code"], "invalid_request_shape");
+
+    let unauthorized = fixture
+        .app()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/v1/voice-notes/{NOTE_MISSING}"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({"text": "edited"}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
 async fn segments_return_in_position_order_with_pagination() {
     let fixture = VoiceNoteFixture::new().await;
     fixture
@@ -310,6 +468,221 @@ async fn segments_return_in_position_order_with_pagination() {
         .await;
     assert_eq!(second["items"][0]["id"], SEGMENT_SECOND);
     assert_eq!(second["next_cursor"], Value::Null);
+}
+
+#[tokio::test]
+async fn put_voice_note_tags_replaces_the_full_tag_set_without_creating_a_version() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "tagged note",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
+    fixture
+        .insert_tag(
+            "alpha",
+            TAG_ACTION,
+            "Action",
+            "2026-04-24T18:01:40.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_tag(
+            "beta",
+            TAG_MISSING,
+            "Hidden",
+            "2026-04-24T18:01:50.000000000Z",
+        )
+        .await;
+
+    let response = fixture
+        .json_request(
+            "PUT",
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/tags"),
+            "alpha-secret",
+            Some(json!({"tag_ids": [TAG_ACTION]})),
+        )
+        .await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body["tags"][0]["id"], TAG_ACTION);
+    assert_eq!(response.body["current_version_id"], VERSION_OLD);
+
+    let versions = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/versions"),
+            "alpha-secret",
+        )
+        .await;
+    assert_eq!(versions["items"].as_array().expect("versions").len(), 1);
+
+    let duplicate = fixture
+        .json_request(
+            "PUT",
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/tags"),
+            "alpha-secret",
+            Some(json!({"tag_ids": [TAG_ACTION, TAG_ACTION]})),
+        )
+        .await;
+    assert_eq!(duplicate.status, StatusCode::BAD_REQUEST);
+    assert_eq!(duplicate.body["error_code"], "validation_error");
+    assert_eq!(duplicate.body["details"][0]["field"], "tag_ids");
+
+    for tag_id in [TAG_MISSING, TAG_ACTION] {
+        let bearer = if tag_id == TAG_MISSING {
+            "alpha-secret"
+        } else {
+            "beta-secret"
+        };
+        let response = fixture
+            .json_request(
+                "PUT",
+                &format!("/api/v1/voice-notes/{NOTE_OLD}/tags"),
+                bearer,
+                Some(json!({"tag_ids": [tag_id]})),
+            )
+            .await;
+        assert_eq!(response.status, StatusCode::NOT_FOUND);
+    }
+
+    let malformed_tag_id = fixture
+        .json_request(
+            "PUT",
+            &format!("/api/v1/voice-notes/{NOTE_OLD}/tags"),
+            "alpha-secret",
+            Some(json!({"tag_ids": ["not-a-ulid"]})),
+        )
+        .await;
+    assert_eq!(malformed_tag_id.status, StatusCode::BAD_REQUEST);
+    assert_eq!(malformed_tag_id.body["details"][0]["field"], "tag_ids");
+}
+
+#[tokio::test]
+async fn delete_voice_note_hard_deletes_children_and_preserves_the_succeeded_job_replay_record() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "doomed note",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        })
+        .await;
+    fixture
+        .insert_version(
+            "alpha",
+            NOTE_OLD,
+            VERSION_NEW,
+            2,
+            "edited text",
+            "2026-04-24T18:01:00.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_segment("alpha", NOTE_OLD, SEGMENT_FIRST, 0, "segment text")
+        .await;
+    fixture.insert_embedding("alpha", NOTE_OLD).await;
+    fixture
+        .insert_succeeded_job("alpha", JOB_ALPHA, NOTE_OLD)
+        .await;
+
+    let response = fixture
+        .request(
+            "DELETE",
+            &format!("/api/v1/voice-notes/{NOTE_OLD}"),
+            "alpha-secret",
+            None,
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(
+        fixture
+            .storage
+            .get_voice_note("alpha", NOTE_OLD)
+            .await
+            .expect("voice note lookup")
+            .is_none()
+    );
+    assert!(
+        fixture
+            .storage
+            .list_voice_note_versions("alpha", NOTE_OLD, None, 10)
+            .await
+            .expect("versions")
+            .is_empty()
+    );
+    assert!(
+        fixture
+            .storage
+            .list_segments("alpha", NOTE_OLD)
+            .await
+            .expect("segments")
+            .is_empty()
+    );
+    assert!(
+        fixture
+            .storage
+            .get_current_embedding("alpha", NOTE_OLD)
+            .await
+            .expect("embedding lookup")
+            .is_none()
+    );
+    assert!(
+        fixture
+            .storage
+            .list_voice_note_tags("alpha", NOTE_OLD)
+            .await
+            .expect("tags")
+            .is_empty()
+    );
+    let job = fixture
+        .storage
+        .get_job("alpha", JOB_ALPHA)
+        .await
+        .expect("job lookup")
+        .expect("job survives");
+    assert_eq!(job.status, "succeeded");
+    assert_eq!(job.voice_note_id, None);
+
+    let missing = fixture
+        .request(
+            "DELETE",
+            &format!("/api/v1/voice-notes/{NOTE_OLD}"),
+            "alpha-secret",
+            None,
+        )
+        .await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    let malformed = fixture
+        .request(
+            "DELETE",
+            "/api/v1/voice-notes/not-a-ulid",
+            "alpha-secret",
+            None,
+        )
+        .await;
+    assert_validation_error(malformed, "voice_note_id").await;
 }
 
 #[tokio::test]
@@ -879,6 +1252,45 @@ struct VoiceNoteFixture {
     storage: Storage,
 }
 
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+#[derive(Clone)]
+struct RecordingEmbeddingTrigger {
+    requests: Arc<Mutex<Vec<EmbeddingRegenerationRequest>>>,
+    fail: bool,
+}
+
+impl RecordingEmbeddingTrigger {
+    fn failing() -> Self {
+        Self {
+            requests: Arc::new(Mutex::new(Vec::new())),
+            fail: true,
+        }
+    }
+
+    fn requests(&self) -> Vec<EmbeddingRegenerationRequest> {
+        self.requests.lock().expect("requests lock").clone()
+    }
+}
+
+impl EmbeddingRegenerationTrigger for RecordingEmbeddingTrigger {
+    fn initiate(
+        &self,
+        request: EmbeddingRegenerationRequest,
+    ) -> Result<(), EmbeddingRegenerationTriggerError> {
+        self.requests.lock().expect("requests lock").push(request);
+        if self.fail {
+            return Err(EmbeddingRegenerationTriggerError::Failed(
+                "simulated enqueue failure".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 struct VoiceNoteSeed<'a> {
     owner: &'a str,
     id: &'a str,
@@ -898,6 +1310,15 @@ struct TagSeed<'a> {
 
 impl VoiceNoteFixture {
     async fn new() -> Self {
+        Self::new_with_trigger(Arc::new(
+            oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
+        ))
+        .await
+    }
+
+    async fn new_with_trigger(
+        embedding_regeneration_trigger: Arc<dyn EmbeddingRegenerationTrigger>,
+    ) -> Self {
         let tempdir = TempDir::new().expect("tempdir");
         let accepted_audio_dir = tempdir.path().join("accepted-audio");
         std::fs::create_dir(&accepted_audio_dir).expect("create accepted audio dir");
@@ -922,6 +1343,7 @@ impl VoiceNoteFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
+            embedding_regeneration_trigger,
         });
 
         Self {
@@ -954,6 +1376,45 @@ impl VoiceNoteFixture {
         json_body(response).await
     }
 
+    async fn json_request(
+        &self,
+        method: &str,
+        path: &str,
+        bearer: &str,
+        body: Option<Value>,
+    ) -> JsonResponse {
+        let response = self
+            .request(method, path, bearer, body.map(|value| value.to_string()))
+            .await;
+        let status = response.status();
+        let body = json_body(response).await;
+        JsonResponse { status, body }
+    }
+
+    async fn request(
+        &self,
+        method: &str,
+        path: &str,
+        bearer: &str,
+        body: Option<String>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(path)
+            .header("Authorization", format!("Bearer {bearer}"));
+        let body = match body {
+            Some(body) => {
+                builder = builder.header("Content-Type", "application/json");
+                Body::from(body)
+            }
+            None => Body::empty(),
+        };
+        self.app()
+            .oneshot(builder.body(body).unwrap())
+            .await
+            .expect("response")
+    }
+
     async fn insert_session(&self, owner: &str, session_id: &str) {
         sqlx::query(
             r#"
@@ -966,6 +1427,23 @@ impl VoiceNoteFixture {
         .execute(self.storage.pool())
         .await
         .expect("insert session");
+    }
+
+    async fn insert_tag(&self, owner: &str, id: &str, name: &str, created_at: &str) {
+        sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO tags (id, api_key_id, name, name_folded, created_at)
+            VALUES (?, ?, ?, lower(?), ?)
+            "#,
+        )
+        .bind(id)
+        .bind(owner)
+        .bind(name)
+        .bind(name)
+        .bind(created_at)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert tag");
     }
 
     async fn insert_voice_note(&self, seed: VoiceNoteSeed<'_>) {
@@ -1094,6 +1572,45 @@ impl VoiceNoteFixture {
         .execute(self.storage.pool())
         .await
         .expect("insert segment");
+    }
+
+    async fn insert_embedding(&self, owner: &str, voice_note_id: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+            VALUES (?, ?, 'embedding-v1', x'010203', '2026-04-24T18:02:00.000000000Z')
+            "#,
+        )
+        .bind(voice_note_id)
+        .bind(owner)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert embedding");
+    }
+
+    async fn insert_succeeded_job(&self, owner: &str, job_id: &str, voice_note_id: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO transcription_jobs (
+                id, api_key_id, idempotency_key, audio_sha256_hex,
+                audio_content_hash_algorithm, recorded_at, accepted_audio_path,
+                status, created_at, updated_at, retry_count, max_retries, voice_note_id
+            )
+            VALUES (
+                ?, ?, ?, 'hash', 'sha256:chunk-sha256-v1',
+                '2026-04-24T17:59:00.000000000Z', '/tmp/audio',
+                'succeeded', '2026-04-24T18:00:00.000000000Z',
+                '2026-04-24T18:00:00.000000000Z', 0, 3, ?
+            )
+            "#,
+        )
+        .bind(job_id)
+        .bind(owner)
+        .bind(format!("{job_id}-attempt"))
+        .bind(voice_note_id)
+        .execute(self.storage.pool())
+        .await
+        .expect("insert succeeded job");
     }
 
     async fn insert_job(&self, owner: &str, job_id: &str) {


### PR DESCRIPTION
## Summary

- Implements the mutable voice-note API surface for text replacement, full tag-set replacement, and hard deletion.
- Adds a real internal embedding-regeneration trigger handoff for edit initiation while leaving generation itself to #27.
- Preserves accepted-submission replay records when voice notes are deleted.

## Changes

- Adds `PATCH /api/v1/voice-notes/{voice_note_id}`, `PUT /api/v1/voice-notes/{voice_note_id}/tags`, and `DELETE /api/v1/voice-notes/{voice_note_id}`.
- Adds transactional voice-note text replacement that appends one new version and leaves segments stable.
- Reuses storage tag-replacement and delete cascade semantics through HTTP with contract-shaped error responses.
- Adds the no-op embedding-regeneration trigger seam and integration tests with a recording trigger fake.
- Updates the Unreleased changelog for the user-visible API additions.

## GitHub Issue(s)

Closes #20

## Test plan

- `cargo test`
- `cargo fmt -- --check`
- `git diff --check`
