### PR TITLE
feat(embeddings): implement generation backbone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Add OpenAI-backed voice-note embedding generation, long-text chunk pooling,
   durable edit-triggered embedding regeneration, and the
-  `succeeded`-requires-current-embedding workflow gate.
+  `succeeded`-requires-current-embedding workflow gate. Blank voice-note text
+  updates are rejected so every current embedding has non-empty source text.
 - Add authenticated voice-note mutation APIs for text replacement with
   version history, full tag-set replacement, hard deletion with cascades, and
   edit-triggered embedding-regeneration initiation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add OpenAI-backed voice-note embedding generation, long-text chunk pooling,
+  durable edit-triggered embedding regeneration, and the
+  `succeeded`-requires-current-embedding workflow gate.
 - Add authenticated voice-note mutation APIs for text replacement with
   version history, full tag-set replacement, hard deletion with cascades, and
   edit-triggered embedding-regeneration initiation.
@@ -25,9 +28,7 @@
 - Add the backend transcription-job processing worker, including leased job
   claiming, OpenAI transcription requests, FFmpeg-backed audio slicing,
   coarse segment materialization, backend-owned retries, and terminal failure
-  classification. Until #27 lands, this implementation can reach `succeeded`
-  after voice-note/version/segment materialization without a current embedding;
-  that remains a v0.1.0 release-blocker deviation.
+  classification.
 - Add authenticated tag and session management APIs, including owner-scoped
   CRUD, shared cursor pagination, case-insensitive tag identity with
   latest-spelling display updates, and metadata deletion cascades.

