### PR TITLE
feat(search): implement voice-note search across collection endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Add ranked voice-note search across keyword, semantic, and hybrid modes,
   including historical-version keyword matches, current-embedding semantic
-  ranking, relevance cursors, and the shared voice-note collection filters.
+  ranking, literal full-text query handling, independent semantic and keyword
+  gates, relevance cursors, and the shared voice-note collection filters.
 - Add OpenAI-backed voice-note embedding generation, long-text chunk pooling,
   durable edit-triggered embedding regeneration, and the
   `succeeded`-requires-current-embedding workflow gate. Blank voice-note text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add ranked voice-note search across keyword, semantic, and hybrid modes,
+  including historical-version keyword matches, current-embedding semantic
+  ranking, relevance cursors, and the shared voice-note collection filters.
 - Add OpenAI-backed voice-note embedding generation, long-text chunk pooling,
   durable edit-triggered embedding regeneration, and the
   `succeeded`-requires-current-embedding workflow gate. Blank voice-note text
@@ -35,8 +38,7 @@
   latest-spelling display updates, and metadata deletion cascades.
 - Add authenticated voice-note history, detail, version-history, segment, and
   session-scoped history read APIs. Collection filters compose across tags,
-  sessions, and recorded/created time ranges; search query parameters
-  conservatively return no results until the tracked search work lands.
+  sessions, and recorded/created time ranges.
 - Define the backend runtime commitment not to emit the literal
   `OPENAI_API_KEY` value through backend-controlled logs, diagnostics, or error
   surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Return empty semantic search results without calling the embedding provider
   when local filters leave no current embeddings to rank, preserving hybrid
   keyword results in the same case.
+- Bound keyword-only search pagination so broad keyword matches return only
+  the requested page from storage instead of materializing the full match set.
 - Add OpenAI-backed voice-note embedding generation, long-text chunk pooling,
   durable edit-triggered embedding regeneration, and the
   `succeeded`-requires-current-embedding workflow gate. Blank voice-note text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   including historical-version keyword matches, current-embedding semantic
   ranking, literal full-text query handling, independent semantic and keyword
   gates, relevance cursors, and the shared voice-note collection filters.
+- Return empty semantic search results without calling the embedding provider
+  when local filters leave no current embeddings to rank, preserving hybrid
+  keyword results in the same case.
 - Add OpenAI-backed voice-note embedding generation, long-text chunk pooling,
   durable edit-triggered embedding regeneration, and the
   `succeeded`-requires-current-embedding workflow gate. Blank voice-note text

--- a/backend/migrations/20260504010000_voice_note_version_fts.sql
+++ b/backend/migrations/20260504010000_voice_note_version_fts.sql
@@ -1,0 +1,41 @@
+PRAGMA foreign_keys = ON;
+
+CREATE VIRTUAL TABLE voice_note_versions_fts USING fts5(
+    api_key_id UNINDEXED,
+    voice_note_id UNINDEXED,
+    text,
+    content='voice_note_versions',
+    content_rowid='rowid'
+);
+
+INSERT INTO voice_note_versions_fts (rowid, api_key_id, voice_note_id, text)
+SELECT rowid, api_key_id, voice_note_id, text
+FROM voice_note_versions;
+
+CREATE TRIGGER voice_note_versions_fts_insert
+AFTER INSERT ON voice_note_versions
+BEGIN
+    INSERT INTO voice_note_versions_fts (rowid, api_key_id, voice_note_id, text)
+    VALUES (NEW.rowid, NEW.api_key_id, NEW.voice_note_id, NEW.text);
+END;
+
+CREATE TRIGGER voice_note_versions_fts_delete
+AFTER DELETE ON voice_note_versions
+BEGIN
+    INSERT INTO voice_note_versions_fts (
+        voice_note_versions_fts, rowid, api_key_id, voice_note_id, text
+    )
+    VALUES ('delete', OLD.rowid, OLD.api_key_id, OLD.voice_note_id, OLD.text);
+END;
+
+CREATE TRIGGER voice_note_versions_fts_update
+AFTER UPDATE ON voice_note_versions
+BEGIN
+    INSERT INTO voice_note_versions_fts (
+        voice_note_versions_fts, rowid, api_key_id, voice_note_id, text
+    )
+    VALUES ('delete', OLD.rowid, OLD.api_key_id, OLD.voice_note_id, OLD.text);
+
+    INSERT INTO voice_note_versions_fts (rowid, api_key_id, voice_note_id, text)
+    VALUES (NEW.rowid, NEW.api_key_id, NEW.voice_note_id, NEW.text);
+END;

--- a/backend/src/bootstrap.rs
+++ b/backend/src/bootstrap.rs
@@ -112,6 +112,7 @@ async fn load_runtime_from_path_with_openai_key(
         metrics: Metrics::new(),
         operator_listen_addr: settings.operator_listen_addr,
         openai_api_key,
+        openai_base_url: "https://api.openai.com".to_owned(),
         storage,
     };
 

