### PR TITLE
chore(backend): add a repo-defined backend CI parity gate

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "backend/**"
+      - "scripts/backend-ci"
       - ".github/workflows/backend.yml"
   pull_request:
     branches: [main]
     paths:
       - "backend/**"
+      - "scripts/backend-ci"
       - ".github/workflows/backend.yml"
 
 jobs:
@@ -34,14 +36,5 @@ jobs:
           ffmpeg -version
           ffprobe -version
 
-      - name: Check formatting
-        working-directory: backend
-        run: cargo fmt --check
-
-      - name: Lint
-        working-directory: backend
-        run: cargo clippy -- -D warnings
-
-      - name: Test
-        working-directory: backend
-        run: cargo test
+      - name: Run backend CI parity gate
+        run: ./scripts/backend-ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a repo-defined backend CI-parity gate for contributor pre-review checks.
 - Add ranked voice-note search across keyword, semantic, and hybrid modes,
   including historical-version keyword matches, current-embedding semantic
   ranking, literal full-text query handling, independent semantic and keyword

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ and `client/`.
 Backend:
 
 ```sh
-cd backend
-cargo fmt --check
-cargo clippy -- -D warnings
-cargo test
+./scripts/backend-ci
 ```
 
 Frontend:

--- a/scripts/backend-ci
+++ b/scripts/backend-ci
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir/../backend"
+
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test


### PR DESCRIPTION
## Summary

- Adds one repo-defined backend CI-parity gate for contributor pre-review checks.
- Routes Backend CI through the same local gate so format, clippy, and tests cannot drift between local and GitHub runs.
- Documents the gate in the repository quality gates and records the contributor-facing change.

## Changes

- Adds `scripts/backend-ci` with fail-fast shell semantics and the backend sequence: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`.
- Updates Backend CI path filters and replaces duplicated cargo workflow steps with the shared gate.
- Updates README quality-gate guidance and the Unreleased changelog.

## GitHub Issue(s)

Closes #74

## Test plan

- `./scripts/backend-ci`
- `git diff --check`
- `bash -n scripts/backend-ci`
