### PR TITLE
docs(spec): document VoiceNote.language nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Clarify that `VoiceNote.language` may be `null` in the API contract when no
+  language hint or detected language is available.
 - Refresh queued Flutter transcription idempotency keys when a saved language
   hint changes, preventing backend replay conflicts on the fresh submission.
 - Fix Flutter foreground transcription provenance so web recordings persist the

--- a/spec/api-contract.md
+++ b/spec/api-contract.md
@@ -907,7 +907,7 @@ Fields:
 - `audio_format`: accepted audio format
 - `audio_size_bytes`: composed audio size in bytes
 - `language`: the language hint or detected language for the
-  transcription
+  transcription, or `null` when unavailable
 - `model`: transcription engine identifier in use when the voice note
   was produced
 - `processing_time_ms`: total server-side processing time


### PR DESCRIPTION
## Summary

- Documents that `VoiceNote.language` may be `null` when no language hint or detected language is available.
- Preserves the non-null `"language": "en"` example while making the nullable wire case explicit.
- Records the API contract clarification in the Unreleased changelog.

## Changes

- Updated the `VoiceNote` field documentation in `spec/api-contract.md` to match shipped backend `Option<String>` serialization.
- Added a changelog entry for the API-visible documentation correction.

## GitHub Issue(s)

Closes #79

## Test plan

- `sed -n '880,914p' spec/api-contract.md`
- `sed -n '1,12p' CHANGELOG.md`
- `git diff --check`

## Documentation coverage

- Updated: `spec/api-contract.md`, `CHANGELOG.md`
- Verified accurate: no backend or client behavior changed; this PR corrects contract documentation to match existing backend behavior.
