### PR TITLE
fix(search): make semantic embedding lookup SQLite-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Add a repo-defined backend CI-parity gate for contributor pre-review checks.
+- Fix semantic and hybrid voice-note search over large filtered candidate sets
+  so embedding lookup no longer fails on SQLite host-parameter limits.
 - Add ranked voice-note search across keyword, semantic, and hybrid modes,
   including historical-version keyword matches, current-embedding semantic
   ranking, literal full-text query handling, independent semantic and keyword

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -17,6 +17,7 @@ use crate::settings::DEFAULT_TRANSCRIPTION_MODEL;
 
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
 const EMBEDDING_REGENERATION_MAX_RETRIES: i64 = 3;
+const TEMP_EMBEDDING_CANDIDATE_INSERT_CHUNK_SIZE: usize = 30_000;
 
 #[derive(Clone, Debug)]
 pub struct Storage {
@@ -2336,21 +2337,44 @@ impl Storage {
         if voice_note_ids.is_empty() {
             return Ok(HashMap::new());
         }
-        let mut query = QueryBuilder::new(
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
             r#"
-            SELECT voice_note_id, vector
-            FROM embeddings
-            WHERE api_key_id =
+            CREATE TEMP TABLE IF NOT EXISTS temp_voice_note_embedding_candidates (
+                voice_note_id TEXT PRIMARY KEY
+            )
             "#,
-        );
-        query.push_bind(api_key_id);
-        query.push(" AND voice_note_id IN (");
-        let mut separated = query.separated(", ");
-        for voice_note_id in voice_note_ids {
-            separated.push_bind(voice_note_id);
+        )
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM temp_voice_note_embedding_candidates")
+            .execute(&mut *tx)
+            .await?;
+        for chunk in voice_note_ids.chunks(TEMP_EMBEDDING_CANDIDATE_INSERT_CHUNK_SIZE) {
+            let mut query = QueryBuilder::new(
+                "INSERT OR IGNORE INTO temp_voice_note_embedding_candidates (voice_note_id) ",
+            );
+            query.push_values(chunk, |mut row, voice_note_id| {
+                row.push_bind(voice_note_id);
+            });
+            query.build().execute(&mut *tx).await?;
         }
-        separated.push_unseparated(")");
-        let rows = query.build().fetch_all(&self.pool).await?;
+        let rows = sqlx::query(
+            r#"
+            SELECT embeddings.voice_note_id, embeddings.vector
+            FROM embeddings
+            JOIN temp_voice_note_embedding_candidates
+                ON temp_voice_note_embedding_candidates.voice_note_id = embeddings.voice_note_id
+            WHERE embeddings.api_key_id = ?
+            "#,
+        )
+        .bind(api_key_id)
+        .fetch_all(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM temp_voice_note_embedding_candidates")
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
         let mut embeddings = HashMap::new();
         for row in rows {
             embeddings.insert(row.try_get("voice_note_id")?, row.try_get("vector")?);

--- a/backend/tests/storage.rs
+++ b/backend/tests/storage.rs
@@ -1240,6 +1240,67 @@ async fn completed_voice_notes_expose_current_version_ordered_segments_and_curre
 }
 
 #[tokio::test]
+async fn current_embedding_lookup_accepts_more_candidates_than_sqlite_variable_limit() {
+    let (_tempdir, storage) = storage().await;
+    insert_searchable_voice_note(
+        &storage,
+        "owner-a",
+        "voice-note-a",
+        "version-a",
+        "alpha note",
+        "2026-04-24T18:00:00.000000000Z",
+    )
+    .await;
+    insert_searchable_voice_note(
+        &storage,
+        "owner-b",
+        "voice-note-b",
+        "version-b",
+        "beta note",
+        "2026-04-24T18:00:00.000000000Z",
+    )
+    .await;
+    storage
+        .replace_current_embedding(
+            "owner-a",
+            "voice-note-a",
+            NewEmbedding {
+                model: "embedding-v1".to_owned(),
+                vector: vec![1, 2, 3],
+                created_at: datetime!(2026-04-24 18:00:31 UTC),
+            },
+        )
+        .await
+        .expect("insert alpha embedding");
+    storage
+        .replace_current_embedding(
+            "owner-b",
+            "voice-note-b",
+            NewEmbedding {
+                model: "embedding-v1".to_owned(),
+                vector: vec![4, 5, 6],
+                created_at: datetime!(2026-04-24 18:00:31 UTC),
+            },
+        )
+        .await
+        .expect("insert beta embedding");
+    let mut candidate_ids = (0..33_000)
+        .map(|index| format!("missing-{index}"))
+        .collect::<Vec<_>>();
+    candidate_ids.push("voice-note-a".to_owned());
+    candidate_ids.push("voice-note-b".to_owned());
+
+    let embeddings = storage
+        .get_current_embeddings_for_voice_notes("owner-a", &candidate_ids)
+        .await
+        .expect("embedding lookup above SQLite variable limit");
+
+    assert_eq!(embeddings.len(), 1);
+    assert_eq!(embeddings.get("voice-note-a"), Some(&vec![1, 2, 3]));
+    assert!(!embeddings.contains_key("voice-note-b"));
+}
+
+#[tokio::test]
 async fn voice_note_text_replacement_appends_one_current_version_without_mutating_segments() {
     let (_tempdir, storage) = storage().await;
     let job = created_job(&storage, "owner-a", "attempt-1").await;

--- a/backend/tests/voice_notes.rs
+++ b/backend/tests/voice_notes.rs
@@ -10,6 +10,7 @@ use oracy_backend::router::build_router;
 use oracy_backend::state::AppState;
 use oracy_backend::storage::{Storage, encode_embedding_vector};
 use serde_json::{Value, json};
+use sqlx::{QueryBuilder, Sqlite};
 use tempfile::TempDir;
 use time::macros::datetime;
 use tower::util::ServiceExt;
@@ -1391,6 +1392,32 @@ async fn hybrid_search_keeps_keyword_results_without_provider_when_semantic_cand
 }
 
 #[tokio::test]
+async fn semantic_and_hybrid_search_skip_provider_when_large_candidate_set_has_no_embeddings() {
+    let fixture = VoiceNoteFixture::new().await;
+    fixture
+        .insert_large_unembedded_search_candidate_set("alpha")
+        .await;
+
+    assert_empty_collection(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?q=query&search_mode=semantic",
+                "alpha-secret",
+            )
+            .await,
+    );
+    assert_collection_ids(
+        fixture
+            .get_json(
+                "/api/v1/voice-notes?q=apollo&search_mode=hybrid",
+                "alpha-secret",
+            )
+            .await,
+        &["bulk-note-00000"],
+    );
+}
+
+#[tokio::test]
 async fn search_filters_and_cursors_apply_to_relevance_ordered_results() {
     let fixture = VoiceNoteFixture::new().await;
     fixture.insert_session("alpha", SESSION_A).await;
@@ -1981,6 +2008,72 @@ impl VoiceNoteFixture {
         .execute(self.storage.pool())
         .await
         .expect("insert segment");
+    }
+
+    async fn insert_large_unembedded_search_candidate_set(&self, owner: &str) {
+        const CANDIDATE_COUNT: usize = 33_000;
+        const INSERT_CHUNK_SIZE: usize = 2_500;
+
+        for start in (0..CANDIDATE_COUNT).step_by(INSERT_CHUNK_SIZE) {
+            let end = (start + INSERT_CHUNK_SIZE).min(CANDIDATE_COUNT);
+            let mut query = QueryBuilder::<Sqlite>::new(
+                r#"
+                INSERT INTO voice_notes (
+                    id, api_key_id, audio_duration_seconds, audio_format, audio_size_bytes,
+                    language, model, processing_time_ms, cost_cents,
+                    created_at, recorded_at, session_id
+                )
+                "#,
+            );
+            query.push_values(start..end, |mut row, index| {
+                row.push_bind(format!("bulk-note-{index:05}"))
+                    .push_bind(owner)
+                    .push_bind(12.5_f64)
+                    .push_bind("wav")
+                    .push_bind(401_280_i64)
+                    .push_bind("en")
+                    .push_bind("gpt-4o-mini-transcribe")
+                    .push_bind(1_843_i64)
+                    .push_bind(Option::<i64>::None)
+                    .push_bind("2026-04-24T18:00:00.000000000Z")
+                    .push_bind("2026-04-24T17:59:00.000000000Z")
+                    .push_bind(Option::<&str>::None);
+            });
+            query
+                .build()
+                .execute(self.storage.pool())
+                .await
+                .expect("insert large voice note candidate set");
+        }
+
+        for start in (0..CANDIDATE_COUNT).step_by(INSERT_CHUNK_SIZE) {
+            let end = (start + INSERT_CHUNK_SIZE).min(CANDIDATE_COUNT);
+            let mut query = QueryBuilder::<Sqlite>::new(
+                r#"
+                INSERT INTO voice_note_versions (
+                    id, api_key_id, voice_note_id, version_number, text, created_at
+                )
+                "#,
+            );
+            query.push_values(start..end, |mut row, index| {
+                let text = if index == 0 {
+                    "apollo keyword match"
+                } else {
+                    "quiet note"
+                };
+                row.push_bind(format!("bulk-version-{index:05}"))
+                    .push_bind(owner)
+                    .push_bind(format!("bulk-note-{index:05}"))
+                    .push_bind(1_i64)
+                    .push_bind(text)
+                    .push_bind("2026-04-24T18:00:00.000000000Z");
+            });
+            query
+                .build()
+                .execute(self.storage.pool())
+                .await
+                .expect("insert large voice note version candidate set");
+        }
     }
 
     async fn insert_embedding(&self, owner: &str, voice_note_id: &str) {


### PR DESCRIPTION
## Summary

- Replaces large semantic embedding `IN (...)` lookups with a SQLite temp-table join so candidate sets can exceed SQLite host-parameter limits.
- Preserves authenticated API-key scoping while keeping the storage API and search ranking flow unchanged.
- Adds regression coverage for above-limit embedding lookup and semantic/hybrid provider-skip behavior without external OpenAI calls.

## Changes

- `Storage::get_current_embeddings_for_voice_notes` now creates and clears a connection-local temp candidate table, inserts candidate ids in bounded chunks, joins to `embeddings`, and cleans up before returning the pooled connection.
- Storage coverage exercises more than 32,766 candidate ids and verifies other-owner embeddings are not returned.
- Voice-note search coverage verifies semantic empty results and hybrid keyword preservation when a large filtered candidate set has no current embeddings.
- Changelog records the semantic/hybrid search reliability fix.

## GitHub Issue(s)

Closes #73

## Test plan

- `cargo test --manifest-path backend/Cargo.toml current_embedding_lookup_accepts_more_candidates_than_sqlite_variable_limit -- --nocapture`
- `cargo test --manifest-path backend/Cargo.toml semantic_and_hybrid_search_skip_provider_when_large_candidate_set_has_no_embeddings -- --nocapture`
- `scripts/backend-ci`
- `git diff --check`