--- a/backend/migrations/20260504000000_embedding_regeneration_jobs.sql
+++ b/backend/migrations/20260504000000_embedding_regeneration_jobs.sql
@@ -1,0 +1,33 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE embedding_regeneration_jobs (
+    voice_note_id TEXT PRIMARY KEY,
+    api_key_id TEXT NOT NULL,
+    voice_note_version_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('queued', 'processing', 'retry_waiting', 'failed')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    max_retries INTEGER NOT NULL CHECK (max_retries >= 0),
+    next_attempt_at TEXT,
+    failure_code TEXT CHECK (
+        failure_code IS NULL OR failure_code IN (
+            'engine_timeout',
+            'engine_rate_limited',
+            'engine_error',
+            'storage_error',
+            'internal_error'
+        )
+    ),
+    failure_message TEXT,
+    processing_lease_token TEXT,
+    processing_lease_expires_at TEXT,
+    FOREIGN KEY (api_key_id, voice_note_id) REFERENCES voice_notes(api_key_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (voice_note_version_id) REFERENCES voice_note_versions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX embedding_regeneration_jobs_ready_idx
+    ON embedding_regeneration_jobs (status, next_attempt_at, created_at, voice_note_id);
+
+CREATE INDEX embedding_regeneration_jobs_processing_lease_idx
+    ON embedding_regeneration_jobs (status, processing_lease_expires_at, next_attempt_at, created_at, voice_note_id);

--- a/backend/migrations/20260504000000_embedding_regeneration_jobs.sql
+++ b/backend/migrations/20260504000000_embedding_regeneration_jobs.sql
@@ -31,3 +31,39 @@ CREATE INDEX embedding_regeneration_jobs_ready_idx
 
 CREATE INDEX embedding_regeneration_jobs_processing_lease_idx
     ON embedding_regeneration_jobs (status, processing_lease_expires_at, next_attempt_at, created_at, voice_note_id);
+
+INSERT INTO embedding_regeneration_jobs (
+    voice_note_id, api_key_id, voice_note_version_id, status, created_at,
+    updated_at, retry_count, max_retries, next_attempt_at, failure_code,
+    failure_message, processing_lease_token, processing_lease_expires_at
+)
+SELECT
+    voice_notes.id,
+    voice_notes.api_key_id,
+    current_versions.id,
+    'queued',
+    current_versions.created_at,
+    current_versions.created_at,
+    0,
+    3,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+FROM voice_notes
+JOIN voice_note_versions AS current_versions
+    ON current_versions.api_key_id = voice_notes.api_key_id
+    AND current_versions.voice_note_id = voice_notes.id
+WHERE current_versions.version_number = (
+        SELECT MAX(version_number)
+        FROM voice_note_versions
+        WHERE voice_note_id = voice_notes.id
+    )
+    AND TRIM(current_versions.text) <> ''
+    AND NOT EXISTS (
+        SELECT 1
+        FROM embeddings
+        WHERE embeddings.api_key_id = voice_notes.api_key_id
+            AND embeddings.voice_note_id = voice_notes.id
+    );

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -9,7 +9,6 @@ use tracing::info;
 
 use crate::auth::AuthStore;
 use crate::config::Settings;
-use crate::embedding_regeneration::NoopEmbeddingRegenerationTrigger;
 use crate::metrics::Metrics;
 use crate::state::AppState;
 use crate::storage::{Storage, StorageError};
@@ -114,7 +113,6 @@ async fn load_runtime_from_path_with_openai_key(
         operator_listen_addr: settings.operator_listen_addr,
         openai_api_key,
         storage,
-        embedding_regeneration_trigger: Arc::new(NoopEmbeddingRegenerationTrigger),
     };
 
     Ok((settings.listen_addr, state))

--- a/backend/src/embedding.rs
+++ b/backend/src/embedding.rs
@@ -1,0 +1,241 @@
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const DEFAULT_OPENAI_EMBEDDING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const OPENAI_EMBEDDING_MODEL: &str = "text-embedding-3-small";
+const OPENAI_EMBEDDING_DIMENSIONS: usize = 1536;
+const MAX_CHUNK_BYTES: usize = 6_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingInput {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbeddingOutput {
+    pub model: String,
+    pub vector: Vec<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum EmbeddingFailure {
+    #[error("transient embedding failure: {message}")]
+    Transient {
+        failure_code: String,
+        message: String,
+        retry_after_seconds: Option<i64>,
+    },
+    #[error("terminal embedding failure: {failure_code}: {message}")]
+    Terminal {
+        failure_code: String,
+        message: String,
+    },
+}
+
+#[allow(async_fn_in_trait)]
+pub trait EmbeddingEngine {
+    async fn embed(&self, input: EmbeddingInput) -> Result<EmbeddingOutput, EmbeddingFailure>;
+}
+
+#[derive(Clone)]
+pub struct OpenAiEmbeddingEngine {
+    base_url: String,
+    api_key: String,
+    client: reqwest::Client,
+    request_timeout: std::time::Duration,
+}
+
+impl OpenAiEmbeddingEngine {
+    pub fn new(base_url: String, api_key: String) -> Self {
+        Self::with_request_timeout(base_url, api_key, DEFAULT_OPENAI_EMBEDDING_TIMEOUT)
+    }
+
+    pub fn with_request_timeout(
+        base_url: String,
+        api_key: String,
+        request_timeout: std::time::Duration,
+    ) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_owned(),
+            api_key,
+            client: reqwest::Client::new(),
+            request_timeout,
+        }
+    }
+}
+
+impl EmbeddingEngine for OpenAiEmbeddingEngine {
+    async fn embed(&self, input: EmbeddingInput) -> Result<EmbeddingOutput, EmbeddingFailure> {
+        if input.text.trim().is_empty() {
+            return Err(EmbeddingFailure::Terminal {
+                failure_code: "audio_invalid".to_owned(),
+                message: "canonical voice-note text is empty".to_owned(),
+            });
+        }
+
+        let chunks = text_chunks(&input.text);
+        let response = self
+            .client
+            .post(format!("{}/v1/embeddings", self.base_url))
+            .bearer_auth(&self.api_key)
+            .json(&OpenAiEmbeddingRequest {
+                model: OPENAI_EMBEDDING_MODEL,
+                input: &chunks,
+            })
+            .timeout(self.request_timeout)
+            .send()
+            .await
+            .map_err(|error| {
+                let failure_code = if error.is_timeout() {
+                    "engine_timeout"
+                } else {
+                    "engine_error"
+                };
+                EmbeddingFailure::Transient {
+                    failure_code: failure_code.to_owned(),
+                    message: error.to_string(),
+                    retry_after_seconds: None,
+                }
+            })?;
+
+        if !response.status().is_success() {
+            return Err(classify_openai_embedding_error(response).await);
+        }
+
+        let body = response
+            .json::<OpenAiEmbeddingResponse>()
+            .await
+            .map_err(|error| EmbeddingFailure::Transient {
+                failure_code: "engine_error".to_owned(),
+                message: format!("OpenAI embedding response was invalid: {error}"),
+                retry_after_seconds: None,
+            })?;
+        if body.data.len() != chunks.len() {
+            return Err(EmbeddingFailure::Terminal {
+                failure_code: "engine_error".to_owned(),
+                message: "OpenAI embedding response returned the wrong number of vectors"
+                    .to_owned(),
+            });
+        }
+
+        let mut vectors = vec![Vec::new(); chunks.len()];
+        for item in body.data {
+            if item.embedding.len() != OPENAI_EMBEDDING_DIMENSIONS {
+                return Err(EmbeddingFailure::Terminal {
+                    failure_code: "engine_error".to_owned(),
+                    message: "OpenAI embedding response returned an unexpected vector dimension"
+                        .to_owned(),
+                });
+            }
+            if item.index >= vectors.len() {
+                return Err(EmbeddingFailure::Terminal {
+                    failure_code: "engine_error".to_owned(),
+                    message: "OpenAI embedding response returned an out-of-range vector index"
+                        .to_owned(),
+                });
+            }
+            vectors[item.index] = item.embedding;
+        }
+        if vectors.iter().any(Vec::is_empty) {
+            return Err(EmbeddingFailure::Terminal {
+                failure_code: "engine_error".to_owned(),
+                message: "OpenAI embedding response omitted a vector".to_owned(),
+            });
+        }
+
+        Ok(EmbeddingOutput {
+            model: body.model,
+            vector: pooled_normalized_vector(&vectors),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiEmbeddingRequest<'a> {
+    model: &'a str,
+    input: &'a [String],
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingResponse {
+    model: String,
+    data: Vec<OpenAiEmbeddingData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingData {
+    index: usize,
+    embedding: Vec<f32>,
+}
+
+async fn classify_openai_embedding_error(response: reqwest::Response) -> EmbeddingFailure {
+    let status = response.status();
+    let retry_after_seconds = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<i64>().ok());
+    let message = response
+        .text()
+        .await
+        .unwrap_or_else(|_| format!("OpenAI embedding request failed with {status}"));
+
+    match status {
+        StatusCode::REQUEST_TIMEOUT => EmbeddingFailure::Transient {
+            failure_code: "engine_timeout".to_owned(),
+            message,
+            retry_after_seconds,
+        },
+        StatusCode::TOO_MANY_REQUESTS => EmbeddingFailure::Transient {
+            failure_code: "engine_rate_limited".to_owned(),
+            message,
+            retry_after_seconds,
+        },
+        status if status.is_server_error() => EmbeddingFailure::Transient {
+            failure_code: "engine_error".to_owned(),
+            message,
+            retry_after_seconds,
+        },
+        _ => EmbeddingFailure::Terminal {
+            failure_code: "engine_error".to_owned(),
+            message,
+        },
+    }
+}
+
+fn text_chunks(text: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if !current.is_empty() && current.len() + ch.len_utf8() > MAX_CHUNK_BYTES {
+            chunks.push(current);
+            current = String::new();
+        }
+        current.push(ch);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+fn pooled_normalized_vector(vectors: &[Vec<f32>]) -> Vec<f32> {
+    let mut pooled = vec![0.0; OPENAI_EMBEDDING_DIMENSIONS];
+    for vector in vectors {
+        for (index, value) in vector.iter().enumerate() {
+            pooled[index] += *value;
+        }
+    }
+    let count = vectors.len() as f32;
+    for value in &mut pooled {
+        *value /= count;
+    }
+    let magnitude = pooled.iter().map(|value| value * value).sum::<f32>().sqrt();
+    if magnitude > 0.0 {
+        for value in &mut pooled {
+            *value /= magnitude;
+        }
+    }
+    pooled
+}

--- a/backend/src/embedding_regeneration.rs
+++ b/backend/src/embedding_regeneration.rs
@@ -1,32 +1,183 @@
 use thiserror::Error;
+use time::{Duration, OffsetDateTime};
+use ulid::Ulid;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EmbeddingRegenerationRequest {
-    pub api_key_id: String,
-    pub voice_note_id: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum EmbeddingRegenerationTriggerError {
-    #[error("{0}")]
-    Failed(String),
-}
-
-pub trait EmbeddingRegenerationTrigger: Send + Sync {
-    fn initiate(
-        &self,
-        request: EmbeddingRegenerationRequest,
-    ) -> Result<(), EmbeddingRegenerationTriggerError>;
-}
+use crate::embedding::{EmbeddingEngine, EmbeddingFailure, EmbeddingInput};
+use crate::storage::{
+    EmbeddingRegenerationFailure, EmbeddingRegenerationRetryOutcome, NewEmbedding, Storage,
+    StorageError, encode_embedding_vector,
+};
 
 #[derive(Debug, Clone)]
-pub struct NoopEmbeddingRegenerationTrigger;
+pub struct EmbeddingRegenerationConfig {
+    pub lease_duration: Duration,
+    pub idle_sleep: std::time::Duration,
+    pub error_sleep: std::time::Duration,
+}
 
-impl EmbeddingRegenerationTrigger for NoopEmbeddingRegenerationTrigger {
-    fn initiate(
-        &self,
-        _request: EmbeddingRegenerationRequest,
-    ) -> Result<(), EmbeddingRegenerationTriggerError> {
-        Ok(())
+impl EmbeddingRegenerationConfig {
+    pub fn test() -> Self {
+        Self {
+            lease_duration: Duration::minutes(5),
+            idle_sleep: std::time::Duration::from_millis(10),
+            error_sleep: std::time::Duration::from_millis(10),
+        }
+    }
+}
+
+impl Default for EmbeddingRegenerationConfig {
+    fn default() -> Self {
+        Self {
+            lease_duration: Duration::minutes(5),
+            idle_sleep: std::time::Duration::from_secs(5),
+            error_sleep: std::time::Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbeddingRegenerationOutcome {
+    NoJob,
+    Replaced { voice_note_id: String },
+    Stale { voice_note_id: String },
+    RetryWaiting { voice_note_id: String },
+    Failed { voice_note_id: String },
+}
+
+#[derive(Debug, Error)]
+pub enum EmbeddingRegenerationWorkerError {
+    #[error("{0}")]
+    Storage(#[from] StorageError),
+}
+
+pub async fn process_one_embedding_regeneration_job<E>(
+    storage: &Storage,
+    engine: &E,
+    config: EmbeddingRegenerationConfig,
+) -> Result<EmbeddingRegenerationOutcome, EmbeddingRegenerationWorkerError>
+where
+    E: EmbeddingEngine,
+{
+    let now = OffsetDateTime::now_utc();
+    let lease_token = Ulid::new().to_string();
+    let Some(job) = storage
+        .claim_next_embedding_regeneration_job(&lease_token, now, now + config.lease_duration)
+        .await?
+    else {
+        return Ok(EmbeddingRegenerationOutcome::NoJob);
+    };
+
+    if job.text.trim().is_empty() {
+        storage
+            .fail_embedding_regeneration_job(EmbeddingRegenerationFailure {
+                api_key_id: job.api_key_id,
+                voice_note_id: job.voice_note_id.clone(),
+                lease_token,
+                failure_code: "engine_error".to_owned(),
+                failure_message: "canonical voice-note text is empty".to_owned(),
+                now: OffsetDateTime::now_utc(),
+            })
+            .await?;
+        return Ok(EmbeddingRegenerationOutcome::Failed {
+            voice_note_id: job.voice_note_id,
+        });
+    }
+
+    let embedding = match engine.embed(EmbeddingInput { text: job.text }).await {
+        Ok(embedding) => embedding,
+        Err(EmbeddingFailure::Transient {
+            failure_code,
+            message,
+            retry_after_seconds,
+        }) => {
+            let now = OffsetDateTime::now_utc();
+            let next_attempt_at = now + Duration::seconds(retry_after_seconds.unwrap_or(60).max(1));
+            let outcome = storage
+                .record_transient_embedding_regeneration_failure(
+                    EmbeddingRegenerationFailure {
+                        api_key_id: job.api_key_id,
+                        voice_note_id: job.voice_note_id.clone(),
+                        lease_token,
+                        failure_code,
+                        failure_message: message,
+                        now,
+                    },
+                    next_attempt_at,
+                )
+                .await?;
+            return Ok(match outcome {
+                EmbeddingRegenerationRetryOutcome::RetryWaiting => {
+                    EmbeddingRegenerationOutcome::RetryWaiting {
+                        voice_note_id: job.voice_note_id,
+                    }
+                }
+                EmbeddingRegenerationRetryOutcome::Failed => EmbeddingRegenerationOutcome::Failed {
+                    voice_note_id: job.voice_note_id,
+                },
+            });
+        }
+        Err(EmbeddingFailure::Terminal {
+            failure_code,
+            message,
+        }) => {
+            storage
+                .fail_embedding_regeneration_job(EmbeddingRegenerationFailure {
+                    api_key_id: job.api_key_id,
+                    voice_note_id: job.voice_note_id.clone(),
+                    lease_token,
+                    failure_code,
+                    failure_message: message,
+                    now: OffsetDateTime::now_utc(),
+                })
+                .await?;
+            return Ok(EmbeddingRegenerationOutcome::Failed {
+                voice_note_id: job.voice_note_id,
+            });
+        }
+    };
+
+    let replaced = storage
+        .complete_embedding_regeneration_job_if_current(
+            &job.api_key_id,
+            &job.voice_note_id,
+            &job.voice_note_version_id,
+            &lease_token,
+            NewEmbedding {
+                model: embedding.model,
+                vector: encode_embedding_vector(&embedding.vector),
+                created_at: OffsetDateTime::now_utc(),
+            },
+        )
+        .await?;
+
+    Ok(if replaced {
+        EmbeddingRegenerationOutcome::Replaced {
+            voice_note_id: job.voice_note_id,
+        }
+    } else {
+        EmbeddingRegenerationOutcome::Stale {
+            voice_note_id: job.voice_note_id,
+        }
+    })
+}
+
+pub async fn run_embedding_regeneration_loop<E>(
+    storage: Storage,
+    engine: E,
+    config: EmbeddingRegenerationConfig,
+) where
+    E: EmbeddingEngine + Sync,
+{
+    loop {
+        match process_one_embedding_regeneration_job(&storage, &engine, config.clone()).await {
+            Ok(EmbeddingRegenerationOutcome::NoJob) => {
+                tokio::time::sleep(config.idle_sleep).await;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::error!("embedding regeneration worker iteration failed: {error}");
+                tokio::time::sleep(config.error_sleep).await;
+            }
+        }
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod bootstrap;
 pub mod collections;
 pub mod config;
+pub mod embedding;
 pub mod embedding_regeneration;
 pub mod errors;
 pub mod json;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,6 +2,10 @@ use std::net::SocketAddr;
 
 use oracy_backend::abandonment_sweeper::{AbandonmentSweeperConfig, run_abandonment_sweeper_loop};
 use oracy_backend::bootstrap::load_runtime_from_env;
+use oracy_backend::embedding::OpenAiEmbeddingEngine;
+use oracy_backend::embedding_regeneration::{
+    EmbeddingRegenerationConfig, run_embedding_regeneration_loop,
+};
 use oracy_backend::retention_cleanup::{RetentionCleanupConfig, run_retention_cleanup_loop};
 use oracy_backend::router::{build_operator_router, build_router};
 use oracy_backend::transcription_worker::{
@@ -29,6 +33,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         state.openai_api_key.clone(),
         FfmpegAudioSlicer::openai_limit(),
     );
+    let embedding_engine = OpenAiEmbeddingEngine::new(
+        "https://api.openai.com".to_owned(),
+        state.openai_api_key.clone(),
+    );
+    let regeneration_embedding_engine = OpenAiEmbeddingEngine::new(
+        "https://api.openai.com".to_owned(),
+        state.openai_api_key.clone(),
+    );
     tokio::spawn(run_retention_cleanup_loop(
         state.storage.clone(),
         state.accepted_audio_dir.clone(),
@@ -40,10 +52,16 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         state.metrics.clone(),
         AbandonmentSweeperConfig::default(),
     ));
+    tokio::spawn(run_embedding_regeneration_loop(
+        state.storage.clone(),
+        regeneration_embedding_engine,
+        EmbeddingRegenerationConfig::default(),
+    ));
     tokio::spawn(run_worker_loop(
         worker_storage,
         state.accepted_audio_dir.clone(),
         worker_engine,
+        embedding_engine,
         FfprobeDurationProbe,
         WorkerConfig::default(),
         state.metrics.clone(),

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -6,7 +6,6 @@ use std::{fmt, fmt::Debug};
 use axum::extract::FromRef;
 
 use crate::auth::AuthStore;
-use crate::embedding_regeneration::EmbeddingRegenerationTrigger;
 use crate::metrics::Metrics;
 use crate::storage::Storage;
 
@@ -18,7 +17,6 @@ pub struct AppState {
     pub operator_listen_addr: SocketAddr,
     pub openai_api_key: String,
     pub storage: Storage,
-    pub embedding_regeneration_trigger: Arc<dyn EmbeddingRegenerationTrigger>,
 }
 
 impl Debug for AppState {
@@ -31,7 +29,6 @@ impl Debug for AppState {
             .field("operator_listen_addr", &self.operator_listen_addr)
             .field("openai_api_key", &"<redacted>")
             .field("storage", &self.storage)
-            .field("embedding_regeneration_trigger", &"<trigger>")
             .finish()
     }
 }

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -2189,6 +2189,28 @@ impl Storage {
         embedding: NewEmbedding,
     ) -> Result<bool, StorageError> {
         let mut tx = self.begin_immediate_tx().await?;
+        let active_version_id: Option<String> = sqlx::query_scalar(
+            r#"
+            SELECT voice_note_version_id
+            FROM embedding_regeneration_jobs
+            WHERE api_key_id = ?
+                AND voice_note_id = ?
+                AND voice_note_version_id = ?
+                AND status = 'processing'
+                AND processing_lease_token = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(voice_note_id)
+        .bind(voice_note_version_id)
+        .bind(lease_token)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if active_version_id.is_none() {
+            tx.commit().await?;
+            return Ok(false);
+        }
+
         let Some(current_version_id): Option<String> = sqlx::query_scalar(
             r#"
             SELECT voice_note_versions.id
@@ -2209,30 +2231,65 @@ impl Storage {
         .fetch_optional(&mut *tx)
         .await?
         else {
+            sqlx::query(
+                r#"
+                DELETE FROM embedding_regeneration_jobs
+                WHERE api_key_id = ?
+                    AND voice_note_id = ?
+                    AND voice_note_version_id = ?
+                    AND status = 'processing'
+                    AND processing_lease_token = ?
+                "#,
+            )
+            .bind(api_key_id)
+            .bind(voice_note_id)
+            .bind(voice_note_version_id)
+            .bind(lease_token)
+            .execute(&mut *tx)
+            .await?;
             tx.commit().await?;
             return Ok(false);
         };
 
-        if current_version_id == voice_note_version_id {
+        if current_version_id != voice_note_version_id {
             sqlx::query(
                 r#"
-                INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(voice_note_id) DO UPDATE SET
-                    model = excluded.model,
-                    vector = excluded.vector,
-                    created_at = excluded.created_at
-                WHERE embeddings.api_key_id = excluded.api_key_id
+                DELETE FROM embedding_regeneration_jobs
+                WHERE api_key_id = ?
+                    AND voice_note_id = ?
+                    AND voice_note_version_id = ?
+                    AND status = 'processing'
+                    AND processing_lease_token = ?
                 "#,
             )
-            .bind(voice_note_id)
             .bind(api_key_id)
-            .bind(&embedding.model)
-            .bind(&embedding.vector)
-            .bind(format_timestamp(embedding.created_at)?)
+            .bind(voice_note_id)
+            .bind(voice_note_version_id)
+            .bind(lease_token)
             .execute(&mut *tx)
             .await?;
+            tx.commit().await?;
+            return Ok(false);
         }
+
+        sqlx::query(
+            r#"
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(voice_note_id) DO UPDATE SET
+                model = excluded.model,
+                vector = excluded.vector,
+                created_at = excluded.created_at
+            WHERE embeddings.api_key_id = excluded.api_key_id
+            "#,
+        )
+        .bind(voice_note_id)
+        .bind(api_key_id)
+        .bind(&embedding.model)
+        .bind(&embedding.vector)
+        .bind(format_timestamp(embedding.created_at)?)
+        .execute(&mut *tx)
+        .await?;
 
         sqlx::query(
             r#"
@@ -2252,7 +2309,7 @@ impl Storage {
         .await?;
         tx.commit().await?;
 
-        Ok(current_version_id == voice_note_version_id)
+        Ok(true)
     }
 
     pub async fn record_transient_embedding_regeneration_failure(

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -16,6 +16,7 @@ use crate::audio_hash::AUDIO_CONTENT_HASH_ALGORITHM_ID;
 use crate::settings::DEFAULT_TRANSCRIPTION_MODEL;
 
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
+const EMBEDDING_REGENERATION_MAX_RETRIES: i64 = 3;
 
 #[derive(Clone, Debug)]
 pub struct Storage {
@@ -374,6 +375,52 @@ pub struct EmbeddingRecord {
     pub model: String,
     pub vector: Vec<u8>,
     pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingRegenerationJobRecord {
+    pub api_key_id: String,
+    pub voice_note_id: String,
+    pub voice_note_version_id: String,
+    pub text: String,
+    pub retry_count: i64,
+    pub max_retries: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingRegenerationFailure {
+    pub api_key_id: String,
+    pub voice_note_id: String,
+    pub lease_token: String,
+    pub failure_code: String,
+    pub failure_message: String,
+    pub now: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbeddingRegenerationRetryOutcome {
+    RetryWaiting,
+    Failed,
+}
+
+pub fn encode_embedding_vector(vector: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(vector.len() * std::mem::size_of::<f32>());
+    for value in vector {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+    bytes
+}
+
+pub fn decode_embedding_vector(bytes: &[u8]) -> Option<Vec<f32>> {
+    if !bytes.len().is_multiple_of(std::mem::size_of::<f32>()) {
+        return None;
+    }
+    Some(
+        bytes
+            .chunks_exact(std::mem::size_of::<f32>())
+            .map(|chunk| f32::from_le_bytes(chunk.try_into().expect("chunk has four bytes")))
+            .collect(),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1049,6 +1096,12 @@ impl Storage {
         let mut tx = self.pool.begin().await?;
         let voice_note = materialization.voice_note;
         let version = materialization.initial_version;
+        let embedding =
+            materialization
+                .embedding
+                .ok_or_else(|| StorageError::JobNotCompletable {
+                    job_id: job_id.to_owned(),
+                })?;
         let now = format_timestamp(voice_note.created_at)?;
 
         let Some(job) = select_job_by_id(&mut tx, api_key_id, job_id).await? else {
@@ -1145,21 +1198,19 @@ impl Storage {
             .await?;
         }
 
-        if let Some(embedding) = materialization.embedding {
-            sqlx::query(
-                r#"
-                INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
-                VALUES (?, ?, ?, ?, ?)
-                "#,
-            )
-            .bind(&voice_note.id)
-            .bind(api_key_id)
-            .bind(&embedding.model)
-            .bind(&embedding.vector)
-            .bind(format_timestamp(embedding.created_at)?)
-            .execute(&mut *tx)
-            .await?;
-        }
+        sqlx::query(
+            r#"
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&voice_note.id)
+        .bind(api_key_id)
+        .bind(&embedding.model)
+        .bind(&embedding.vector)
+        .bind(format_timestamp(embedding.created_at)?)
+        .execute(&mut *tx)
+        .await?;
 
         let result = sqlx::query(
             r#"
@@ -1622,6 +1673,7 @@ impl Storage {
         .bind(voice_note_id)
         .fetch_one(&mut *tx)
         .await?;
+        let version_id = new_id();
         sqlx::query(
             r#"
             INSERT INTO voice_note_versions (
@@ -1630,12 +1682,44 @@ impl Storage {
             VALUES (?, ?, ?, ?, ?, ?)
             "#,
         )
-        .bind(new_id())
+        .bind(&version_id)
         .bind(api_key_id)
         .bind(voice_note_id)
         .bind(version_number)
         .bind(text)
         .bind(format_timestamp(created_at)?)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO embedding_regeneration_jobs (
+                voice_note_id, api_key_id, voice_note_version_id, status,
+                created_at, updated_at, retry_count, max_retries, next_attempt_at,
+                failure_code, failure_message, processing_lease_token,
+                processing_lease_expires_at
+            )
+            VALUES (?, ?, ?, 'queued', ?, ?, 0, ?, NULL, NULL, NULL, NULL, NULL)
+            ON CONFLICT(voice_note_id) DO UPDATE SET
+                api_key_id = excluded.api_key_id,
+                voice_note_version_id = excluded.voice_note_version_id,
+                status = 'queued',
+                updated_at = excluded.updated_at,
+                retry_count = 0,
+                max_retries = excluded.max_retries,
+                next_attempt_at = NULL,
+                failure_code = NULL,
+                failure_message = NULL,
+                processing_lease_token = NULL,
+                processing_lease_expires_at = NULL
+            WHERE embedding_regeneration_jobs.api_key_id = excluded.api_key_id
+            "#,
+        )
+        .bind(voice_note_id)
+        .bind(api_key_id)
+        .bind(&version_id)
+        .bind(format_timestamp(created_at)?)
+        .bind(format_timestamp(created_at)?)
+        .bind(EMBEDDING_REGENERATION_MAX_RETRIES)
         .execute(&mut *tx)
         .await?;
 
@@ -2019,6 +2103,278 @@ impl Storage {
         .await?;
 
         row.map(embedding_from_row).transpose()
+    }
+
+    pub async fn claim_next_embedding_regeneration_job(
+        &self,
+        lease_token: &str,
+        now: OffsetDateTime,
+        lease_expires_at: OffsetDateTime,
+    ) -> Result<Option<EmbeddingRegenerationJobRecord>, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let now_text = format_timestamp(now)?;
+        let lease_expires_at_text = format_timestamp(lease_expires_at)?;
+        let row = sqlx::query(
+            r#"
+            SELECT
+                embedding_regeneration_jobs.api_key_id,
+                embedding_regeneration_jobs.voice_note_id,
+                embedding_regeneration_jobs.voice_note_version_id,
+                voice_note_versions.text,
+                embedding_regeneration_jobs.retry_count,
+                embedding_regeneration_jobs.max_retries
+            FROM embedding_regeneration_jobs
+            JOIN voice_note_versions
+                ON voice_note_versions.id = embedding_regeneration_jobs.voice_note_version_id
+            WHERE embedding_regeneration_jobs.status = 'queued'
+                OR (
+                    embedding_regeneration_jobs.status = 'retry_waiting'
+                    AND embedding_regeneration_jobs.next_attempt_at <= ?
+                )
+                OR (
+                    embedding_regeneration_jobs.status = 'processing'
+                    AND embedding_regeneration_jobs.processing_lease_expires_at <= ?
+                )
+            ORDER BY embedding_regeneration_jobs.created_at ASC,
+                embedding_regeneration_jobs.voice_note_id ASC
+            LIMIT 1
+            "#,
+        )
+        .bind(&now_text)
+        .bind(&now_text)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(row) = row else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+        let job = EmbeddingRegenerationJobRecord {
+            api_key_id: row.try_get("api_key_id")?,
+            voice_note_id: row.try_get("voice_note_id")?,
+            voice_note_version_id: row.try_get("voice_note_version_id")?,
+            text: row.try_get("text")?,
+            retry_count: row.try_get("retry_count")?,
+            max_retries: row.try_get("max_retries")?,
+        };
+
+        sqlx::query(
+            r#"
+            UPDATE embedding_regeneration_jobs
+            SET status = 'processing',
+                processing_lease_token = ?,
+                processing_lease_expires_at = ?,
+                next_attempt_at = NULL,
+                updated_at = ?
+            WHERE api_key_id = ? AND voice_note_id = ?
+            "#,
+        )
+        .bind(lease_token)
+        .bind(&lease_expires_at_text)
+        .bind(&now_text)
+        .bind(&job.api_key_id)
+        .bind(&job.voice_note_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+
+        Ok(Some(job))
+    }
+
+    pub async fn complete_embedding_regeneration_job_if_current(
+        &self,
+        api_key_id: &str,
+        voice_note_id: &str,
+        voice_note_version_id: &str,
+        lease_token: &str,
+        embedding: NewEmbedding,
+    ) -> Result<bool, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let Some(current_version_id): Option<String> = sqlx::query_scalar(
+            r#"
+            SELECT voice_note_versions.id
+            FROM voice_notes
+            JOIN voice_note_versions
+                ON voice_note_versions.voice_note_id = voice_notes.id
+            WHERE voice_notes.api_key_id = ?
+                AND voice_notes.id = ?
+                AND voice_note_versions.version_number = (
+                    SELECT MAX(version_number)
+                    FROM voice_note_versions
+                    WHERE voice_note_id = voice_notes.id
+                )
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(voice_note_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        else {
+            tx.commit().await?;
+            return Ok(false);
+        };
+
+        if current_version_id == voice_note_version_id {
+            sqlx::query(
+                r#"
+                INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(voice_note_id) DO UPDATE SET
+                    model = excluded.model,
+                    vector = excluded.vector,
+                    created_at = excluded.created_at
+                WHERE embeddings.api_key_id = excluded.api_key_id
+                "#,
+            )
+            .bind(voice_note_id)
+            .bind(api_key_id)
+            .bind(&embedding.model)
+            .bind(&embedding.vector)
+            .bind(format_timestamp(embedding.created_at)?)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        sqlx::query(
+            r#"
+            DELETE FROM embedding_regeneration_jobs
+            WHERE api_key_id = ?
+                AND voice_note_id = ?
+                AND voice_note_version_id = ?
+                AND status = 'processing'
+                AND processing_lease_token = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .bind(voice_note_id)
+        .bind(voice_note_version_id)
+        .bind(lease_token)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+
+        Ok(current_version_id == voice_note_version_id)
+    }
+
+    pub async fn record_transient_embedding_regeneration_failure(
+        &self,
+        failure: EmbeddingRegenerationFailure,
+        next_attempt_at: OffsetDateTime,
+    ) -> Result<EmbeddingRegenerationRetryOutcome, StorageError> {
+        let mut tx = self.begin_immediate_tx().await?;
+        let retry_count: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT retry_count + 1
+            FROM embedding_regeneration_jobs
+            WHERE api_key_id = ?
+                AND voice_note_id = ?
+                AND status = 'processing'
+                AND processing_lease_token = ?
+            "#,
+        )
+        .bind(&failure.api_key_id)
+        .bind(&failure.voice_note_id)
+        .bind(&failure.lease_token)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(retry_count) = retry_count else {
+            tx.commit().await?;
+            return Ok(EmbeddingRegenerationRetryOutcome::Failed);
+        };
+        let now = format_timestamp(failure.now)?;
+        let max_retries: i64 = sqlx::query_scalar(
+            r#"
+            SELECT max_retries
+            FROM embedding_regeneration_jobs
+            WHERE api_key_id = ? AND voice_note_id = ?
+            "#,
+        )
+        .bind(&failure.api_key_id)
+        .bind(&failure.voice_note_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        if retry_count >= max_retries {
+            sqlx::query(
+                r#"
+                UPDATE embedding_regeneration_jobs
+                SET status = 'failed',
+                    retry_count = ?,
+                    next_attempt_at = NULL,
+                    failure_code = ?,
+                    failure_message = ?,
+                    processing_lease_token = NULL,
+                    processing_lease_expires_at = NULL,
+                    updated_at = ?
+                WHERE api_key_id = ? AND voice_note_id = ?
+                "#,
+            )
+            .bind(retry_count)
+            .bind(&failure.failure_code)
+            .bind(&failure.failure_message)
+            .bind(&now)
+            .bind(&failure.api_key_id)
+            .bind(&failure.voice_note_id)
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            return Ok(EmbeddingRegenerationRetryOutcome::Failed);
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE embedding_regeneration_jobs
+            SET status = 'retry_waiting',
+                retry_count = ?,
+                next_attempt_at = ?,
+                failure_code = ?,
+                failure_message = ?,
+                processing_lease_token = NULL,
+                processing_lease_expires_at = NULL,
+                updated_at = ?
+            WHERE api_key_id = ? AND voice_note_id = ?
+            "#,
+        )
+        .bind(retry_count)
+        .bind(format_timestamp(next_attempt_at)?)
+        .bind(&failure.failure_code)
+        .bind(&failure.failure_message)
+        .bind(&now)
+        .bind(&failure.api_key_id)
+        .bind(&failure.voice_note_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(EmbeddingRegenerationRetryOutcome::RetryWaiting)
+    }
+
+    pub async fn fail_embedding_regeneration_job(
+        &self,
+        failure: EmbeddingRegenerationFailure,
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            r#"
+            UPDATE embedding_regeneration_jobs
+            SET status = 'failed',
+                next_attempt_at = NULL,
+                failure_code = ?,
+                failure_message = ?,
+                processing_lease_token = NULL,
+                processing_lease_expires_at = NULL,
+                updated_at = ?
+            WHERE api_key_id = ?
+                AND voice_note_id = ?
+                AND status = 'processing'
+                AND processing_lease_token = ?
+            "#,
+        )
+        .bind(&failure.failure_code)
+        .bind(&failure.failure_message)
+        .bind(format_timestamp(failure.now)?)
+        .bind(&failure.api_key_id)
+        .bind(&failure.voice_note_id)
+        .bind(&failure.lease_token)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     pub async fn delete_voice_note(

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -404,7 +404,7 @@ pub enum EmbeddingRegenerationRetryOutcome {
 }
 
 pub fn encode_embedding_vector(vector: &[f32]) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(vector.len() * std::mem::size_of::<f32>());
+    let mut bytes = Vec::with_capacity(std::mem::size_of_val(vector));
     for value in vector {
         bytes.extend_from_slice(&value.to_le_bytes());
     }

--- a/backend/src/transcription_worker.rs
+++ b/backend/src/transcription_worker.rs
@@ -10,11 +10,13 @@ use time::{Duration, OffsetDateTime};
 use tokio::process::Command;
 use ulid::Ulid;
 
+use crate::embedding::{EmbeddingEngine, EmbeddingFailure, EmbeddingInput};
 use crate::metrics::Metrics;
 use crate::retention_cleanup::cleanup_retained_audio_for_job;
 use crate::storage::{
-    NewSegment, NewVoiceNote, NewVoiceNoteVersion, RetryOutcome, Storage, StorageError,
-    TerminalJobFailure, TransientJobFailure, VoiceNoteMaterialization,
+    NewEmbedding, NewSegment, NewVoiceNote, NewVoiceNoteVersion, RetryOutcome, Storage,
+    StorageError, TerminalJobFailure, TransientJobFailure, VoiceNoteMaterialization,
+    encode_embedding_vector,
 };
 
 const DEFAULT_OPENAI_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
@@ -524,16 +526,44 @@ fn effective_lease_renewal_interval(config: &WorkerConfig) -> std::time::Duratio
     configured.min(std::time::Duration::from_millis(half_lease_ms))
 }
 
-pub async fn process_one_available_job<E, D>(
+enum ProcessingFailure {
+    Duration(DurationProbeError),
+    Engine(EngineFailure),
+}
+
+fn embedding_failure_to_engine_failure(error: EmbeddingFailure) -> EngineFailure {
+    match error {
+        EmbeddingFailure::Transient {
+            failure_code,
+            message,
+            retry_after_seconds,
+        } => EngineFailure::Transient {
+            failure_code,
+            message,
+            retry_after_seconds,
+        },
+        EmbeddingFailure::Terminal {
+            failure_code,
+            message,
+        } => EngineFailure::Terminal {
+            failure_code,
+            message,
+        },
+    }
+}
+
+pub async fn process_one_available_job<E, B, D>(
     storage: &Storage,
     accepted_audio_dir: &Path,
     engine: &E,
+    embedding_engine: &B,
     duration_probe: &D,
     config: WorkerConfig,
     metrics: &Metrics,
 ) -> Result<ProcessOutcome, WorkerError>
 where
     E: TranscriptionEngine,
+    B: EmbeddingEngine,
     D: DurationProbe,
 {
     let now = OffsetDateTime::now_utc();
@@ -554,7 +584,8 @@ where
         async {
             let duration_ms = duration_probe
                 .duration_ms(&job.accepted_audio_path, &job.audio_format)
-                .await?;
+                .await
+                .map_err(ProcessingFailure::Duration)?;
             let transcription = engine
                 .transcribe(TranscriptionInput {
                     audio_path: job.accepted_audio_path.clone(),
@@ -562,15 +593,29 @@ where
                     language: job.language.clone(),
                     model: job.transcription_model.clone(),
                 })
-                .await;
-            Ok::<_, DurationProbeError>((duration_ms, transcription))
+                .await
+                .map_err(ProcessingFailure::Engine)?;
+            if transcription.text.trim().is_empty() {
+                return Err(ProcessingFailure::Engine(EngineFailure::Terminal {
+                    failure_code: "audio_invalid".to_owned(),
+                    message: "transcription produced empty canonical text".to_owned(),
+                }));
+            }
+            let embedding = embedding_engine
+                .embed(EmbeddingInput {
+                    text: transcription.text.clone(),
+                })
+                .await
+                .map_err(embedding_failure_to_engine_failure)
+                .map_err(ProcessingFailure::Engine)?;
+            Ok((duration_ms, transcription, embedding))
         },
     )
     .await?;
 
-    let (duration_ms, transcription) = match active_work {
+    let (duration_ms, transcription, embedding) = match active_work {
         Ok(active_work) => active_work,
-        Err(error) => {
+        Err(ProcessingFailure::Duration(error)) => {
             let failed = storage
                 .fail_leased_job(TerminalJobFailure {
                     api_key_id: job.api_key_id.clone(),
@@ -593,14 +638,11 @@ where
             .await;
             return Ok(ProcessOutcome::Failed { job_id: job.id });
         }
-    };
-    let transcription = match transcription {
-        Ok(transcription) => transcription,
-        Err(EngineFailure::Transient {
+        Err(ProcessingFailure::Engine(EngineFailure::Transient {
             failure_code,
             message,
             retry_after_seconds,
-        }) => {
+        })) => {
             let metric_failure_code = failure_code.clone();
             let now = OffsetDateTime::now_utc();
             let next_attempt_at = now + Duration::seconds(retry_after_seconds.unwrap_or(60).max(1));
@@ -634,10 +676,10 @@ where
                 }
             };
         }
-        Err(EngineFailure::Terminal {
+        Err(ProcessingFailure::Engine(EngineFailure::Terminal {
             failure_code,
             message,
-        }) => {
+        })) => {
             let metric_failure_code = failure_code.clone();
             let failed = storage
                 .fail_leased_job(TerminalJobFailure {
@@ -699,7 +741,11 @@ where
                     end_ms: duration_ms,
                     text: transcription.text,
                 }],
-                embedding: None,
+                embedding: Some(NewEmbedding {
+                    model: embedding.model,
+                    vector: encode_embedding_vector(&embedding.vector),
+                    created_at,
+                }),
             },
         )
         .await?;
@@ -731,15 +777,17 @@ async fn cleanup_terminal_job_audio(
     }
 }
 
-pub async fn run_worker_loop<E, D>(
+pub async fn run_worker_loop<E, B, D>(
     storage: Storage,
     accepted_audio_dir: PathBuf,
     engine: E,
+    embedding_engine: B,
     duration_probe: D,
     config: WorkerConfig,
     metrics: Metrics,
 ) where
     E: TranscriptionEngine + Sync,
+    B: EmbeddingEngine + Sync,
     D: DurationProbe + Sync,
 {
     loop {
@@ -747,6 +795,7 @@ pub async fn run_worker_loop<E, D>(
             &storage,
             &accepted_audio_dir,
             &engine,
+            &embedding_engine,
             &duration_probe,
             config.clone(),
             &metrics,

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -10,7 +10,6 @@ use crate::collections::{
     parse_rfc3339_field, parse_time_cursor, position_cursor, query_any, query_first, query_values,
     time_cursor, timestamp, validate_rfc3339_field, validate_ulid_field, validation_error,
 };
-use crate::embedding_regeneration::EmbeddingRegenerationRequest;
 use crate::errors::{ApiError, CollectionEnvelope};
 use crate::json::JsonBody;
 use crate::state::AppState;
@@ -157,6 +156,9 @@ pub async fn patch_voice_note(
     JsonBody(body): JsonBody<VoiceNoteTextRequest>,
 ) -> Result<Json<VoiceNoteResource>, ApiError> {
     validate_ulid_field("voice_note_id", &voice_note_id)?;
+    if body.text.trim().is_empty() {
+        return Err(validation_error("text", "Must not be blank."));
+    }
     let record = match state
         .storage
         .update_voice_note_text(
@@ -173,20 +175,6 @@ pub async fn patch_voice_note(
             return Err(ApiError::not_found("Voice note not found."));
         }
     };
-
-    if let Err(error) =
-        state
-            .embedding_regeneration_trigger
-            .initiate(EmbeddingRegenerationRequest {
-                api_key_id: authenticated_key.api_key_id.to_string(),
-                voice_note_id: voice_note_id.clone(),
-            })
-    {
-        tracing::error!(
-            voice_note_id = %voice_note_id,
-            "embedding regeneration trigger failed: {error}"
-        );
-    }
 
     render_voice_note_resource(&state, authenticated_key.api_key_id.as_str(), record).await
 }

--- a/backend/tests/abandonment_sweeper.rs
+++ b/backend/tests/abandonment_sweeper.rs
@@ -133,9 +133,6 @@ impl SweeperFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: self.storage.clone(),
-            embedding_regeneration_trigger: Arc::new(
-                oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
-            ),
         };
         let response = build_operator_router(state)
             .oneshot(

--- a/backend/tests/embedding_engine.rs
+++ b/backend/tests/embedding_engine.rs
@@ -1,0 +1,109 @@
+use std::sync::{Arc, Mutex};
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
+use oracy_backend::embedding::{
+    EmbeddingEngine, EmbeddingFailure, EmbeddingInput, OpenAiEmbeddingEngine,
+};
+use serde_json::{Value, json};
+
+#[tokio::test]
+async fn openai_embedding_engine_posts_embedding_requests_and_pools_long_text_chunks() {
+    let captured = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let app = Router::new()
+        .route("/v1/embeddings", post(fake_embedding))
+        .with_state(captured.clone());
+    let base_url = spawn(app).await;
+    let engine = OpenAiEmbeddingEngine::new(base_url, "test-key".to_owned());
+
+    let output = engine
+        .embed(EmbeddingInput {
+            text: format!("{}{}", "a".repeat(6_000), "b".repeat(6_000)),
+        })
+        .await
+        .expect("embedding output");
+
+    assert_eq!(output.model, "text-embedding-3-small");
+    assert!((output.vector[0] - std::f32::consts::FRAC_1_SQRT_2).abs() < 0.0001);
+    assert!((output.vector[1] - std::f32::consts::FRAC_1_SQRT_2).abs() < 0.0001);
+    assert!(output.vector[2..].iter().all(|value| *value == 0.0));
+
+    let requests = captured.lock().expect("captured requests");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["model"], "text-embedding-3-small");
+    assert_eq!(
+        requests[0]["input"].as_array().expect("input array").len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn openai_embedding_engine_preserves_retry_after_rate_limit_semantics() {
+    async fn rate_limited() -> impl IntoResponse {
+        let mut headers = HeaderMap::new();
+        headers.insert("Retry-After", "37".parse().expect("retry-after"));
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            headers,
+            Json(json!({"error": {"message": "rate limited"}})),
+        )
+    }
+
+    let app = Router::new().route("/v1/embeddings", post(rate_limited));
+    let base_url = spawn(app).await;
+    let engine = OpenAiEmbeddingEngine::new(base_url, "test-key".to_owned());
+
+    let error = engine
+        .embed(EmbeddingInput {
+            text: "hello".to_owned(),
+        })
+        .await
+        .expect_err("rate limit should fail");
+
+    assert_eq!(
+        error,
+        EmbeddingFailure::Transient {
+            failure_code: "engine_rate_limited".to_owned(),
+            message: "{\"error\":{\"message\":\"rate limited\"}}".to_owned(),
+            retry_after_seconds: Some(37),
+        }
+    );
+}
+
+async fn fake_embedding(
+    State(captured): State<Arc<Mutex<Vec<Value>>>>,
+    Json(body): Json<Value>,
+) -> impl IntoResponse {
+    captured.lock().expect("captured").push(body.clone());
+    let input = body["input"].as_array().expect("input array");
+    let data = input
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            let mut embedding = vec![0.0; 1536];
+            embedding[index] = 1.0;
+            json!({
+                "index": index,
+                "embedding": embedding,
+            })
+        })
+        .collect::<Vec<_>>();
+    Json(json!({
+        "model": "text-embedding-3-small",
+        "data": data,
+    }))
+}
+
+async fn spawn(app: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake openai");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve fake openai");
+    });
+    format!("http://{addr}")
+}

--- a/backend/tests/embedding_regeneration.rs
+++ b/backend/tests/embedding_regeneration.rs
@@ -1,0 +1,302 @@
+use std::sync::{Arc, Mutex};
+
+use oracy_backend::embedding::{
+    EmbeddingEngine, EmbeddingFailure, EmbeddingInput, EmbeddingOutput,
+};
+use oracy_backend::embedding_regeneration::{
+    EmbeddingRegenerationConfig, EmbeddingRegenerationOutcome,
+    process_one_embedding_regeneration_job,
+};
+use oracy_backend::storage::{Storage, decode_embedding_vector};
+use tempfile::TempDir;
+use time::macros::datetime;
+
+const NOTE_ID: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5R";
+const VERSION_ID: &str = "01JS9P1D6CK9M0N1P2Q3R4S5T6";
+
+#[tokio::test]
+async fn regeneration_worker_replaces_the_current_embedding_for_the_edited_version() {
+    let (_tempdir, storage) = storage().await;
+    insert_voice_note(&storage).await;
+    storage
+        .update_voice_note_text(
+            "owner-a",
+            NOTE_ID,
+            "edited text",
+            datetime!(2026-04-24 18:03:00 UTC),
+        )
+        .await
+        .expect("update text");
+    let engine = FakeEmbeddingEngine::success(vec![0.2, 0.4, 0.6]);
+
+    let outcome = process_one_embedding_regeneration_job(
+        &storage,
+        &engine,
+        EmbeddingRegenerationConfig::test(),
+    )
+    .await
+    .expect("process regeneration");
+
+    assert_eq!(
+        outcome,
+        EmbeddingRegenerationOutcome::Replaced {
+            voice_note_id: NOTE_ID.to_owned()
+        }
+    );
+    assert_eq!(
+        engine.inputs(),
+        vec![EmbeddingInput {
+            text: "edited text".to_owned()
+        }]
+    );
+    let embedding = storage
+        .get_current_embedding("owner-a", NOTE_ID)
+        .await
+        .expect("embedding lookup")
+        .expect("embedding exists");
+    assert_eq!(
+        decode_embedding_vector(&embedding.vector).expect("encoded vector"),
+        vec![0.2, 0.4, 0.6]
+    );
+    assert!(
+        storage
+            .claim_next_embedding_regeneration_job(
+                "next-lease",
+                datetime!(2026-04-24 18:10:00 UTC),
+                datetime!(2026-04-24 18:15:00 UTC),
+            )
+            .await
+            .expect("claim next")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn stale_regeneration_completion_does_not_replace_a_newer_current_embedding() {
+    let (_tempdir, storage) = storage().await;
+    insert_voice_note(&storage).await;
+    let updated = storage
+        .update_voice_note_text(
+            "owner-a",
+            NOTE_ID,
+            "first edit",
+            datetime!(2026-04-24 18:03:00 UTC),
+        )
+        .await
+        .expect("first edit");
+    let claimed = storage
+        .claim_next_embedding_regeneration_job(
+            "stale-lease",
+            datetime!(2026-04-24 18:04:00 UTC),
+            datetime!(2026-04-24 18:09:00 UTC),
+        )
+        .await
+        .expect("claim")
+        .expect("job exists");
+    assert_eq!(
+        claimed.voice_note_version_id,
+        updated.unwrap_record().current_version_id
+    );
+    storage
+        .update_voice_note_text(
+            "owner-a",
+            NOTE_ID,
+            "second edit",
+            datetime!(2026-04-24 18:05:00 UTC),
+        )
+        .await
+        .expect("second edit");
+
+    let replaced = storage
+        .complete_embedding_regeneration_job_if_current(
+            "owner-a",
+            NOTE_ID,
+            &claimed.voice_note_version_id,
+            "stale-lease",
+            oracy_backend::storage::NewEmbedding {
+                model: "text-embedding-3-small".to_owned(),
+                vector: oracy_backend::storage::encode_embedding_vector(&[0.9, 0.9, 0.9]),
+                created_at: datetime!(2026-04-24 18:06:00 UTC),
+            },
+        )
+        .await
+        .expect("complete stale");
+
+    assert!(!replaced);
+    let embedding = storage
+        .get_current_embedding("owner-a", NOTE_ID)
+        .await
+        .expect("embedding lookup")
+        .expect("embedding exists");
+    assert_eq!(
+        decode_embedding_vector(&embedding.vector).expect("encoded vector"),
+        vec![0.1, 0.1, 0.1]
+    );
+    let latest = storage
+        .claim_next_embedding_regeneration_job(
+            "latest-lease",
+            datetime!(2026-04-24 18:10:00 UTC),
+            datetime!(2026-04-24 18:15:00 UTC),
+        )
+        .await
+        .expect("claim latest")
+        .expect("latest job exists");
+    assert_eq!(latest.text, "second edit");
+}
+
+#[tokio::test]
+async fn transient_regeneration_failures_retry_without_removing_the_previous_embedding() {
+    let (_tempdir, storage) = storage().await;
+    insert_voice_note(&storage).await;
+    storage
+        .update_voice_note_text(
+            "owner-a",
+            NOTE_ID,
+            "edited text",
+            datetime!(2026-04-24 18:03:00 UTC),
+        )
+        .await
+        .expect("update text");
+    let engine = FakeEmbeddingEngine::transient();
+
+    let outcome = process_one_embedding_regeneration_job(
+        &storage,
+        &engine,
+        EmbeddingRegenerationConfig::test(),
+    )
+    .await
+    .expect("process regeneration");
+
+    assert_eq!(
+        outcome,
+        EmbeddingRegenerationOutcome::RetryWaiting {
+            voice_note_id: NOTE_ID.to_owned()
+        }
+    );
+    let embedding = storage
+        .get_current_embedding("owner-a", NOTE_ID)
+        .await
+        .expect("embedding lookup")
+        .expect("embedding exists");
+    assert_eq!(
+        decode_embedding_vector(&embedding.vector).expect("encoded vector"),
+        vec![0.1, 0.1, 0.1]
+    );
+    assert!(
+        storage
+            .claim_next_embedding_regeneration_job(
+                "early-lease",
+                datetime!(2026-04-24 18:03:30 UTC),
+                datetime!(2026-04-24 18:08:30 UTC),
+            )
+            .await
+            .expect("early claim")
+            .is_none()
+    );
+}
+
+async fn storage() -> (TempDir, Storage) {
+    let tempdir = TempDir::new().expect("tempdir");
+    let storage = Storage::connect(&tempdir.path().join("oracy.sqlite"))
+        .await
+        .expect("connect storage");
+    (tempdir, storage)
+}
+
+async fn insert_voice_note(storage: &Storage) {
+    sqlx::query(
+        r#"
+        INSERT INTO voice_notes (
+            id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+            language, model, processing_time_ms, cost_cents, created_at, recorded_at, session_id
+        )
+        VALUES (?, 'owner-a', 1.0, 'wav', 42, 'en', 'gpt-4o-mini-transcribe', 100, NULL,
+            '2026-04-24T18:00:00.000000000Z', '2026-04-24T17:59:00.000000000Z', NULL)
+        "#,
+    )
+    .bind(NOTE_ID)
+    .execute(storage.pool())
+    .await
+    .expect("insert voice note");
+    sqlx::query(
+        r#"
+        INSERT INTO voice_note_versions (
+            id, api_key_id, voice_note_id, version_number, text, created_at
+        )
+        VALUES (?, 'owner-a', ?, 1, 'initial text', '2026-04-24T18:00:00.000000000Z')
+        "#,
+    )
+    .bind(VERSION_ID)
+    .bind(NOTE_ID)
+    .execute(storage.pool())
+    .await
+    .expect("insert version");
+    sqlx::query(
+        r#"
+        INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+        VALUES (?, 'owner-a', 'text-embedding-3-small', ?, '2026-04-24T18:00:00.000000000Z')
+        "#,
+    )
+    .bind(NOTE_ID)
+    .bind(oracy_backend::storage::encode_embedding_vector(&[
+        0.1, 0.1, 0.1,
+    ]))
+    .execute(storage.pool())
+    .await
+    .expect("insert embedding");
+}
+
+trait UpdatedRecord {
+    fn unwrap_record(self) -> Box<oracy_backend::storage::VoiceNoteRecord>;
+}
+
+impl UpdatedRecord for oracy_backend::storage::UpdateVoiceNoteTextOutcome {
+    fn unwrap_record(self) -> Box<oracy_backend::storage::VoiceNoteRecord> {
+        match self {
+            oracy_backend::storage::UpdateVoiceNoteTextOutcome::Updated(record) => record,
+            oracy_backend::storage::UpdateVoiceNoteTextOutcome::NotFound => {
+                panic!("voice note should exist")
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct FakeEmbeddingEngine {
+    output: Result<EmbeddingOutput, EmbeddingFailure>,
+    inputs: Arc<Mutex<Vec<EmbeddingInput>>>,
+}
+
+impl FakeEmbeddingEngine {
+    fn success(vector: Vec<f32>) -> Self {
+        Self {
+            output: Ok(EmbeddingOutput {
+                model: "text-embedding-3-small".to_owned(),
+                vector,
+            }),
+            inputs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn transient() -> Self {
+        Self {
+            output: Err(EmbeddingFailure::Transient {
+                failure_code: "engine_rate_limited".to_owned(),
+                message: "slow down".to_owned(),
+                retry_after_seconds: Some(60),
+            }),
+            inputs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn inputs(&self) -> Vec<EmbeddingInput> {
+        self.inputs.lock().expect("inputs").clone()
+    }
+}
+
+impl EmbeddingEngine for FakeEmbeddingEngine {
+    async fn embed(&self, input: EmbeddingInput) -> Result<EmbeddingOutput, EmbeddingFailure> {
+        self.inputs.lock().expect("inputs").push(input);
+        self.output.clone()
+    }
+}

--- a/backend/tests/embedding_regeneration.rs
+++ b/backend/tests/embedding_regeneration.rs
@@ -9,7 +9,10 @@ use oracy_backend::embedding_regeneration::{
 };
 use oracy_backend::storage::{Storage, decode_embedding_vector};
 use tempfile::TempDir;
+use time::Duration;
 use time::macros::datetime;
+use tokio::sync::Barrier;
+use tokio::time::{Duration as TokioDuration, sleep};
 
 const NOTE_ID: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5R";
 const VERSION_ID: &str = "01JS9P1D6CK9M0N1P2Q3R4S5T6";
@@ -142,6 +145,82 @@ async fn stale_regeneration_completion_does_not_replace_a_newer_current_embeddin
         .expect("claim latest")
         .expect("latest job exists");
     assert_eq!(latest.text, "second edit");
+}
+
+#[tokio::test]
+async fn expired_regeneration_worker_does_not_replace_reclaimed_embedding() {
+    let (_tempdir, storage) = storage().await;
+    insert_voice_note(&storage).await;
+    storage
+        .update_voice_note_text(
+            "owner-a",
+            NOTE_ID,
+            "edited text",
+            datetime!(2026-04-24 18:03:00 UTC),
+        )
+        .await
+        .expect("update text");
+    let stale_started = Arc::new(Barrier::new(2));
+    let stale_release = Arc::new(Barrier::new(2));
+    let stale_engine = BlockingEmbeddingEngine {
+        output: EmbeddingOutput {
+            model: "text-embedding-3-small".to_owned(),
+            vector: vec![0.9, 0.9, 0.9],
+        },
+        started: stale_started.clone(),
+        release: stale_release.clone(),
+    };
+    let stale_storage = storage.clone();
+    let stale_handle = tokio::spawn(async move {
+        process_one_embedding_regeneration_job(
+            &stale_storage,
+            &stale_engine,
+            EmbeddingRegenerationConfig {
+                lease_duration: Duration::milliseconds(1),
+                ..EmbeddingRegenerationConfig::test()
+            },
+        )
+        .await
+    });
+
+    stale_started.wait().await;
+    sleep(TokioDuration::from_millis(20)).await;
+    let fresh_engine = FakeEmbeddingEngine::success(vec![0.2, 0.4, 0.6]);
+
+    let fresh_outcome = process_one_embedding_regeneration_job(
+        &storage,
+        &fresh_engine,
+        EmbeddingRegenerationConfig::test(),
+    )
+    .await
+    .expect("fresh worker completes reclaimed job");
+
+    assert_eq!(
+        fresh_outcome,
+        EmbeddingRegenerationOutcome::Replaced {
+            voice_note_id: NOTE_ID.to_owned()
+        }
+    );
+    stale_release.wait().await;
+    let stale_outcome = stale_handle
+        .await
+        .expect("stale worker joins")
+        .expect("stale worker completes");
+    assert_eq!(
+        stale_outcome,
+        EmbeddingRegenerationOutcome::Stale {
+            voice_note_id: NOTE_ID.to_owned()
+        }
+    );
+    let embedding = storage
+        .get_current_embedding("owner-a", NOTE_ID)
+        .await
+        .expect("embedding lookup")
+        .expect("embedding exists");
+    assert_eq!(
+        decode_embedding_vector(&embedding.vector).expect("encoded vector"),
+        vec![0.2, 0.4, 0.6]
+    );
 }
 
 #[tokio::test]
@@ -298,5 +377,19 @@ impl EmbeddingEngine for FakeEmbeddingEngine {
     async fn embed(&self, input: EmbeddingInput) -> Result<EmbeddingOutput, EmbeddingFailure> {
         self.inputs.lock().expect("inputs").push(input);
         self.output.clone()
+    }
+}
+
+struct BlockingEmbeddingEngine {
+    output: EmbeddingOutput,
+    started: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl EmbeddingEngine for BlockingEmbeddingEngine {
+    async fn embed(&self, _input: EmbeddingInput) -> Result<EmbeddingOutput, EmbeddingFailure> {
+        self.started.wait().await;
+        self.release.wait().await;
+        Ok(self.output.clone())
     }
 }

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -478,9 +478,6 @@ impl MetadataFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
-            embedding_regeneration_trigger: Arc::new(
-                oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
-            ),
         });
 
         Self {

--- a/backend/tests/migrations.rs
+++ b/backend/tests/migrations.rs
@@ -1,0 +1,159 @@
+use std::borrow::Cow;
+
+use sqlx::migrate::Migrator;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+use sqlx::{Row, SqlitePool};
+use tempfile::TempDir;
+
+static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
+const EMBEDDING_REGENERATION_MIGRATION: i64 = 20260504000000;
+
+#[tokio::test]
+async fn embedding_regeneration_migration_backfills_unembedded_current_voice_notes() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let database_path = tempdir.path().join("oracy.sqlite");
+    let pool = sqlite_pool(&database_path).await;
+    migrator_before(EMBEDDING_REGENERATION_MIGRATION)
+        .run(&pool)
+        .await
+        .expect("run pre-regeneration migrations");
+    seed_current_voice_note(
+        &pool,
+        "owner-a",
+        "missing-embedding-note",
+        "version-missing",
+        "needs embedding",
+    )
+    .await;
+    seed_current_voice_note(
+        &pool,
+        "owner-a",
+        "embedded-note",
+        "version-embedded",
+        "already embedded",
+    )
+    .await;
+    seed_embedding(&pool, "owner-a", "embedded-note").await;
+    seed_current_voice_note(&pool, "owner-a", "blank-note", "version-blank", "   ").await;
+
+    MIGRATOR.run(&pool).await.expect("run full migrations");
+
+    let rows = sqlx::query(
+        r#"
+        SELECT voice_note_id, api_key_id, voice_note_version_id, status, retry_count,
+            max_retries, created_at, updated_at
+        FROM embedding_regeneration_jobs
+        ORDER BY voice_note_id
+        "#,
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("fetch regeneration jobs");
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(
+        row.get::<String, _>("voice_note_id"),
+        "missing-embedding-note"
+    );
+    assert_eq!(row.get::<String, _>("api_key_id"), "owner-a");
+    assert_eq!(
+        row.get::<String, _>("voice_note_version_id"),
+        "version-missing"
+    );
+    assert_eq!(row.get::<String, _>("status"), "queued");
+    assert_eq!(row.get::<i64, _>("retry_count"), 0);
+    assert_eq!(row.get::<i64, _>("max_retries"), 3);
+    assert_eq!(
+        row.get::<String, _>("created_at"),
+        "2026-04-24T18:00:00.000000000Z"
+    );
+    assert_eq!(
+        row.get::<String, _>("updated_at"),
+        "2026-04-24T18:00:00.000000000Z"
+    );
+}
+
+fn migrator_before(version: i64) -> Migrator {
+    Migrator {
+        migrations: Cow::Owned(
+            MIGRATOR
+                .iter()
+                .filter(|migration| migration.version < version)
+                .cloned()
+                .collect(),
+        ),
+        ignore_missing: false,
+        locking: true,
+        no_tx: false,
+    }
+}
+
+async fn sqlite_pool(database_path: &std::path::Path) -> SqlitePool {
+    let options = SqliteConnectOptions::new()
+        .filename(database_path)
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect_with(options)
+        .await
+        .expect("connect sqlite")
+}
+
+async fn seed_current_voice_note(
+    pool: &SqlitePool,
+    owner: &str,
+    voice_note_id: &str,
+    version_id: &str,
+    text: &str,
+) {
+    sqlx::query(
+        r#"
+        INSERT INTO voice_notes (
+            id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+            language, model, processing_time_ms, cost_cents, created_at, recorded_at, session_id
+        )
+        VALUES (
+            ?, ?, 1.0, 'wav', 42, 'en', 'gpt-4o-mini-transcribe', 100, NULL,
+            '2026-04-24T18:00:00.000000000Z',
+            '2026-04-24T17:59:00.000000000Z',
+            NULL
+        )
+        "#,
+    )
+    .bind(voice_note_id)
+    .bind(owner)
+    .execute(pool)
+    .await
+    .expect("insert voice note");
+    sqlx::query(
+        r#"
+        INSERT INTO voice_note_versions (
+            id, api_key_id, voice_note_id, version_number, text, created_at
+        )
+        VALUES (?, ?, ?, 1, ?, '2026-04-24T18:00:00.000000000Z')
+        "#,
+    )
+    .bind(version_id)
+    .bind(owner)
+    .bind(voice_note_id)
+    .bind(text)
+    .execute(pool)
+    .await
+    .expect("insert voice-note version");
+}
+
+async fn seed_embedding(pool: &SqlitePool, owner: &str, voice_note_id: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+        VALUES (?, ?, 'text-embedding-3-small', x'010203', '2026-04-24T18:00:00.000000000Z')
+        "#,
+    )
+    .bind(voice_note_id)
+    .bind(owner)
+    .execute(pool)
+    .await
+    .expect("insert embedding");
+}

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -360,7 +360,7 @@ async fn retry_waiting_jobs_are_claimed_only_after_next_attempt_at() {
 }
 
 #[tokio::test]
-async fn leased_completion_requires_the_active_token_and_allows_missing_embedding() {
+async fn leased_completion_requires_the_active_token_and_current_embedding() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;
     storage
@@ -371,8 +371,7 @@ async fn leased_completion_requires_the_active_token_and_allows_missing_embeddin
         )
         .await
         .expect("claim job");
-    let mut materialization = materialization("voice-note-a");
-    materialization.embedding = None;
+    let materialization = materialization("voice-note-a");
 
     let error = storage
         .complete_leased_job_with_voice_note(
@@ -383,6 +382,17 @@ async fn leased_completion_requires_the_active_token_and_allows_missing_embeddin
         )
         .await
         .expect_err("stale lease should not complete");
+    assert!(matches!(
+        error,
+        StorageError::JobNotCompletable { job_id } if job_id == job.id
+    ));
+
+    let mut missing_embedding = materialization.clone();
+    missing_embedding.embedding = None;
+    let error = storage
+        .complete_leased_job_with_voice_note("owner-a", &job.id, "active-lease", missing_embedding)
+        .await
+        .expect_err("missing embedding should not complete");
     assert!(matches!(
         error,
         StorageError::JobNotCompletable { job_id } if job_id == job.id
@@ -405,7 +415,7 @@ async fn leased_completion_requires_the_active_token_and_allows_missing_embeddin
             .get_current_embedding("owner-a", "voice-note-a")
             .await
             .expect("embedding lookup")
-            .is_none()
+            .is_some()
     );
 }
 

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -735,9 +735,6 @@ impl TranscriptionJobFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
-            embedding_regeneration_trigger: Arc::new(
-                oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
-            ),
         });
 
         Self {

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -10,6 +10,9 @@ use axum::routing::post;
 use axum::{Json, Router};
 use oracy_backend::auth::AuthStore;
 use oracy_backend::config::ApiKeyConfig;
+use oracy_backend::embedding::{
+    EmbeddingEngine, EmbeddingFailure, EmbeddingInput, EmbeddingOutput,
+};
 use oracy_backend::metrics::Metrics;
 use oracy_backend::retention_cleanup::{
     RetainedAudioReleaser, RetentionCleanupError, cleanup_retained_audio_once,
@@ -19,7 +22,7 @@ use oracy_backend::router::build_operator_router;
 use oracy_backend::state::AppState;
 use oracy_backend::storage::{
     AcceptJobOutcome, AcceptedChunk, FinalizeJobOutcome, NewOpenTranscriptionJob,
-    NewTranscriptionJob, OpenJobOutcome, Storage, StoreChunkOutcome,
+    NewTranscriptionJob, OpenJobOutcome, Storage, StoreChunkOutcome, decode_embedding_vector,
 };
 use oracy_backend::transcription_worker::{
     AudioSliceError, AudioSlicer, DurationProbe, DurationProbeError, EngineFailure,
@@ -44,12 +47,14 @@ async fn worker_materializes_a_queued_job_with_a_fake_engine() {
     let fixture = WorkerFixture::new().await;
     let job = fixture.create_queued_job("attempt-1", b"hello audio").await;
     let engine = FakeEngine::success("transcribed text");
+    let embedding_engine = FakeEmbeddingEngine::success(vec![0.25, 0.5, 0.75]);
     let probe = FakeDurationProbe::success(1_480);
 
     let outcome = process_one_available_job(
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &embedding_engine,
         &probe,
         WorkerConfig::test(),
         &Metrics::new(),
@@ -87,13 +92,16 @@ async fn worker_materializes_a_queued_job_with_a_fake_engine() {
     assert_eq!(voice_note.text, "transcribed text");
     assert_eq!(voice_note.audio_duration_seconds, 1.48);
     assert_eq!(voice_note.model, "gpt-4o-mini-transcribe");
-    assert!(
-        fixture
-            .storage
-            .get_current_embedding("owner-a", &voice_note.id)
-            .await
-            .expect("embedding lookup")
-            .is_none()
+    let embedding = fixture
+        .storage
+        .get_current_embedding("owner-a", &voice_note.id)
+        .await
+        .expect("embedding lookup")
+        .expect("current embedding exists before succeeded");
+    assert_eq!(embedding.model, "text-embedding-3-small");
+    assert_eq!(
+        decode_embedding_vector(&embedding.vector).expect("encoded vector"),
+        vec![0.25, 0.5, 0.75]
     );
     let segments = fixture
         .storage
@@ -134,6 +142,7 @@ async fn worker_releases_chunks_and_composed_audio_after_success() {
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &metrics,
@@ -207,6 +216,7 @@ async fn worker_releases_chunks_and_composed_audio_after_failure() {
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &Metrics::new(),
@@ -500,6 +510,7 @@ async fn worker_success_increments_operator_success_counter() {
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &metrics,
@@ -531,6 +542,7 @@ async fn worker_retry_increments_operator_retry_counter_with_failure_class() {
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &metrics,
@@ -565,6 +577,7 @@ async fn worker_terminal_failure_increments_operator_failure_counter_with_failur
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &metrics,
@@ -595,6 +608,7 @@ async fn worker_marks_duration_probe_failure_as_audio_invalid() {
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &Metrics::new(),
@@ -633,6 +647,7 @@ async fn worker_routes_transient_engine_failure_to_retry_waiting() {
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &Metrics::new(),
@@ -659,6 +674,89 @@ async fn worker_routes_transient_engine_failure_to_retry_waiting() {
 }
 
 #[tokio::test]
+async fn worker_routes_transient_embedding_failure_to_retry_waiting_before_materialization() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-transient-embedding", b"hello audio")
+        .await;
+    let engine = FakeEngine::success("transcribed text");
+    let embedding_engine =
+        FakeEmbeddingEngine::transient("engine_rate_limited", "slow down", Some(42));
+    let probe = FakeDurationProbe::success(1_480);
+
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &engine,
+        &embedding_engine,
+        &probe,
+        WorkerConfig::test(),
+        &Metrics::new(),
+    )
+    .await
+    .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::RetryWaiting {
+            job_id: job.id.clone()
+        }
+    );
+    let retrying = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(retrying.status, "retry_waiting");
+    assert_eq!(
+        retrying.failure_code.as_deref(),
+        Some("engine_rate_limited")
+    );
+    assert!(retrying.next_attempt_at.is_some());
+    assert!(retrying.voice_note_id.is_none());
+}
+
+#[tokio::test]
+async fn worker_fails_empty_transcription_without_materializing_a_voice_note() {
+    let fixture = WorkerFixture::new().await;
+    let job = fixture
+        .create_queued_job("attempt-empty-transcript", b"silent audio")
+        .await;
+    let engine = FakeEngine::success(" \n\t");
+    let embedding_engine = FakeEmbeddingEngine::success(vec![1.0]);
+    let probe = FakeDurationProbe::success(1_480);
+
+    let outcome = process_one_available_job(
+        &fixture.storage,
+        &fixture.accepted_audio_dir,
+        &engine,
+        &embedding_engine,
+        &probe,
+        WorkerConfig::test(),
+        &Metrics::new(),
+    )
+    .await
+    .expect("process one job");
+
+    assert_eq!(
+        outcome,
+        ProcessOutcome::Failed {
+            job_id: job.id.clone()
+        }
+    );
+    let failed = fixture
+        .storage
+        .get_job("owner-a", &job.id)
+        .await
+        .expect("job lookup")
+        .expect("job exists");
+    assert_eq!(failed.status, "failed");
+    assert_eq!(failed.failure_code.as_deref(), Some("audio_invalid"));
+    assert!(failed.voice_note_id.is_none());
+}
+
+#[tokio::test]
 async fn worker_releases_retained_audio_when_retry_exhaustion_fails_the_job() {
     let fixture = WorkerFixture::new().await;
     let job = fixture
@@ -673,6 +771,7 @@ async fn worker_releases_retained_audio_when_retry_exhaustion_fails_the_job() {
         &fixture.storage,
         &fixture.accepted_audio_dir,
         &engine,
+        &FakeEmbeddingEngine::success(vec![1.0]),
         &probe,
         WorkerConfig::test(),
         &Metrics::new(),
@@ -730,6 +829,7 @@ async fn stalled_openai_request_records_transient_timeout_and_worker_processes_n
             &fixture.storage,
             &fixture.accepted_audio_dir,
             &engine,
+            &FakeEmbeddingEngine::success(vec![1.0]),
             &probe,
             WorkerConfig::test(),
             &Metrics::new(),
@@ -759,6 +859,7 @@ async fn stalled_openai_request_records_transient_timeout_and_worker_processes_n
             &fixture.storage,
             &fixture.accepted_audio_dir,
             &engine,
+            &FakeEmbeddingEngine::success(vec![1.0]),
             &probe,
             WorkerConfig::test(),
             &Metrics::new(),
@@ -814,6 +915,7 @@ async fn worker_renews_processing_lease_while_transcription_outlives_initial_lea
             &storage_for_worker,
             &accepted_audio_dir,
             &engine,
+            &FakeEmbeddingEngine::success(vec![1.0]),
             &probe,
             config,
             &Metrics::new(),
@@ -1306,9 +1408,6 @@ async fn operator_metrics_text(fixture: &WorkerFixture, metrics: Metrics) -> Str
         operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
         openai_api_key: "test-openai-key".to_owned(),
         storage: fixture.storage.clone(),
-        embedding_regeneration_trigger: Arc::new(
-            oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
-        ),
     };
     let response = build_operator_router(state)
         .oneshot(
@@ -1369,6 +1468,42 @@ impl TranscriptionEngine for FakeEngine {
         &self,
         input: TranscriptionInput,
     ) -> Result<TranscriptionOutput, EngineFailure> {
+        self.inputs.lock().expect("inputs").push(input);
+        self.output.clone()
+    }
+}
+
+#[derive(Clone)]
+struct FakeEmbeddingEngine {
+    output: Result<EmbeddingOutput, EmbeddingFailure>,
+    inputs: Arc<Mutex<Vec<EmbeddingInput>>>,
+}
+
+impl FakeEmbeddingEngine {
+    fn success(vector: Vec<f32>) -> Self {
+        Self {
+            output: Ok(EmbeddingOutput {
+                model: "text-embedding-3-small".to_owned(),
+                vector,
+            }),
+            inputs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn transient(failure_code: &str, message: &str, retry_after_seconds: Option<i64>) -> Self {
+        Self {
+            output: Err(EmbeddingFailure::Transient {
+                failure_code: failure_code.to_owned(),
+                message: message.to_owned(),
+                retry_after_seconds,
+            }),
+            inputs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl EmbeddingEngine for FakeEmbeddingEngine {
+    async fn embed(&self, input: EmbeddingInput) -> Result<EmbeddingOutput, EmbeddingFailure> {
         self.inputs.lock().expect("inputs").push(input);
         self.output.clone()
     }

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -1,17 +1,15 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use oracy_backend::auth::AuthStore;
 use oracy_backend::config::ApiKeyConfig;
-use oracy_backend::embedding_regeneration::{
-    EmbeddingRegenerationRequest, EmbeddingRegenerationTrigger, EmbeddingRegenerationTriggerError,
-};
 use oracy_backend::router::build_router;
 use oracy_backend::state::AppState;
 use oracy_backend::storage::Storage;
 use serde_json::{Value, json};
 use tempfile::TempDir;
+use time::macros::datetime;
 use tower::util::ServiceExt;
 
 const NOTE_OLD: &str = "01JS8D6E2S3T1J7H9J2Q2N4P5R";
@@ -277,8 +275,7 @@ async fn version_history_returns_versions_newest_first_in_shared_envelope() {
 #[tokio::test]
 async fn patch_voice_note_text_appends_version_updates_reads_and_initiates_embedding_regeneration()
 {
-    let trigger = Arc::new(RecordingEmbeddingTrigger::failing());
-    let fixture = VoiceNoteFixture::new_with_trigger(trigger.clone()).await;
+    let fixture = VoiceNoteFixture::new().await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
@@ -312,13 +309,6 @@ async fn patch_voice_note_text_appends_version_updates_reads_and_initiates_embed
     assert_eq!(response.body["id"], NOTE_OLD);
     assert_eq!(response.body["text"], "edited text");
     assert_ne!(response.body["current_version_id"], VERSION_OLD);
-    assert_eq!(
-        trigger.requests(),
-        vec![EmbeddingRegenerationRequest {
-            api_key_id: "alpha".to_owned(),
-            voice_note_id: NOTE_OLD.to_owned(),
-        }]
-    );
 
     let versions = fixture
         .get_json(
@@ -347,6 +337,24 @@ async fn patch_voice_note_text_appends_version_updates_reads_and_initiates_embed
         )
         .await;
     assert_eq!(segments["items"][0]["text"], "original segment");
+
+    let regeneration_job = fixture
+        .storage
+        .claim_next_embedding_regeneration_job(
+            "regen-lease",
+            datetime!(2026-04-24 18:10:00 UTC),
+            datetime!(2026-04-24 18:15:00 UTC),
+        )
+        .await
+        .expect("claim regeneration job")
+        .expect("regeneration job exists");
+    assert_eq!(regeneration_job.api_key_id, "alpha");
+    assert_eq!(regeneration_job.voice_note_id, NOTE_OLD);
+    assert_eq!(
+        regeneration_job.voice_note_version_id,
+        response.body["current_version_id"]
+    );
+    assert_eq!(regeneration_job.text, "edited text");
 }
 
 #[tokio::test]
@@ -413,6 +421,17 @@ async fn patch_voice_note_text_reports_contract_errors_for_invalid_requests() {
         .await;
     assert_eq!(invalid_shape.status, StatusCode::UNPROCESSABLE_ENTITY);
     assert_eq!(invalid_shape.body["error_code"], "invalid_request_shape");
+
+    let blank_text = fixture
+        .json_request(
+            "PATCH",
+            &format!("/api/v1/voice-notes/{NOTE_MISSING}"),
+            "alpha-secret",
+            Some(json!({"text": "   \n\t"})),
+        )
+        .await;
+    assert_eq!(blank_text.status, StatusCode::BAD_REQUEST);
+    assert_eq!(blank_text.body["details"][0]["field"], "text");
 
     let unauthorized = fixture
         .app()
@@ -1257,40 +1276,6 @@ struct JsonResponse {
     body: Value,
 }
 
-#[derive(Clone)]
-struct RecordingEmbeddingTrigger {
-    requests: Arc<Mutex<Vec<EmbeddingRegenerationRequest>>>,
-    fail: bool,
-}
-
-impl RecordingEmbeddingTrigger {
-    fn failing() -> Self {
-        Self {
-            requests: Arc::new(Mutex::new(Vec::new())),
-            fail: true,
-        }
-    }
-
-    fn requests(&self) -> Vec<EmbeddingRegenerationRequest> {
-        self.requests.lock().expect("requests lock").clone()
-    }
-}
-
-impl EmbeddingRegenerationTrigger for RecordingEmbeddingTrigger {
-    fn initiate(
-        &self,
-        request: EmbeddingRegenerationRequest,
-    ) -> Result<(), EmbeddingRegenerationTriggerError> {
-        self.requests.lock().expect("requests lock").push(request);
-        if self.fail {
-            return Err(EmbeddingRegenerationTriggerError::Failed(
-                "simulated enqueue failure".to_owned(),
-            ));
-        }
-        Ok(())
-    }
-}
-
 struct VoiceNoteSeed<'a> {
     owner: &'a str,
     id: &'a str,
@@ -1310,15 +1295,6 @@ struct TagSeed<'a> {
 
 impl VoiceNoteFixture {
     async fn new() -> Self {
-        Self::new_with_trigger(Arc::new(
-            oracy_backend::embedding_regeneration::NoopEmbeddingRegenerationTrigger,
-        ))
-        .await
-    }
-
-    async fn new_with_trigger(
-        embedding_regeneration_trigger: Arc<dyn EmbeddingRegenerationTrigger>,
-    ) -> Self {
         let tempdir = TempDir::new().expect("tempdir");
         let accepted_audio_dir = tempdir.path().join("accepted-audio");
         std::fs::create_dir(&accepted_audio_dir).expect("create accepted audio dir");
@@ -1343,7 +1319,6 @@ impl VoiceNoteFixture {
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
             storage: storage.clone(),
-            embedding_regeneration_trigger,
         });
 
         Self {

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -356,6 +356,7 @@ Responses:
 Notes:
 
 - The request changes voice-note text only.
+- `text` must contain at least one non-whitespace character.
 - Editing is the only adjustment path for an existing voice note. The
   backend does not re-transcribe audio against an existing voice note.
 - A successful edit creates one new `VoiceNoteVersion` and moves

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -576,6 +576,8 @@ Semantics:
 
 - `PATCH /api/v1/voice-notes/{voice_note_id}` changes voice-note text
   only.
+- Edited voice-note text must contain at least one non-whitespace
+  character.
 - A voice-note edit creates a new `VoiceNoteVersion`; it does not
   rewrite or delete prior versions.
 - `PUT /api/v1/voice-notes/{voice_note_id}/tags` replaces the voice


### PR DESCRIPTION
## Summary

- Adds the internal embedding engine boundary and OpenAI `text-embedding-3-small` provider for v0.1.0 voice-note embeddings.
- Gates transcription-job success on durable current-embedding storage, including transient retry behavior and empty-text failure handling.
- Replaces the prior no-op edit trigger with a durable regeneration queue and worker that atomically refreshes embeddings for the current version only.

## Changes

- Adds long-text chunking, per-chunk embedding, pooled normalization, and stable little-endian `f32` vector encoding for the existing embeddings table.
- Adds persistent `embedding_regeneration_jobs` storage with lease/retry state and cascades on voice-note deletion.
- Tightens storage and worker tests so `succeeded` requires a current embedding, blank canonical text cannot produce a meaningless vector, and regeneration failures preserve the previous embedding.
- Updates the changelog to close the #58 release-blocker deviation while leaving search endpoint behavior unchanged for #19.

## GitHub Issue(s)

Closes #27
Refs #58
Refs #19

## Test plan

- `cargo fmt --manifest-path backend/Cargo.toml --check`
- `cargo test --manifest-path backend/Cargo.toml --tests`
- `git diff --check`