--- a/backend/src/collections.rs
+++ b/backend/src/collections.rs
@@ -27,6 +27,15 @@ struct PositionCursor {
     position: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct ScoreCursor {
+    v: u8,
+    kind: String,
+    score: f64,
+    created_at: String,
+    id: String,
+}
+
 pub fn parse_query_params(raw_query: Option<&str>) -> Vec<(String, String)> {
     raw_query
         .map(|query| {
@@ -118,10 +127,52 @@ pub fn parse_position_cursor(cursor: &str, expected_kind: &str) -> Result<i64, A
     Ok(decoded.position)
 }
 
+pub fn parse_score_cursor(
+    cursor: &str,
+    expected_kind: &str,
+) -> Result<(f64, OffsetDateTime, String), ApiError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| malformed_cursor())?;
+    let decoded: ScoreCursor = serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
+    if decoded.v != CURSOR_VERSION || decoded.kind != expected_kind || !decoded.score.is_finite() {
+        return Err(malformed_cursor());
+    }
+    let created_at =
+        OffsetDateTime::parse(&decoded.created_at, &Rfc3339).map_err(|_| malformed_cursor())?;
+    let Ok(parsed_id) = Ulid::from_string(&decoded.id) else {
+        return Err(malformed_cursor());
+    };
+    if parsed_id.to_string() != decoded.id {
+        return Err(malformed_cursor());
+    }
+
+    Ok((decoded.score, created_at, decoded.id))
+}
+
 pub fn time_cursor(kind: &str, created_at: OffsetDateTime, id: &str) -> Result<String, ApiError> {
     let cursor = TimeCursor {
         v: CURSOR_VERSION,
         kind: kind.to_owned(),
+        created_at: timestamp(created_at)?,
+        id: id.to_owned(),
+    };
+    encode_cursor(&cursor)
+}
+
+pub fn score_cursor(
+    kind: &str,
+    score: f64,
+    created_at: OffsetDateTime,
+    id: &str,
+) -> Result<String, ApiError> {
+    if !score.is_finite() {
+        return Err(ApiError::internal("Failed to encode cursor."));
+    }
+    let cursor = ScoreCursor {
+        v: CURSOR_VERSION,
+        kind: kind.to_owned(),
+        score,
         created_at: timestamp(created_at)?,
         id: id.to_owned(),
     };

--- a/backend/src/collections.rs
+++ b/backend/src/collections.rs
@@ -36,6 +36,15 @@ struct ScoreCursor {
     id: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct KeywordSearchCursor {
+    v: u8,
+    kind: String,
+    keyword_score: f64,
+    created_at: String,
+    id: String,
+}
+
 pub fn parse_query_params(raw_query: Option<&str>) -> Vec<(String, String)> {
     raw_query
         .map(|query| {
@@ -150,6 +159,33 @@ pub fn parse_score_cursor(
     Ok((decoded.score, created_at, decoded.id))
 }
 
+pub fn parse_keyword_search_cursor(
+    cursor: &str,
+    expected_kind: &str,
+) -> Result<(f64, OffsetDateTime, String), ApiError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| malformed_cursor())?;
+    let decoded: KeywordSearchCursor =
+        serde_json::from_slice(&bytes).map_err(|_| malformed_cursor())?;
+    if decoded.v != CURSOR_VERSION
+        || decoded.kind != expected_kind
+        || !decoded.keyword_score.is_finite()
+    {
+        return Err(malformed_cursor());
+    }
+    let created_at =
+        OffsetDateTime::parse(&decoded.created_at, &Rfc3339).map_err(|_| malformed_cursor())?;
+    let Ok(parsed_id) = Ulid::from_string(&decoded.id) else {
+        return Err(malformed_cursor());
+    };
+    if parsed_id.to_string() != decoded.id {
+        return Err(malformed_cursor());
+    }
+
+    Ok((decoded.keyword_score, created_at, decoded.id))
+}
+
 pub fn time_cursor(kind: &str, created_at: OffsetDateTime, id: &str) -> Result<String, ApiError> {
     let cursor = TimeCursor {
         v: CURSOR_VERSION,
@@ -173,6 +209,25 @@ pub fn score_cursor(
         v: CURSOR_VERSION,
         kind: kind.to_owned(),
         score,
+        created_at: timestamp(created_at)?,
+        id: id.to_owned(),
+    };
+    encode_cursor(&cursor)
+}
+
+pub fn keyword_search_cursor(
+    kind: &str,
+    keyword_score: f64,
+    created_at: OffsetDateTime,
+    id: &str,
+) -> Result<String, ApiError> {
+    if !keyword_score.is_finite() {
+        return Err(ApiError::internal("Failed to encode cursor."));
+    }
+    let cursor = KeywordSearchCursor {
+        v: CURSOR_VERSION,
+        kind: kind.to_owned(),
+        keyword_score,
         created_at: timestamp(created_at)?,
         id: id.to_owned(),
     };

--- a/backend/src/retention_cleanup.rs
+++ b/backend/src/retention_cleanup.rs
@@ -475,7 +475,7 @@ mod tests {
 
         let retry_releaser = FileRetainedAudioReleaser::new_with_deletion_sync(
             fixture.accepted_audio_dir.clone(),
-            Arc::new(RecordingDeletionSync::default()),
+            Arc::new(RecordingDeletionSync),
         );
         cleanup_retained_audio_once_with_releaser(
             &fixture.storage,

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -16,6 +16,7 @@ pub struct AppState {
     pub metrics: Metrics,
     pub operator_listen_addr: SocketAddr,
     pub openai_api_key: String,
+    pub openai_base_url: String,
     pub storage: Storage,
 }
 
@@ -28,6 +29,7 @@ impl Debug for AppState {
             .field("metrics", &"<metrics>")
             .field("operator_listen_addr", &self.operator_listen_addr)
             .field("openai_api_key", &"<redacted>")
+            .field("openai_base_url", &self.openai_base_url)
             .field("storage", &self.storage)
             .finish()
     }

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -1774,6 +1774,45 @@ impl Storage {
             .await
     }
 
+    pub async fn list_voice_notes_for_search(
+        &self,
+        api_key_id: &str,
+        session_id: Option<&str>,
+        filters: &VoiceNoteFilters,
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        self.list_voice_notes_in_session(api_key_id, session_id, filters, None, i64::MAX)
+            .await
+    }
+
+    pub async fn search_voice_notes_keyword(
+        &self,
+        api_key_id: &str,
+        filters: &VoiceNoteFilters,
+        fts_query: &str,
+        limit: i64,
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        self.search_voice_notes_keyword_in_session(api_key_id, None, filters, fts_query, limit)
+            .await
+    }
+
+    pub async fn search_session_voice_notes_keyword(
+        &self,
+        api_key_id: &str,
+        session_id: &str,
+        filters: &VoiceNoteFilters,
+        fts_query: &str,
+        limit: i64,
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        self.search_voice_notes_keyword_in_session(
+            api_key_id,
+            Some(session_id),
+            filters,
+            fts_query,
+            limit,
+        )
+        .await
+    }
+
     async fn list_voice_notes_in_session(
         &self,
         api_key_id: &str,
@@ -1863,6 +1902,116 @@ impl Storage {
             query.push("))");
         }
         query.push(" ORDER BY voice_notes.created_at DESC, voice_notes.id DESC LIMIT ");
+        query.push_bind(limit);
+        let rows = query.build().fetch_all(&self.pool).await?;
+
+        rows.into_iter().map(voice_note_from_row).collect()
+    }
+
+    async fn search_voice_notes_keyword_in_session(
+        &self,
+        api_key_id: &str,
+        session_id: Option<&str>,
+        filters: &VoiceNoteFilters,
+        fts_query: &str,
+        limit: i64,
+    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+        let recorded_after = filters.recorded_after.map(format_timestamp).transpose()?;
+        let recorded_before = filters.recorded_before.map(format_timestamp).transpose()?;
+        let created_after = filters.created_after.map(format_timestamp).transpose()?;
+        let created_before = filters.created_before.map(format_timestamp).transpose()?;
+        let effective_session_id = session_id.or(filters.session_id.as_deref());
+        let mut query = QueryBuilder::new(
+            r#"
+            WITH raw_keyword_matches AS (
+                SELECT
+                    voice_note_versions_fts.voice_note_id,
+                    rank AS keyword_score
+                FROM voice_note_versions_fts
+                WHERE voice_note_versions_fts.api_key_id =
+            "#,
+        );
+        query.push_bind(api_key_id);
+        query.push(" AND voice_note_versions_fts MATCH ");
+        query.push_bind(fts_query);
+        query.push(
+            r#"
+            ),
+            keyword_matches AS (
+                SELECT voice_note_id, MIN(keyword_score) AS keyword_score
+                FROM raw_keyword_matches
+                GROUP BY voice_note_id
+            )
+            SELECT
+                voice_notes.*,
+                voice_note_versions.id AS current_version_id,
+                voice_note_versions.text AS current_text
+            FROM keyword_matches
+            JOIN voice_notes
+                ON voice_notes.api_key_id =
+            "#,
+        );
+        query.push_bind(api_key_id);
+        query.push(
+            r#"
+                AND voice_notes.id = keyword_matches.voice_note_id
+            JOIN voice_note_versions
+                ON voice_note_versions.voice_note_id = voice_notes.id
+            WHERE voice_notes.api_key_id =
+            "#,
+        );
+        query.push_bind(api_key_id);
+        if let Some(session_id) = effective_session_id {
+            query.push(" AND voice_notes.session_id = ");
+            query.push_bind(session_id);
+        }
+        if let Some(recorded_after) = recorded_after.as_deref() {
+            query.push(" AND voice_notes.recorded_at > ");
+            query.push_bind(recorded_after);
+        }
+        if let Some(recorded_before) = recorded_before.as_deref() {
+            query.push(" AND voice_notes.recorded_at <= ");
+            query.push_bind(recorded_before);
+        }
+        if let Some(created_after) = created_after.as_deref() {
+            query.push(" AND voice_notes.created_at > ");
+            query.push_bind(created_after);
+        }
+        if let Some(created_before) = created_before.as_deref() {
+            query.push(" AND voice_notes.created_at <= ");
+            query.push_bind(created_before);
+        }
+        for tag_id in &filters.tag_ids {
+            query.push(
+                r#"
+                AND EXISTS (
+                    SELECT 1
+                    FROM voice_note_tags
+                    WHERE voice_note_tags.api_key_id = voice_notes.api_key_id
+                        AND voice_note_tags.voice_note_id = voice_notes.id
+                        AND voice_note_tags.tag_id =
+                "#,
+            );
+            query.push_bind(tag_id);
+            query.push(")");
+        }
+        query.push(
+            r#"
+                AND voice_note_versions.version_number = (
+                    SELECT MAX(version_number)
+                    FROM voice_note_versions
+                    WHERE voice_note_id = voice_notes.id
+                )
+            "#,
+        );
+        query.push(
+            r#"
+            ORDER BY keyword_matches.keyword_score ASC,
+                voice_notes.created_at DESC,
+                voice_notes.id DESC
+            LIMIT
+            "#,
+        );
         query.push_bind(limit);
         let rows = query.build().fetch_all(&self.pool).await?;
 
@@ -2103,6 +2252,37 @@ impl Storage {
         .await?;
 
         row.map(embedding_from_row).transpose()
+    }
+
+    pub async fn get_current_embeddings_for_voice_notes(
+        &self,
+        api_key_id: &str,
+        voice_note_ids: &[String],
+    ) -> Result<HashMap<String, Vec<u8>>, StorageError> {
+        if voice_note_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut query = QueryBuilder::new(
+            r#"
+            SELECT voice_note_id, vector
+            FROM embeddings
+            WHERE api_key_id =
+            "#,
+        );
+        query.push_bind(api_key_id);
+        query.push(" AND voice_note_id IN (");
+        let mut separated = query.separated(", ");
+        for voice_note_id in voice_note_ids {
+            separated.push_bind(voice_note_id);
+        }
+        separated.push_unseparated(")");
+        let rows = query.build().fetch_all(&self.pool).await?;
+        let mut embeddings = HashMap::new();
+        for row in rows {
+            embeddings.insert(row.try_get("voice_note_id")?, row.try_get("vector")?);
+        }
+
+        Ok(embeddings)
     }
 
     pub async fn claim_next_embedding_regeneration_job(

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -349,6 +349,29 @@ pub struct VoiceNoteVersionRecord {
     pub created_at: OffsetDateTime,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeywordSearchMatch {
+    pub record: VoiceNoteRecord,
+    pub keyword_score: f64,
+}
+
+impl KeywordSearchMatch {
+    pub fn cursor(&self) -> KeywordSearchCursor {
+        KeywordSearchCursor {
+            keyword_score: self.keyword_score,
+            created_at: self.record.created_at,
+            id: self.record.id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeywordSearchCursor {
+    pub keyword_score: f64,
+    pub created_at: OffsetDateTime,
+    pub id: String,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct VoiceNoteFilters {
     pub tag_ids: Vec<String>,
@@ -1789,10 +1812,13 @@ impl Storage {
         api_key_id: &str,
         filters: &VoiceNoteFilters,
         fts_query: &str,
+        cursor: Option<&KeywordSearchCursor>,
         limit: i64,
-    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
-        self.search_voice_notes_keyword_in_session(api_key_id, None, filters, fts_query, limit)
-            .await
+    ) -> Result<Vec<KeywordSearchMatch>, StorageError> {
+        self.search_voice_notes_keyword_in_session(
+            api_key_id, None, filters, fts_query, cursor, limit,
+        )
+        .await
     }
 
     pub async fn search_session_voice_notes_keyword(
@@ -1801,13 +1827,15 @@ impl Storage {
         session_id: &str,
         filters: &VoiceNoteFilters,
         fts_query: &str,
+        cursor: Option<&KeywordSearchCursor>,
         limit: i64,
-    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+    ) -> Result<Vec<KeywordSearchMatch>, StorageError> {
         self.search_voice_notes_keyword_in_session(
             api_key_id,
             Some(session_id),
             filters,
             fts_query,
+            cursor,
             limit,
         )
         .await
@@ -1914,8 +1942,12 @@ impl Storage {
         session_id: Option<&str>,
         filters: &VoiceNoteFilters,
         fts_query: &str,
+        cursor: Option<&KeywordSearchCursor>,
         limit: i64,
-    ) -> Result<Vec<VoiceNoteRecord>, StorageError> {
+    ) -> Result<Vec<KeywordSearchMatch>, StorageError> {
+        let cursor_created_at = cursor
+            .map(|cursor| format_timestamp(cursor.created_at))
+            .transpose()?;
         let recorded_after = filters.recorded_after.map(format_timestamp).transpose()?;
         let recorded_before = filters.recorded_before.map(format_timestamp).transpose()?;
         let created_after = filters.created_after.map(format_timestamp).transpose()?;
@@ -1943,6 +1975,7 @@ impl Storage {
                 GROUP BY voice_note_id
             )
             SELECT
+                keyword_matches.keyword_score AS keyword_score,
                 voice_notes.*,
                 voice_note_versions.id AS current_version_id,
                 voice_note_versions.text AS current_text
@@ -2004,6 +2037,45 @@ impl Storage {
                 )
             "#,
         );
+        if let Some(cursor) = cursor {
+            let cursor_created_at = cursor_created_at
+                .as_deref()
+                .expect("cursor timestamp is formatted when cursor is present");
+            query.push(
+                r#"
+                AND (
+                    keyword_matches.keyword_score >
+                "#,
+            );
+            query.push_bind(cursor.keyword_score);
+            query.push(
+                r#"
+                    OR (
+                        keyword_matches.keyword_score =
+                "#,
+            );
+            query.push_bind(cursor.keyword_score);
+            query.push(" AND voice_notes.created_at < ");
+            query.push_bind(cursor_created_at);
+            query.push(
+                r#"
+                    )
+                    OR (
+                        keyword_matches.keyword_score =
+                "#,
+            );
+            query.push_bind(cursor.keyword_score);
+            query.push(" AND voice_notes.created_at = ");
+            query.push_bind(cursor_created_at);
+            query.push(" AND voice_notes.id < ");
+            query.push_bind(&cursor.id);
+            query.push(
+                r#"
+                    )
+                )
+                "#,
+            );
+        }
         query.push(
             r#"
             ORDER BY keyword_matches.keyword_score ASC,
@@ -2015,7 +2087,9 @@ impl Storage {
         query.push_bind(limit);
         let rows = query.build().fetch_all(&self.pool).await?;
 
-        rows.into_iter().map(voice_note_from_row).collect()
+        rows.into_iter()
+            .map(keyword_search_match_from_row)
+            .collect()
     }
 
     pub async fn list_voice_note_versions(
@@ -3299,6 +3373,16 @@ fn voice_note_from_row(row: sqlx::sqlite::SqliteRow) -> Result<VoiceNoteRecord, 
         created_at: parse_timestamp(row.try_get("created_at")?)?,
         recorded_at: parse_timestamp(row.try_get("recorded_at")?)?,
         session_id: row.try_get("session_id")?,
+    })
+}
+
+fn keyword_search_match_from_row(
+    row: sqlx::sqlite::SqliteRow,
+) -> Result<KeywordSearchMatch, StorageError> {
+    let keyword_score = row.try_get("keyword_score")?;
+    Ok(KeywordSearchMatch {
+        record: voice_note_from_row(row)?,
+        keyword_score,
     })
 }
 

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -556,12 +556,6 @@ async fn semantic_search_rows(
     filters: &VoiceNoteFilters,
     q: &str,
 ) -> Result<Vec<VoiceNoteRecord>, ApiError> {
-    let engine =
-        OpenAiEmbeddingEngine::new(state.openai_base_url.clone(), state.openai_api_key.clone());
-    let query_embedding = engine
-        .embed(EmbeddingInput { text: q.to_owned() })
-        .await
-        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
     let rows = state
         .storage
         .list_voice_notes_for_search(api_key_id, session_id, filters)
@@ -573,16 +567,32 @@ async fn semantic_search_rows(
         .get_current_embeddings_for_voice_notes(api_key_id, &ids)
         .await
         .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
-    let mut scored = rows
+    let candidates = rows
         .into_iter()
         .filter_map(|record| {
             let embedding = embeddings
                 .get(&record.id)
                 .and_then(|bytes| crate::storage::decode_embedding_vector(bytes))?;
-            Some((
+            Some((record, embedding))
+        })
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let engine =
+        OpenAiEmbeddingEngine::new(state.openai_base_url.clone(), state.openai_api_key.clone());
+    let query_embedding = engine
+        .embed(EmbeddingInput { text: q.to_owned() })
+        .await
+        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+    let mut scored = candidates
+        .into_iter()
+        .map(|(record, embedding)| {
+            (
                 cosine_similarity(&query_embedding.vector, &embedding),
                 record,
-            ))
+            )
         })
         .collect::<Vec<_>>();
     scored.sort_by(|(left_score, left), (right_score, right)| {

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -483,32 +483,32 @@ async fn execute_voice_note_search(
 ) -> Result<Vec<RankedVoiceNote>, ApiError> {
     let mut ranks: HashMap<String, (VoiceNoteRecord, Option<usize>, Option<usize>)> =
         HashMap::new();
-    if matches!(search.mode, SearchMode::Keyword | SearchMode::Hybrid) {
-        if let Some(fts_query) = search.fts_query.as_deref() {
-            let rows = match session_id {
-                Some(session_id) => {
-                    state
-                        .storage
-                        .search_session_voice_notes_keyword(
-                            api_key_id,
-                            session_id,
-                            filters,
-                            fts_query,
-                            i64::MAX,
-                        )
-                        .await
-                }
-                None => {
-                    state
-                        .storage
-                        .search_voice_notes_keyword(api_key_id, filters, fts_query, i64::MAX)
-                        .await
-                }
+    if matches!(search.mode, SearchMode::Keyword | SearchMode::Hybrid)
+        && let Some(fts_query) = search.fts_query.as_deref()
+    {
+        let rows = match session_id {
+            Some(session_id) => {
+                state
+                    .storage
+                    .search_session_voice_notes_keyword(
+                        api_key_id,
+                        session_id,
+                        filters,
+                        fts_query,
+                        i64::MAX,
+                    )
+                    .await
             }
-            .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
-            for (index, record) in rows.into_iter().enumerate() {
-                ranks.insert(record.id.clone(), (record, Some(index + 1), None));
+            None => {
+                state
+                    .storage
+                    .search_voice_notes_keyword(api_key_id, filters, fts_query, i64::MAX)
+                    .await
             }
+        }
+        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+        for (index, record) in rows.into_iter().enumerate() {
+            ranks.insert(record.id.clone(), (record, Some(index + 1), None));
         }
     }
 
@@ -534,7 +534,7 @@ async fn execute_voice_note_search(
         .filter(|row| {
             cursor
                 .as_ref()
-                .map_or(true, |(cursor_score, cursor_created_at, cursor_id)| {
+                .is_none_or(|(cursor_score, cursor_created_at, cursor_id)| {
                     row.score < *cursor_score
                         || (row.score == *cursor_score
                             && (row.record.created_at < *cursor_created_at
@@ -543,7 +543,7 @@ async fn execute_voice_note_search(
                 })
         })
         .collect::<Vec<_>>();
-    rows.sort_by(|left, right| compare_ranked_voice_notes(left, right));
+    rows.sort_by(compare_ranked_voice_notes);
     rows.truncate((limit + 1) as usize);
 
     Ok(rows)

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -8,18 +8,18 @@ use time::OffsetDateTime;
 
 use crate::auth::AuthenticatedKey;
 use crate::collections::{
-    ensure_singular_query_param, parse_limit, parse_position_cursor, parse_query_params,
-    parse_rfc3339_field, parse_score_cursor, parse_time_cursor, position_cursor, query_any,
-    query_first, query_values, score_cursor, time_cursor, timestamp, validate_rfc3339_field,
-    validate_ulid_field, validation_error,
+    ensure_singular_query_param, keyword_search_cursor, parse_keyword_search_cursor, parse_limit,
+    parse_position_cursor, parse_query_params, parse_rfc3339_field, parse_score_cursor,
+    parse_time_cursor, position_cursor, query_any, query_first, query_values, score_cursor,
+    time_cursor, timestamp, validate_rfc3339_field, validate_ulid_field, validation_error,
 };
 use crate::embedding::{EmbeddingEngine, EmbeddingInput, OpenAiEmbeddingEngine};
 use crate::errors::{ApiError, CollectionEnvelope};
 use crate::json::JsonBody;
 use crate::state::AppState;
 use crate::storage::{
-    ReplaceVoiceNoteTagsOutcome, SegmentRecord, TagRecord, UpdateVoiceNoteTextOutcome,
-    VoiceNoteFilters, VoiceNoteRecord, VoiceNoteVersionRecord,
+    KeywordSearchCursor, ReplaceVoiceNoteTagsOutcome, SegmentRecord, TagRecord,
+    UpdateVoiceNoteTextOutcome, VoiceNoteFilters, VoiceNoteRecord, VoiceNoteVersionRecord,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,9 +40,15 @@ struct PageQuery<T> {
 struct VoiceNoteCollectionQuery {
     limit: i64,
     history_cursor: Option<(OffsetDateTime, String)>,
-    search_cursor: Option<(f64, OffsetDateTime, String)>,
+    search_cursor: Option<SearchCursor>,
     filters: VoiceNoteFilters,
     search: Option<SearchQuery>,
+}
+
+#[derive(Debug, Clone)]
+enum SearchCursor {
+    Keyword(KeywordSearchCursor),
+    Relevance(f64, OffsetDateTime, String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +69,7 @@ struct SearchQuery {
 struct RankedVoiceNote {
     record: VoiceNoteRecord,
     score: f64,
+    keyword_score: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -145,6 +152,7 @@ pub async fn list_voice_notes(
             rows,
             query.limit,
             CursorKind::VoiceNoteHistory,
+            search.mode,
         )
         .await;
     }
@@ -414,6 +422,7 @@ pub async fn list_session_voice_notes(
             rows,
             query.limit,
             CursorKind::SessionVoiceNoteHistory,
+            search.mode,
         )
         .await;
     }
@@ -478,9 +487,20 @@ async fn execute_voice_note_search(
     session_id: Option<&str>,
     filters: &VoiceNoteFilters,
     search: &SearchQuery,
-    cursor: Option<(f64, OffsetDateTime, String)>,
+    cursor: Option<SearchCursor>,
     limit: i64,
 ) -> Result<Vec<RankedVoiceNote>, ApiError> {
+    if search.mode == SearchMode::Keyword {
+        return execute_keyword_voice_note_search(
+            api_key_id, state, session_id, filters, search, cursor, limit,
+        )
+        .await;
+    }
+
+    let relevance_cursor = match cursor {
+        Some(SearchCursor::Relevance(score, created_at, id)) => Some((score, created_at, id)),
+        Some(SearchCursor::Keyword(_)) | None => None,
+    };
     let mut ranks: HashMap<String, (VoiceNoteRecord, Option<usize>, Option<usize>)> =
         HashMap::new();
     if matches!(search.mode, SearchMode::Keyword | SearchMode::Hybrid)
@@ -495,6 +515,7 @@ async fn execute_voice_note_search(
                         session_id,
                         filters,
                         fts_query,
+                        None,
                         i64::MAX,
                     )
                     .await
@@ -502,12 +523,13 @@ async fn execute_voice_note_search(
             None => {
                 state
                     .storage
-                    .search_voice_notes_keyword(api_key_id, filters, fts_query, i64::MAX)
+                    .search_voice_notes_keyword(api_key_id, filters, fts_query, None, i64::MAX)
                     .await
             }
         }
         .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
-        for (index, record) in rows.into_iter().enumerate() {
+        for (index, row) in rows.into_iter().enumerate() {
+            let record = row.record;
             ranks.insert(record.id.clone(), (record, Some(index + 1), None));
         }
     }
@@ -530,9 +552,10 @@ async fn execute_voice_note_search(
         .map(|(record, keyword_rank, semantic_rank)| RankedVoiceNote {
             record,
             score: reciprocal_rank_score(keyword_rank, semantic_rank),
+            keyword_score: None,
         })
         .filter(|row| {
-            cursor
+            relevance_cursor
                 .as_ref()
                 .is_none_or(|(cursor_score, cursor_created_at, cursor_id)| {
                     row.score < *cursor_score
@@ -547,6 +570,61 @@ async fn execute_voice_note_search(
     rows.truncate((limit + 1) as usize);
 
     Ok(rows)
+}
+
+async fn execute_keyword_voice_note_search(
+    api_key_id: &str,
+    state: &AppState,
+    session_id: Option<&str>,
+    filters: &VoiceNoteFilters,
+    search: &SearchQuery,
+    cursor: Option<SearchCursor>,
+    limit: i64,
+) -> Result<Vec<RankedVoiceNote>, ApiError> {
+    let Some(fts_query) = search.fts_query.as_deref() else {
+        return Ok(Vec::new());
+    };
+    let cursor = match cursor {
+        Some(SearchCursor::Keyword(cursor)) => Some(cursor),
+        Some(SearchCursor::Relevance(..)) | None => None,
+    };
+    let rows = match session_id {
+        Some(session_id) => {
+            state
+                .storage
+                .search_session_voice_notes_keyword(
+                    api_key_id,
+                    session_id,
+                    filters,
+                    fts_query,
+                    cursor.as_ref(),
+                    limit + 1,
+                )
+                .await
+        }
+        None => {
+            state
+                .storage
+                .search_voice_notes_keyword(
+                    api_key_id,
+                    filters,
+                    fts_query,
+                    cursor.as_ref(),
+                    limit + 1,
+                )
+                .await
+        }
+    }
+    .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| RankedVoiceNote {
+            record: row.record,
+            score: -row.keyword_score,
+            keyword_score: Some(row.keyword_score),
+        })
+        .collect())
 }
 
 async fn semantic_search_rows(
@@ -690,6 +768,7 @@ async fn render_voice_note_search_page(
     mut rows: Vec<RankedVoiceNote>,
     limit: i64,
     cursor_kind: CursorKind,
+    search_mode: SearchMode,
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
     let has_next = rows.len() as i64 > limit;
     if has_next {
@@ -698,12 +777,23 @@ async fn render_voice_note_search_page(
     let next_cursor = if has_next {
         rows.last()
             .map(|voice_note| {
-                score_cursor(
-                    cursor_kind.search_cursor_kind(),
-                    voice_note.score,
-                    voice_note.record.created_at,
-                    &voice_note.record.id,
-                )
+                if search_mode == SearchMode::Keyword {
+                    keyword_search_cursor(
+                        cursor_kind.keyword_search_cursor_kind(),
+                        voice_note
+                            .keyword_score
+                            .expect("keyword search rows carry keyword score"),
+                        voice_note.record.created_at,
+                        &voice_note.record.id,
+                    )
+                } else {
+                    score_cursor(
+                        cursor_kind.search_cursor_kind(),
+                        voice_note.score,
+                        voice_note.record.created_at,
+                        &voice_note.record.id,
+                    )
+                }
             })
             .transpose()?
     } else {
@@ -746,10 +836,31 @@ fn parse_voice_note_collection_query(
     } else {
         None
     };
-    let search_cursor = if search.is_some() {
-        cursor
-            .map(|cursor| parse_score_cursor(cursor, cursor_kind.search_cursor_kind()))
-            .transpose()?
+    let search_cursor = if let Some(search) = &search {
+        match search {
+            SearchQuery {
+                mode: SearchMode::Keyword,
+                ..
+            } => cursor
+                .map(|cursor| {
+                    parse_keyword_search_cursor(cursor, cursor_kind.keyword_search_cursor_kind())
+                        .map(|(keyword_score, created_at, id)| {
+                            SearchCursor::Keyword(KeywordSearchCursor {
+                                keyword_score,
+                                created_at,
+                                id,
+                            })
+                        })
+                })
+                .transpose()?,
+            _ => cursor
+                .map(|cursor| {
+                    parse_score_cursor(cursor, cursor_kind.search_cursor_kind()).map(
+                        |(score, created_at, id)| SearchCursor::Relevance(score, created_at, id),
+                    )
+                })
+                .transpose()?,
+        }
     } else {
         None
     };
@@ -1002,6 +1113,14 @@ impl CursorKind {
         match self {
             Self::VoiceNoteHistory => "voice_note_search",
             Self::SessionVoiceNoteHistory => "session_voice_note_search",
+            _ => self.as_str(),
+        }
+    }
+
+    fn keyword_search_cursor_kind(self) -> &'static str {
+        match self {
+            Self::VoiceNoteHistory => "voice_note_keyword_search",
+            Self::SessionVoiceNoteHistory => "session_voice_note_keyword_search",
             _ => self.as_str(),
         }
     }

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use axum::Json;
 use axum::extract::{Path, RawQuery, State};
 use axum::http::StatusCode;
@@ -7,9 +9,11 @@ use time::OffsetDateTime;
 use crate::auth::AuthenticatedKey;
 use crate::collections::{
     ensure_singular_query_param, parse_limit, parse_position_cursor, parse_query_params,
-    parse_rfc3339_field, parse_time_cursor, position_cursor, query_any, query_first, query_values,
-    time_cursor, timestamp, validate_rfc3339_field, validate_ulid_field, validation_error,
+    parse_rfc3339_field, parse_score_cursor, parse_time_cursor, position_cursor, query_any,
+    query_first, query_values, score_cursor, time_cursor, timestamp, validate_rfc3339_field,
+    validate_ulid_field, validation_error,
 };
+use crate::embedding::{EmbeddingEngine, EmbeddingInput, OpenAiEmbeddingEngine};
 use crate::errors::{ApiError, CollectionEnvelope};
 use crate::json::JsonBody;
 use crate::state::AppState;
@@ -34,9 +38,31 @@ struct PageQuery<T> {
 
 #[derive(Debug, Clone)]
 struct VoiceNoteCollectionQuery {
-    page: PageQuery<(OffsetDateTime, String)>,
+    limit: i64,
+    history_cursor: Option<(OffsetDateTime, String)>,
+    search_cursor: Option<(f64, OffsetDateTime, String)>,
     filters: VoiceNoteFilters,
-    search_requested: bool,
+    search: Option<SearchQuery>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchMode {
+    Keyword,
+    Semantic,
+    Hybrid,
+}
+
+#[derive(Debug, Clone)]
+struct SearchQuery {
+    raw_query: String,
+    fts_query: Option<String>,
+    mode: SearchMode,
+}
+
+#[derive(Debug, Clone)]
+struct RankedVoiceNote {
+    record: VoiceNoteRecord,
+    score: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -101,8 +127,26 @@ pub async fn list_voice_notes(
 ) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
     let params = parse_query_params(raw_query.as_deref());
     let query = parse_voice_note_collection_query(&params, CursorKind::VoiceNoteHistory)?;
-    if query.search_requested {
-        return Ok(empty_voice_note_collection());
+    if let Some(search) = &query.search {
+        let rows = execute_voice_note_search(
+            authenticated_key.api_key_id.as_str(),
+            &state,
+            None,
+            &query.filters,
+            search,
+            query.search_cursor,
+            query.limit,
+        )
+        .await?;
+
+        return render_voice_note_search_page(
+            authenticated_key.api_key_id.as_str(),
+            &state,
+            rows,
+            query.limit,
+            CursorKind::VoiceNoteHistory,
+        )
+        .await;
     }
 
     let rows = state
@@ -110,8 +154,8 @@ pub async fn list_voice_notes(
         .list_voice_notes(
             authenticated_key.api_key_id.as_str(),
             &query.filters,
-            query.page.cursor,
-            query.page.limit + 1,
+            query.history_cursor,
+            query.limit + 1,
         )
         .await
         .map_err(|_| ApiError::internal("Failed to list voice notes."))?;
@@ -120,7 +164,7 @@ pub async fn list_voice_notes(
         authenticated_key.api_key_id.as_str(),
         &state,
         rows,
-        query.page.limit,
+        query.limit,
         CursorKind::VoiceNoteHistory,
     )
     .await
@@ -352,8 +396,26 @@ pub async fn list_session_voice_notes(
         return Err(ApiError::not_found("Session not found."));
     }
 
-    if query.search_requested {
-        return Ok(empty_voice_note_collection());
+    if let Some(search) = &query.search {
+        let rows = execute_voice_note_search(
+            authenticated_key.api_key_id.as_str(),
+            &state,
+            Some(&session_id),
+            &query.filters,
+            search,
+            query.search_cursor,
+            query.limit,
+        )
+        .await?;
+
+        return render_voice_note_search_page(
+            authenticated_key.api_key_id.as_str(),
+            &state,
+            rows,
+            query.limit,
+            CursorKind::SessionVoiceNoteHistory,
+        )
+        .await;
     }
 
     let rows = state
@@ -362,8 +424,8 @@ pub async fn list_session_voice_notes(
             authenticated_key.api_key_id.as_str(),
             &session_id,
             &query.filters,
-            query.page.cursor,
-            query.page.limit + 1,
+            query.history_cursor,
+            query.limit + 1,
         )
         .await
         .map_err(|_| ApiError::internal("Failed to list session voice notes."))?;
@@ -372,7 +434,7 @@ pub async fn list_session_voice_notes(
         authenticated_key.api_key_id.as_str(),
         &state,
         rows,
-        query.page.limit,
+        query.limit,
         CursorKind::SessionVoiceNoteHistory,
     )
     .await
@@ -408,6 +470,170 @@ async fn render_voice_note_resource(
         .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
 
     Ok(Json(voice_note_resource(record, tags)?))
+}
+
+async fn execute_voice_note_search(
+    api_key_id: &str,
+    state: &AppState,
+    session_id: Option<&str>,
+    filters: &VoiceNoteFilters,
+    search: &SearchQuery,
+    cursor: Option<(f64, OffsetDateTime, String)>,
+    limit: i64,
+) -> Result<Vec<RankedVoiceNote>, ApiError> {
+    let Some(fts_query) = search.fts_query.as_deref() else {
+        return Ok(Vec::new());
+    };
+    let mut ranks: HashMap<String, (VoiceNoteRecord, Option<usize>, Option<usize>)> =
+        HashMap::new();
+    if matches!(search.mode, SearchMode::Keyword | SearchMode::Hybrid) {
+        let rows = match session_id {
+            Some(session_id) => {
+                state
+                    .storage
+                    .search_session_voice_notes_keyword(
+                        api_key_id,
+                        session_id,
+                        filters,
+                        fts_query,
+                        i64::MAX,
+                    )
+                    .await
+            }
+            None => {
+                state
+                    .storage
+                    .search_voice_notes_keyword(api_key_id, filters, fts_query, i64::MAX)
+                    .await
+            }
+        }
+        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+        for (index, record) in rows.into_iter().enumerate() {
+            ranks.insert(record.id.clone(), (record, Some(index + 1), None));
+        }
+    }
+
+    if matches!(search.mode, SearchMode::Semantic | SearchMode::Hybrid) {
+        let semantic_rows =
+            semantic_search_rows(api_key_id, state, session_id, filters, &search.raw_query).await?;
+        for (index, record) in semantic_rows.into_iter().enumerate() {
+            ranks
+                .entry(record.id.clone())
+                .and_modify(|(_, _, semantic_rank)| *semantic_rank = Some(index + 1))
+                .or_insert((record, None, Some(index + 1)));
+        }
+    }
+
+    let mut rows = ranks
+        .into_values()
+        .map(|(record, keyword_rank, semantic_rank)| RankedVoiceNote {
+            record,
+            score: reciprocal_rank_score(keyword_rank, semantic_rank),
+        })
+        .filter(|row| {
+            cursor
+                .as_ref()
+                .map_or(true, |(cursor_score, cursor_created_at, cursor_id)| {
+                    row.score < *cursor_score
+                        || (row.score == *cursor_score
+                            && (row.record.created_at < *cursor_created_at
+                                || (row.record.created_at == *cursor_created_at
+                                    && row.record.id.as_str() < cursor_id.as_str())))
+                })
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| compare_ranked_voice_notes(left, right));
+    rows.truncate((limit + 1) as usize);
+
+    Ok(rows)
+}
+
+async fn semantic_search_rows(
+    api_key_id: &str,
+    state: &AppState,
+    session_id: Option<&str>,
+    filters: &VoiceNoteFilters,
+    q: &str,
+) -> Result<Vec<VoiceNoteRecord>, ApiError> {
+    let engine =
+        OpenAiEmbeddingEngine::new(state.openai_base_url.clone(), state.openai_api_key.clone());
+    let query_embedding = engine
+        .embed(EmbeddingInput { text: q.to_owned() })
+        .await
+        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+    let rows = state
+        .storage
+        .list_voice_notes_for_search(api_key_id, session_id, filters)
+        .await
+        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+    let ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+    let embeddings = state
+        .storage
+        .get_current_embeddings_for_voice_notes(api_key_id, &ids)
+        .await
+        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+    let mut scored = rows
+        .into_iter()
+        .filter_map(|record| {
+            let embedding = embeddings
+                .get(&record.id)
+                .and_then(|bytes| crate::storage::decode_embedding_vector(bytes))?;
+            Some((
+                cosine_similarity(&query_embedding.vector, &embedding),
+                record,
+            ))
+        })
+        .collect::<Vec<_>>();
+    scored.sort_by(|(left_score, left), (right_score, right)| {
+        right_score
+            .total_cmp(left_score)
+            .then_with(|| right.created_at.cmp(&left.created_at))
+            .then_with(|| right.id.cmp(&left.id))
+    });
+
+    Ok(scored.into_iter().map(|(_, record)| record).collect())
+}
+
+fn reciprocal_rank_score(keyword_rank: Option<usize>, semantic_rank: Option<usize>) -> f64 {
+    const RRF_K: f64 = 60.0;
+    keyword_rank
+        .map(|rank| 1.0 / (RRF_K + rank as f64))
+        .unwrap_or(0.0)
+        + semantic_rank
+            .map(|rank| 1.0 / (RRF_K + rank as f64))
+            .unwrap_or(0.0)
+}
+
+fn cosine_similarity(left: &[f32], right: &[f32]) -> f64 {
+    if left.len() != right.len() || left.is_empty() {
+        return f64::NEG_INFINITY;
+    }
+    let mut dot = 0.0;
+    let mut left_magnitude = 0.0;
+    let mut right_magnitude = 0.0;
+    for (left, right) in left.iter().zip(right.iter()) {
+        let left = *left as f64;
+        let right = *right as f64;
+        dot += left * right;
+        left_magnitude += left * left;
+        right_magnitude += right * right;
+    }
+    if left_magnitude == 0.0 || right_magnitude == 0.0 {
+        f64::NEG_INFINITY
+    } else {
+        dot / (left_magnitude.sqrt() * right_magnitude.sqrt())
+    }
+}
+
+fn compare_ranked_voice_notes(
+    left: &RankedVoiceNote,
+    right: &RankedVoiceNote,
+) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| right.record.created_at.cmp(&left.record.created_at))
+        .then_with(|| right.record.id.cmp(&left.record.id))
 }
 
 async fn render_voice_note_page(
@@ -447,11 +673,51 @@ async fn render_voice_note_page(
     Ok(Json(CollectionEnvelope { items, next_cursor }))
 }
 
-fn empty_voice_note_collection() -> Json<CollectionEnvelope<VoiceNoteResource>> {
-    Json(CollectionEnvelope {
-        items: Vec::new(),
-        next_cursor: None,
-    })
+async fn render_voice_note_search_page(
+    api_key_id: &str,
+    state: &AppState,
+    mut rows: Vec<RankedVoiceNote>,
+    limit: i64,
+    cursor_kind: CursorKind,
+) -> Result<Json<CollectionEnvelope<VoiceNoteResource>>, ApiError> {
+    let has_next = rows.len() as i64 > limit;
+    if has_next {
+        rows.truncate(limit as usize);
+    }
+    let next_cursor = if has_next {
+        rows.last()
+            .map(|voice_note| {
+                score_cursor(
+                    cursor_kind.search_cursor_kind(),
+                    voice_note.score,
+                    voice_note.record.created_at,
+                    &voice_note.record.id,
+                )
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let voice_note_ids = rows
+        .iter()
+        .map(|row| row.record.id.clone())
+        .collect::<Vec<_>>();
+    let mut tags_by_voice_note = state
+        .storage
+        .list_tags_for_voice_notes(api_key_id, &voice_note_ids)
+        .await
+        .map_err(|_| ApiError::internal("Failed to load voice note tags."))?;
+    let items = rows
+        .into_iter()
+        .map(|row| {
+            let tags = tags_by_voice_note
+                .remove(&row.record.id)
+                .unwrap_or_default();
+            voice_note_resource(row.record, tags)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Json(CollectionEnvelope { items, next_cursor }))
 }
 
 fn parse_voice_note_collection_query(
@@ -460,15 +726,28 @@ fn parse_voice_note_collection_query(
 ) -> Result<VoiceNoteCollectionQuery, ApiError> {
     validate_repeated_singular_query_params(params, cursor_kind)?;
     validate_collection_query_values(params, cursor_kind)?;
+    let search = parse_search_query(params)?;
+    let cursor = query_first(params, "cursor");
+    let history_cursor = if search.is_none() {
+        cursor
+            .map(|cursor| parse_time_cursor(cursor, cursor_kind.as_str()))
+            .transpose()?
+    } else {
+        None
+    };
+    let search_cursor = if search.is_some() {
+        cursor
+            .map(|cursor| parse_score_cursor(cursor, cursor_kind.search_cursor_kind()))
+            .transpose()?
+    } else {
+        None
+    };
     Ok(VoiceNoteCollectionQuery {
-        page: PageQuery {
-            limit: parse_limit(params)?,
-            cursor: query_first(params, "cursor")
-                .map(|cursor| parse_time_cursor(cursor, cursor_kind.as_str()))
-                .transpose()?,
-        },
+        limit: parse_limit(params)?,
+        history_cursor,
+        search_cursor,
         filters: parse_voice_note_filters(params, cursor_kind)?,
-        search_requested: query_any(params, "q"),
+        search,
     })
 }
 
@@ -603,6 +882,37 @@ fn parse_optional_rfc3339_filter(
         .transpose()
 }
 
+fn parse_search_query(params: &[(String, String)]) -> Result<Option<SearchQuery>, ApiError> {
+    let Some(q) = query_first(params, "q") else {
+        return Ok(None);
+    };
+    let fts_query = plain_text_fts_query(q);
+    let mode = match query_first(params, "search_mode").unwrap_or("hybrid") {
+        "keyword" => SearchMode::Keyword,
+        "semantic" => SearchMode::Semantic,
+        "hybrid" => SearchMode::Hybrid,
+        _ => unreachable!("search_mode values are validated before parsing"),
+    };
+
+    Ok(Some(SearchQuery {
+        raw_query: q.to_owned(),
+        fts_query,
+        mode,
+    }))
+}
+
+fn plain_text_fts_query(raw: &str) -> Option<String> {
+    let terms = raw
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|term| !term.is_empty())
+        .collect::<Vec<_>>();
+    if terms.is_empty() {
+        None
+    } else {
+        Some(terms.join(" AND "))
+    }
+}
+
 fn voice_note_resource(
     record: VoiceNoteRecord,
     tags: Vec<TagRecord>,
@@ -670,5 +980,13 @@ impl CursorKind {
 
     fn is_voice_note_collection(self) -> bool {
         matches!(self, Self::VoiceNoteHistory | Self::SessionVoiceNoteHistory)
+    }
+
+    fn search_cursor_kind(self) -> &'static str {
+        match self {
+            Self::VoiceNoteHistory => "voice_note_search",
+            Self::SessionVoiceNoteHistory => "session_voice_note_search",
+            _ => self.as_str(),
+        }
     }
 }

--- a/backend/src/voice_notes.rs
+++ b/backend/src/voice_notes.rs
@@ -481,39 +481,40 @@ async fn execute_voice_note_search(
     cursor: Option<(f64, OffsetDateTime, String)>,
     limit: i64,
 ) -> Result<Vec<RankedVoiceNote>, ApiError> {
-    let Some(fts_query) = search.fts_query.as_deref() else {
-        return Ok(Vec::new());
-    };
     let mut ranks: HashMap<String, (VoiceNoteRecord, Option<usize>, Option<usize>)> =
         HashMap::new();
     if matches!(search.mode, SearchMode::Keyword | SearchMode::Hybrid) {
-        let rows = match session_id {
-            Some(session_id) => {
-                state
-                    .storage
-                    .search_session_voice_notes_keyword(
-                        api_key_id,
-                        session_id,
-                        filters,
-                        fts_query,
-                        i64::MAX,
-                    )
-                    .await
+        if let Some(fts_query) = search.fts_query.as_deref() {
+            let rows = match session_id {
+                Some(session_id) => {
+                    state
+                        .storage
+                        .search_session_voice_notes_keyword(
+                            api_key_id,
+                            session_id,
+                            filters,
+                            fts_query,
+                            i64::MAX,
+                        )
+                        .await
+                }
+                None => {
+                    state
+                        .storage
+                        .search_voice_notes_keyword(api_key_id, filters, fts_query, i64::MAX)
+                        .await
+                }
             }
-            None => {
-                state
-                    .storage
-                    .search_voice_notes_keyword(api_key_id, filters, fts_query, i64::MAX)
-                    .await
+            .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
+            for (index, record) in rows.into_iter().enumerate() {
+                ranks.insert(record.id.clone(), (record, Some(index + 1), None));
             }
-        }
-        .map_err(|_| ApiError::internal("Failed to search voice notes."))?;
-        for (index, record) in rows.into_iter().enumerate() {
-            ranks.insert(record.id.clone(), (record, Some(index + 1), None));
         }
     }
 
-    if matches!(search.mode, SearchMode::Semantic | SearchMode::Hybrid) {
+    if matches!(search.mode, SearchMode::Semantic | SearchMode::Hybrid)
+        && !search.raw_query.trim().is_empty()
+    {
         let semantic_rows =
             semantic_search_rows(api_key_id, state, session_id, filters, &search.raw_query).await?;
         for (index, record) in semantic_rows.into_iter().enumerate() {
@@ -905,12 +906,17 @@ fn plain_text_fts_query(raw: &str) -> Option<String> {
     let terms = raw
         .split(|character: char| !character.is_alphanumeric())
         .filter(|term| !term.is_empty())
+        .map(fts_quoted_phrase)
         .collect::<Vec<_>>();
     if terms.is_empty() {
         None
     } else {
         Some(terms.join(" AND "))
     }
+}
+
+fn fts_quoted_phrase(term: &str) -> String {
+    format!("\"{}\"", term.replace('"', "\"\""))
 }
 
 fn voice_note_resource(

--- a/backend/tests/abandonment_sweeper.rs
+++ b/backend/tests/abandonment_sweeper.rs
@@ -132,6 +132,7 @@ impl SweeperFixture {
             metrics: self.metrics.clone(),
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
+            openai_base_url: "http://127.0.0.1".to_owned(),
             storage: self.storage.clone(),
         };
         let response = build_operator_router(state)

--- a/backend/tests/metadata.rs
+++ b/backend/tests/metadata.rs
@@ -477,6 +477,7 @@ impl MetadataFixture {
             metrics: oracy_backend::metrics::Metrics::new(),
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
+            openai_base_url: "http://127.0.0.1".to_owned(),
             storage: storage.clone(),
         });
 

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -7,7 +7,7 @@ use oracy_backend::storage::{
     NewOpenTranscriptionJob, NewSegment, NewSession, NewTag, NewTranscriptionJob, NewVoiceNote,
     NewVoiceNoteVersion, OpenJobOutcome, RenameTagOutcome, ReplaceVoiceNoteTagsOutcome,
     RetryOutcome, Storage, StorageError, StoreChunkOutcome, TransientJobFailure,
-    UpdateVoiceNoteTextOutcome, VoiceNoteMaterialization,
+    UpdateVoiceNoteTextOutcome, VoiceNoteFilters, VoiceNoteMaterialization,
 };
 use sqlx::Row;
 use std::time::Duration as StdDuration;
@@ -134,6 +134,53 @@ async fn storage_owns_the_accepted_audio_hash_algorithm_pin() {
     assert_eq!(
         created.audio_content_hash_algorithm,
         AUDIO_CONTENT_HASH_ALGORITHM_ID
+    );
+}
+
+#[tokio::test]
+async fn keyword_search_resumes_equal_score_pages_by_created_at_and_id() {
+    let (_tempdir, storage) = storage().await;
+    for voice_note_id in ["voice-note-a", "voice-note-b", "voice-note-c"] {
+        insert_searchable_voice_note(
+            &storage,
+            "owner-a",
+            voice_note_id,
+            &format!("version-{voice_note_id}"),
+            "apollo exact",
+            "2026-04-24T18:00:00.000000000Z",
+        )
+        .await;
+    }
+
+    let first_page = storage
+        .search_voice_notes_keyword("owner-a", &VoiceNoteFilters::default(), "apollo", None, 2)
+        .await
+        .expect("first keyword page");
+    assert_eq!(
+        first_page
+            .iter()
+            .map(|row| row.record.id.as_str())
+            .collect::<Vec<_>>(),
+        ["voice-note-c", "voice-note-b"]
+    );
+
+    let cursor = first_page.last().expect("last result").cursor();
+    let second_page = storage
+        .search_voice_notes_keyword(
+            "owner-a",
+            &VoiceNoteFilters::default(),
+            "apollo",
+            Some(&cursor),
+            2,
+        )
+        .await
+        .expect("second keyword page");
+    assert_eq!(
+        second_page
+            .iter()
+            .map(|row| row.record.id.as_str())
+            .collect::<Vec<_>>(),
+        ["voice-note-a"]
     );
 }
 
@@ -2241,6 +2288,52 @@ async fn insert_voice_note_only(storage: &Storage, owner: &str, voice_note_id: &
     .execute(storage.pool())
     .await
     .expect("insert voice note");
+}
+
+async fn insert_searchable_voice_note(
+    storage: &Storage,
+    owner: &str,
+    voice_note_id: &str,
+    version_id: &str,
+    text: &str,
+    created_at: &str,
+) {
+    sqlx::query(
+        r#"
+        INSERT INTO voice_notes (
+            id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+            language, model, processing_time_ms, cost_cents,
+            created_at, recorded_at, session_id
+        )
+        VALUES (
+            ?, ?, 12.5, 'wav', 401280, 'en', 'general-transcription-v1', 1843, 1,
+            ?, '2026-04-24T17:59:00.000000000Z', NULL
+        )
+        "#,
+    )
+    .bind(voice_note_id)
+    .bind(owner)
+    .bind(created_at)
+    .execute(storage.pool())
+    .await
+    .expect("insert searchable voice note");
+
+    sqlx::query(
+        r#"
+        INSERT INTO voice_note_versions (
+            id, api_key_id, voice_note_id, version_number, text, created_at
+        )
+        VALUES (?, ?, ?, 1, ?, ?)
+        "#,
+    )
+    .bind(version_id)
+    .bind(owner)
+    .bind(voice_note_id)
+    .bind(text)
+    .bind(created_at)
+    .execute(storage.pool())
+    .await
+    .expect("insert searchable voice note version");
 }
 
 async fn insert_session_row(storage: &Storage, owner: &str, session_id: &str) {

--- a/backend/tests/transcription_jobs.rs
+++ b/backend/tests/transcription_jobs.rs
@@ -734,6 +734,7 @@ impl TranscriptionJobFixture {
             metrics: metrics.clone(),
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
+            openai_base_url: "http://127.0.0.1".to_owned(),
             storage: storage.clone(),
         });
 

--- a/backend/tests/transcription_worker.rs
+++ b/backend/tests/transcription_worker.rs
@@ -1407,6 +1407,7 @@ async fn operator_metrics_text(fixture: &WorkerFixture, metrics: Metrics) -> Str
         metrics,
         operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
         openai_api_key: "test-openai-key".to_owned(),
+        openai_base_url: "http://127.0.0.1".to_owned(),
         storage: fixture.storage.clone(),
     };
     let response = build_operator_router(state)

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use axum::{Json, Router};
 use oracy_backend::auth::AuthStore;
 use oracy_backend::config::ApiKeyConfig;
 use oracy_backend::router::build_router;
 use oracy_backend::state::AppState;
-use oracy_backend::storage::Storage;
+use oracy_backend::storage::{Storage, encode_embedding_vector};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 use time::macros::datetime;
@@ -1103,48 +1105,301 @@ async fn invalid_collection_query_values_return_validation_errors() {
 }
 
 #[tokio::test]
-async fn each_valid_search_mode_is_accepted_while_search_is_deferred() {
+async fn keyword_search_returns_parent_voice_notes_for_current_and_historical_version_matches() {
     let fixture = VoiceNoteFixture::new().await;
     fixture
         .insert_voice_note(VoiceNoteSeed {
             owner: "alpha",
             id: NOTE_OLD,
             version_id: VERSION_OLD,
-            text: "history result",
+            text: "apollo retrospective",
             created_at: "2026-04-24T18:00:00.000000000Z",
             recorded_at: "2026-04-24T17:59:00.000000000Z",
             session_id: None,
-            tags: vec![TagSeed {
+            tags: vec![],
+        })
+        .await;
+    fixture
+        .insert_version(
+            "alpha",
+            NOTE_OLD,
+            NOTE_PAGE_A,
+            2,
+            "renamed historical note",
+            "2026-04-24T18:02:00.000000000Z",
+        )
+        .await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_NEW,
+            version_id: VERSION_NEW,
+            text: "apollo launch checklist",
+            created_at: "2026-04-24T18:01:00.000000000Z",
+            recorded_at: "2026-04-24T18:00:30.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    let body = fixture
+        .get_json(
+            "/api/v1/voice-notes?q=apollo&search_mode=keyword",
+            "alpha-secret",
+        )
+        .await;
+
+    assert_collection_ids(body.clone(), &[NOTE_OLD, NOTE_NEW]);
+    assert_eq!(body["items"][0]["current_version_id"], NOTE_PAGE_A);
+    assert_eq!(body["items"][0]["text"], "renamed historical note");
+}
+
+#[tokio::test]
+async fn semantic_search_orders_current_embeddings_by_cosine_similarity() {
+    let openai_base_url = spawn_fake_embedding_server().await;
+    let fixture = VoiceNoteFixture::new_with_openai_base_url(openai_base_url).await;
+    for (id, version_id, text, created_at, vector) in [
+        (
+            NOTE_OLD,
+            VERSION_OLD,
+            "least similar",
+            "2026-04-24T18:00:00.000000000Z",
+            [0.0, 1.0, 0.0],
+        ),
+        (
+            NOTE_PAGE_C,
+            NOTE_PAGE_C,
+            "middle similar",
+            "2026-04-24T18:01:00.000000000Z",
+            [0.5, 0.5, 0.0],
+        ),
+        (
+            NOTE_NEW,
+            VERSION_NEW,
+            "most similar",
+            "2026-04-24T18:02:00.000000000Z",
+            [1.0, 0.0, 0.0],
+        ),
+    ] {
+        fixture
+            .insert_voice_note(VoiceNoteSeed {
+                owner: "alpha",
+                id,
+                version_id,
+                text,
+                created_at,
+                recorded_at: "2026-04-24T17:59:00.000000000Z",
+                session_id: None,
+                tags: vec![],
+            })
+            .await;
+        fixture.insert_embedding_vector("alpha", id, vector).await;
+    }
+
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?q=query&search_mode=semantic",
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_NEW, NOTE_PAGE_C, NOTE_OLD],
+    );
+}
+
+#[tokio::test]
+async fn hybrid_search_uses_reciprocal_rank_fusion_for_keyword_and_semantic_results() {
+    let openai_base_url = spawn_fake_embedding_server().await;
+    let fixture = VoiceNoteFixture::new_with_openai_base_url(openai_base_url).await;
+    for (id, version_id, text, created_at, vector) in [
+        (
+            NOTE_OLD,
+            VERSION_OLD,
+            "apollo shared result",
+            "2026-04-24T18:00:00.000000000Z",
+            [1.0, 0.0, 0.0],
+        ),
+        (
+            NOTE_NEW,
+            VERSION_NEW,
+            "apollo keyword only",
+            "2026-04-24T18:01:00.000000000Z",
+            [0.0, 1.0, 0.0],
+        ),
+        (
+            NOTE_PAGE_C,
+            NOTE_PAGE_C,
+            "semantic only",
+            "2026-04-24T18:02:00.000000000Z",
+            [0.9, 0.1, 0.0],
+        ),
+    ] {
+        fixture
+            .insert_voice_note(VoiceNoteSeed {
+                owner: "alpha",
+                id,
+                version_id,
+                text,
+                created_at,
+                recorded_at: "2026-04-24T17:59:00.000000000Z",
+                session_id: None,
+                tags: vec![],
+            })
+            .await;
+        fixture.insert_embedding_vector("alpha", id, vector).await;
+    }
+
+    let body = fixture
+        .get_json("/api/v1/voice-notes?q=apollo", "alpha-secret")
+        .await;
+
+    assert_eq!(body["items"][0]["id"], NOTE_OLD);
+    assert_collection_ids(body, &[NOTE_OLD, NOTE_NEW, NOTE_PAGE_C]);
+}
+
+#[tokio::test]
+async fn search_filters_and_cursors_apply_to_relevance_ordered_results() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture.insert_session("alpha", SESSION_A).await;
+    for (id, version_id, text, created_at, session_id, tags) in [
+        (
+            NOTE_OLD,
+            VERSION_OLD,
+            "apollo exact",
+            "2026-04-24T18:00:00.000000000Z",
+            Some(SESSION_A),
+            vec![TagSeed {
                 id: TAG_MEETING,
                 name: "Meeting",
                 created_at: "2026-04-24T18:01:30.000000000Z",
             }],
-        })
-        .await;
-
-    assert_empty_collection(
+        ),
+        (
+            NOTE_NEW,
+            VERSION_NEW,
+            "apollo exact",
+            "2026-04-24T18:01:00.000000000Z",
+            Some(SESSION_A),
+            vec![TagSeed {
+                id: TAG_MEETING,
+                name: "Meeting",
+                created_at: "2026-04-24T18:01:30.000000000Z",
+            }],
+        ),
+        (
+            NOTE_OUTSIDE_SESSION,
+            NOTE_OUTSIDE_SESSION,
+            "apollo exact",
+            "2026-04-24T18:02:00.000000000Z",
+            None,
+            vec![TagSeed {
+                id: TAG_ACTION,
+                name: "Action",
+                created_at: "2026-04-24T18:01:40.000000000Z",
+            }],
+        ),
+    ] {
         fixture
-            .get_json("/api/v1/voice-notes?q=hello", "alpha-secret")
-            .await,
-    );
-    assert_empty_collection(
-        fixture
-            .get_json(
-                &format!("/api/v1/voice-notes?q=hello&tag_id={TAG_MEETING}"),
-                "alpha-secret",
-            )
-            .await,
-    );
-
-    for mode in ["keyword", "semantic", "hybrid"] {
-        let accepted = fixture
-            .get_json(
-                &format!("/api/v1/voice-notes?q=hello&search_mode={mode}"),
-                "alpha-secret",
-            )
+            .insert_voice_note(VoiceNoteSeed {
+                owner: "alpha",
+                id,
+                version_id,
+                text,
+                created_at,
+                recorded_at: "2026-04-24T17:59:00.000000000Z",
+                session_id,
+                tags,
+            })
             .await;
-        assert_empty_collection(accepted);
     }
+
+    let first = fixture
+        .get_json(
+            &format!(
+                "/api/v1/sessions/{SESSION_A}/voice-notes?q=apollo&search_mode=keyword&tag_id={TAG_MEETING}&limit=1"
+            ),
+            "alpha-secret",
+        )
+        .await;
+    assert_collection_ids(first.clone(), &[NOTE_NEW]);
+    let cursor = first["next_cursor"].as_str().expect("next cursor");
+    let second = fixture
+        .get_json(
+            &format!(
+                "/api/v1/sessions/{SESSION_A}/voice-notes?q=apollo&search_mode=keyword&tag_id={TAG_MEETING}&limit=1&cursor={cursor}"
+            ),
+            "alpha-secret",
+        )
+        .await;
+    assert_collection_ids(second.clone(), &[NOTE_OLD]);
+    assert_eq!(second["next_cursor"], Value::Null);
+}
+
+#[tokio::test]
+async fn search_uses_distinct_cursors_and_blank_queries_return_empty_search_results() {
+    let fixture = VoiceNoteFixture::new().await;
+    for (id, version_id, created_at) in [
+        (NOTE_OLD, VERSION_OLD, "2026-04-24T18:00:00.000000000Z"),
+        (NOTE_NEW, VERSION_NEW, "2026-04-24T18:01:00.000000000Z"),
+        (NOTE_PAGE_C, NOTE_PAGE_C, "2026-04-24T18:02:00.000000000Z"),
+    ] {
+        fixture
+            .insert_voice_note(VoiceNoteSeed {
+                owner: "alpha",
+                id,
+                version_id,
+                text: "apollo exact",
+                created_at,
+                recorded_at: "2026-04-24T17:59:00.000000000Z",
+                session_id: None,
+                tags: vec![],
+            })
+            .await;
+    }
+
+    assert_empty_collection(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?q=...&search_mode=keyword",
+                "alpha-secret",
+            )
+            .await,
+    );
+
+    let history = fixture
+        .get_json("/api/v1/voice-notes?limit=1", "alpha-secret")
+        .await;
+    let history_cursor = history["next_cursor"].as_str().expect("history cursor");
+    assert_validation_error(
+        fixture
+            .get(
+                &format!(
+                    "/api/v1/voice-notes?q=apollo&search_mode=keyword&cursor={history_cursor}"
+                ),
+                "alpha-secret",
+            )
+            .await,
+        "cursor",
+    )
+    .await;
+
+    let search = fixture
+        .get_json(
+            "/api/v1/voice-notes?q=apollo&search_mode=keyword&limit=1",
+            "alpha-secret",
+        )
+        .await;
+    let search_cursor = search["next_cursor"].as_str().expect("search cursor");
+    assert_validation_error(
+        fixture
+            .get(
+                &format!("/api/v1/voice-notes?limit=1&cursor={search_cursor}"),
+                "alpha-secret",
+            )
+            .await,
+        "cursor",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1295,6 +1550,10 @@ struct TagSeed<'a> {
 
 impl VoiceNoteFixture {
     async fn new() -> Self {
+        Self::new_with_openai_base_url("http://127.0.0.1".to_owned()).await
+    }
+
+    async fn new_with_openai_base_url(openai_base_url: String) -> Self {
         let tempdir = TempDir::new().expect("tempdir");
         let accepted_audio_dir = tempdir.path().join("accepted-audio");
         std::fs::create_dir(&accepted_audio_dir).expect("create accepted audio dir");
@@ -1318,6 +1577,7 @@ impl VoiceNoteFixture {
             metrics: oracy_backend::metrics::Metrics::new(),
             operator_listen_addr: "127.0.0.1:9090".parse().expect("operator listen addr"),
             openai_api_key: "test-openai-key".to_owned(),
+            openai_base_url,
             storage: storage.clone(),
         });
 
@@ -1563,6 +1823,25 @@ impl VoiceNoteFixture {
         .expect("insert embedding");
     }
 
+    async fn insert_embedding_vector(&self, owner: &str, voice_note_id: &str, prefix: [f32; 3]) {
+        let mut vector = vec![0.0; 1536];
+        vector[0] = prefix[0];
+        vector[1] = prefix[1];
+        vector[2] = prefix[2];
+        sqlx::query(
+            r#"
+            INSERT INTO embeddings (voice_note_id, api_key_id, model, vector, created_at)
+            VALUES (?, ?, 'embedding-v1', ?, '2026-04-24T18:02:00.000000000Z')
+            "#,
+        )
+        .bind(voice_note_id)
+        .bind(owner)
+        .bind(encode_embedding_vector(&vector))
+        .execute(self.storage.pool())
+        .await
+        .expect("insert embedding");
+    }
+
     async fn insert_succeeded_job(&self, owner: &str, job_id: &str, voice_note_id: &str) {
         sqlx::query(
             r#"
@@ -1618,6 +1897,40 @@ async fn json_body(response: axum::response::Response) -> Value {
         .await
         .expect("read body");
     serde_json::from_slice(&bytes).expect("valid json")
+}
+
+async fn spawn_fake_embedding_server() -> String {
+    let app = Router::new().route("/v1/embeddings", post(fake_embedding));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake embedding server");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve fake embedding server");
+    });
+    format!("http://{addr}")
+}
+
+async fn fake_embedding(Json(body): Json<Value>) -> Json<Value> {
+    let input = body["input"].as_array().expect("input array");
+    let data = input
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            let mut embedding = vec![0.0; 1536];
+            embedding[0] = 1.0;
+            json!({
+                "index": index,
+                "embedding": embedding,
+            })
+        })
+        .collect::<Vec<_>>();
+    Json(json!({
+        "model": "text-embedding-3-small",
+        "data": data,
+    }))
 }
 
 async fn assert_validation_error(response: axum::response::Response, field: &str) {

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -1155,6 +1155,42 @@ async fn keyword_search_returns_parent_voice_notes_for_current_and_historical_ve
 }
 
 #[tokio::test]
+async fn keyword_search_treats_fts_syntax_shaped_query_text_as_literal_terms() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "Rock AND OR NOT NEAR Roll",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    for q in [
+        "AND",
+        "OR",
+        "NOT",
+        "NEAR",
+        "rock*",
+        "^rock",
+        "(rock)",
+        "rock:roll",
+        "Rock AND Roll",
+        "AND OR *",
+    ] {
+        let body = fixture
+            .get_json(&voice_note_search_path(q, "keyword"), "alpha-secret")
+            .await;
+
+        assert_collection_ids(body, &[NOTE_OLD]);
+    }
+}
+
+#[tokio::test]
 async fn semantic_search_orders_current_embeddings_by_cosine_similarity() {
     let openai_base_url = spawn_fake_embedding_server().await;
     let fixture = VoiceNoteFixture::new_with_openai_base_url(openai_base_url).await;
@@ -1204,6 +1240,50 @@ async fn semantic_search_orders_current_embeddings_by_cosine_similarity() {
             )
             .await,
         &[NOTE_NEW, NOTE_PAGE_C, NOTE_OLD],
+    );
+}
+
+#[tokio::test]
+async fn search_modes_gate_keyword_terms_and_semantic_query_text_independently() {
+    let openai_base_url = spawn_fake_embedding_server().await;
+    let fixture = VoiceNoteFixture::new_with_openai_base_url(openai_base_url).await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "plain searchable note",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+    fixture
+        .insert_embedding_vector("alpha", NOTE_OLD, [1.0, 0.0, 0.0])
+        .await;
+
+    assert_empty_collection(
+        fixture
+            .get_json(&voice_note_search_path("😀", "keyword"), "alpha-secret")
+            .await,
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(&voice_note_search_path("😀", "semantic"), "alpha-secret")
+            .await,
+        &[NOTE_OLD],
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(&voice_note_search_path("😀", "hybrid"), "alpha-secret")
+            .await,
+        &[NOTE_OLD],
+    );
+    assert_empty_collection(
+        fixture
+            .get_json(&voice_note_search_path("   ", "semantic"), "alpha-secret")
+            .await,
     );
 }
 
@@ -1945,6 +2025,14 @@ async fn assert_repeated_singular_parameter_error(response: axum::response::Resp
     let body = json_body(response).await;
     assert_eq!(body["error_code"], "repeated_singular_parameter");
     assert_eq!(body["details"][0]["field"], field);
+}
+
+fn voice_note_search_path(q: &str, search_mode: &str) -> String {
+    let query = form_urlencoded::Serializer::new(String::new())
+        .append_pair("q", q)
+        .append_pair("search_mode", search_mode)
+        .finish();
+    format!("/api/v1/voice-notes?{query}")
 }
 
 fn assert_empty_collection(body: Value) {

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -1244,6 +1244,32 @@ async fn semantic_search_orders_current_embeddings_by_cosine_similarity() {
 }
 
 #[tokio::test]
+async fn semantic_search_returns_empty_without_provider_when_filtered_candidates_are_empty() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "unmatched note",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    assert_empty_collection(
+        fixture
+            .get_json(
+                &format!("/api/v1/voice-notes?q=query&search_mode=semantic&tag_id={TAG_MISSING}"),
+                "alpha-secret",
+            )
+            .await,
+    );
+}
+
+#[tokio::test]
 async fn search_modes_gate_keyword_terms_and_semantic_query_text_independently() {
     let openai_base_url = spawn_fake_embedding_server().await;
     let fixture = VoiceNoteFixture::new_with_openai_base_url(openai_base_url).await;
@@ -1335,6 +1361,33 @@ async fn hybrid_search_uses_reciprocal_rank_fusion_for_keyword_and_semantic_resu
 
     assert_eq!(body["items"][0]["id"], NOTE_OLD);
     assert_collection_ids(body, &[NOTE_OLD, NOTE_NEW, NOTE_PAGE_C]);
+}
+
+#[tokio::test]
+async fn hybrid_search_keeps_keyword_results_without_provider_when_semantic_candidates_are_empty() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_voice_note(VoiceNoteSeed {
+            owner: "alpha",
+            id: NOTE_OLD,
+            version_id: VERSION_OLD,
+            text: "apollo keyword match",
+            created_at: "2026-04-24T18:00:00.000000000Z",
+            recorded_at: "2026-04-24T17:59:00.000000000Z",
+            session_id: None,
+            tags: vec![],
+        })
+        .await;
+
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?q=apollo&search_mode=hybrid",
+                "alpha-secret",
+            )
+            .await,
+        &[NOTE_OLD],
+    );
 }
 
 #[tokio::test]

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -1536,6 +1536,47 @@ async fn search_uses_distinct_cursors_and_blank_queries_return_empty_search_resu
 }
 
 #[tokio::test]
+async fn keyword_only_search_paginates_many_matches_in_relevance_order() {
+    let fixture = VoiceNoteFixture::new().await;
+    let mut inserted_ids = Vec::new();
+    for index in 0..8 {
+        let id = format!("01JS8D6E2S3T1J7H9J2Q2N4P{index:02}");
+        let version_id = format!("01JS9P1D6CK9M0N1P2Q3R4S{index:02}");
+        let created_at = format!("2026-04-24T18:00:0{index}.000000000Z");
+        fixture
+            .insert_voice_note(VoiceNoteSeed {
+                owner: "alpha",
+                id: &id,
+                version_id: &version_id,
+                text: "apollo exact",
+                created_at: &created_at,
+                recorded_at: "2026-04-24T17:59:00.000000000Z",
+                session_id: None,
+                tags: vec![],
+            })
+            .await;
+        inserted_ids.push(id);
+    }
+
+    let first = fixture
+        .get_json(
+            "/api/v1/voice-notes?q=apollo&search_mode=keyword&limit=1",
+            "alpha-secret",
+        )
+        .await;
+    assert_collection_ids(first.clone(), &[inserted_ids[7].as_str()]);
+    let cursor = first["next_cursor"].as_str().expect("next cursor");
+
+    let second = fixture
+        .get_json(
+            &format!("/api/v1/voice-notes?q=apollo&search_mode=keyword&limit=1&cursor={cursor}"),
+            "alpha-secret",
+        )
+        .await;
+    assert_collection_ids(second, &[inserted_ids[6].as_str()]);
+}
+
+#[tokio::test]
 async fn repeated_singular_query_parameters_return_repeated_parameter_errors() {
     let fixture = VoiceNoteFixture::new().await;
 

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -288,11 +288,6 @@ Notes:
 - Without `q`, the endpoint returns voice-note history ordered
   newest-first by voice-note `created_at`, with descending `id` as
   the deterministic tiebreaker for cursor pagination.
-- Until search semantics land, a valid `q` returns an empty
-  `{items: [], next_cursor: null}` envelope after validating all
-  supplied search and filter parameters. Search results will use the
-  same `VoiceNote` resource shape, filters, and collection envelope
-  when the tracked search work lands.
 - If `q` is present and `search_mode` is omitted, the backend uses
   `hybrid`.
 - Search results are always voice-note resources.
@@ -725,9 +720,6 @@ Notes:
 - This endpoint applies the same collection semantics as
   `GET /api/v1/voice-notes` but with the session scope fixed by the
   path, including the same ordering and time-bound semantics.
-- Until search semantics land, a valid `q` returns an empty
-  `{items: [], next_cursor: null}` envelope after validating all
-  supplied search and filter parameters.
 - If `q` is present and `search_mode` is omitted, the backend uses
   `hybrid`.
 - Repeated `tag_id` filters combine by intersection.

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -290,6 +290,9 @@ Notes:
   the deterministic tiebreaker for cursor pagination.
 - If `q` is present and `search_mode` is omitted, the backend uses
   `hybrid`.
+- `q` is plain user text, not raw full-text-search syntax. Keyword
+  search treats extracted terms literally, including terms that look like
+  full-text operators or punctuation.
 - Search results are always voice-note resources.
 - Keyword search may match current voice-note text and historical
   `VoiceNoteVersion` text, but the returned item is always the parent
@@ -297,6 +300,9 @@ Notes:
 - Semantic and hybrid search use the current embedding. After a
   voice-note text edit, semantic freshness is eventual rather than
   immediate.
+- Semantic search is gated by non-blank `q` text, not by whether `q`
+  contains keyword-search terms. In hybrid mode, keyword and semantic
+  candidate generation apply those gates independently.
 - Search results are ordered by backend relevance score descending,
   then by voice-note `created_at` descending, then by descending `id`
   as the final deterministic tiebreaker for cursor pagination.

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -682,9 +682,10 @@ following are true:
 - Search behavior is explicit: history and search share one voice-
   note collection contract, omitted `search_mode` with `q` defaults
   to `hybrid`, repeated `tag_id` filters intersect, results are
-  voice-note-only, deferred search returns an empty collection rather
-  than history rows, and semantic search is eventually consistent
-  after edits.
+  voice-note-only, keyword search treats query text literally,
+  semantic search uses current embeddings, hybrid search combines
+  keyword and semantic ranking, and semantic search is eventually
+  consistent after edits.
 - Deletion semantics are explicit and match resource ownership
   expectations.
 - Audio retention semantics are explicit: chunks and composed audio

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -539,12 +539,16 @@ Semantics:
   surface with no semantic gain.
 - Search results are always `VoiceNote` resources. Jobs, sessions,
   tags, versions, and segments are not returned as search hits.
+- Search query text is plain user text, not raw full-text-search syntax.
+  Keyword search treats extracted terms literally.
 - Keyword search supports full-text matching over current voice-note
   text and may additionally match historical voice-note-version text,
   but results always resolve to the parent `VoiceNote`.
-- Semantic search uses the current voice-note embedding.
+- Semantic search uses the current voice-note embedding and is gated by
+  non-blank raw query text, not by keyword tokenization.
 - Hybrid search combines keyword and semantic ranking over the same
-  voice-note result set.
+  voice-note result set, with keyword and semantic candidate generation
+  gated independently.
 - When `q` is present and `search_mode` is omitted, the backend
   defaults to `hybrid`.
 - Search filters support tag, session, `recorded_at` time range, and

--- a/spec/backend-requirements.md
+++ b/spec/backend-requirements.md
@@ -537,10 +537,6 @@ Semantics:
   shape, filters, and pagination. This is an explicit `v0.1.0`
   governance decision to avoid duplicating voice-note collection
   surface with no semantic gain.
-- Until search semantics land, a valid `q` returns an empty
-  collection envelope after validating all supplied search and filter
-  parameters. This preserves the contract surface without presenting
-  history rows as search results.
 - Search results are always `VoiceNote` resources. Jobs, sessions,
   tags, versions, and segments are not returned as search hits.
 - Keyword search supports full-text matching over current voice-note


### PR DESCRIPTION
## Summary

- Implements ranked voice-note search for the shared global and session-scoped collection endpoints.
- Adds FTS5 keyword indexing over voice-note versions, current-embedding semantic ranking, and RRF hybrid ranking.
- Bounds keyword-only search pagination in storage so broad keyword queries return page-sized result sets without materializing every match.
- Removes the transitional empty-search documentation now that search semantics have landed.

## Changes

- Adds a SQLite FTS5 migration for `voice_note_versions` with insert/update/delete triggers so current and historical version text can produce parent `VoiceNote` results.
- Adds relevance cursors distinct from history cursors, plain-text query tokenization, blank-query empty results, and filter-aware search execution.
- Adds a distinct keyword-search cursor over FTS rank plus voice-note tiebreakers for keyword-only keyset pagination; hybrid search keeps the existing full-candidate RRF behavior.
- Adds integration coverage for keyword, semantic, hybrid, filtered search, relevance pagination, keyword-only page bounding, cursor-kind rejection, and edit-triggered embedding-regeneration visibility.

## GitHub Issue(s)

Closes #19

## Test plan

- `cargo test --manifest-path backend/Cargo.toml`
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
