### PR TITLE
feat(deploy): containerize backend with Quadlet template

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,9 @@
+.git
+.github
+backend/target
+client
+server
+src
+target
+*.swp
+*.tmp

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,12 +5,18 @@ on:
     branches: [main]
     paths:
       - "backend/**"
+      - "deploy/**"
+      - ".containerignore"
+      - "Containerfile"
       - "scripts/backend-ci"
       - ".github/workflows/backend.yml"
   pull_request:
     branches: [main]
     paths:
       - "backend/**"
+      - "deploy/**"
+      - ".containerignore"
+      - "Containerfile"
       - "scripts/backend-ci"
       - ".github/workflows/backend.yml"
 
@@ -32,9 +38,12 @@ jobs:
       - name: Install media tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg
+          sudo apt-get install -y ffmpeg podman
           ffmpeg -version
           ffprobe -version
 
       - name: Run backend CI parity gate
         run: ./scripts/backend-ci
+
+      - name: Build backend container image
+        run: podman build -t localhost/oracy:ci .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add backend container and Quadlet deployment templates, including
+  bind-backed persistence, example configuration, loopback-default operator
+  metrics publishing, and graceful SIGTERM shutdown.
 - Clarify that `VoiceNote.language` may be `null` in the API contract when no
   language hint or detected language is available.
 - Refresh queued Flutter transcription idempotency keys when a saved language

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,16 @@
+FROM docker.io/library/rust:1.95-bookworm AS builder
+
+WORKDIR /workspace
+COPY backend ./backend
+WORKDIR /workspace/backend
+RUN cargo build --release --locked --bin oracy-backend
+
+FROM docker.io/library/debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /workspace/backend/target/release/oracy-backend /usr/local/bin/oracy-backend
+
+ENTRYPOINT ["/usr/local/bin/oracy-backend"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ documentation drifts, the spec wins.
 
 - [`backend/`](backend/) — Rust service.
 - [`client/`](client/) — Flutter application.
+- [`deploy/`](deploy/) — backend container and Quadlet deployment templates.
 - [`spec/`](spec/) — API contract and backend requirements.
 
 ## Quality Gates

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,7 +20,7 @@ sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio
 subtle = "2.6"
 thiserror = "2.0"
 time = { version = "0.3.47", features = ["formatting", "macros", "parsing"] }
-tokio = { version = "1.48", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread"] }
+tokio = { version = "1.48", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync"] }
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,7 @@
 
 `backend/` contains the Rust service for Oracy's `v0.1.0` backend. The
 backend targets Linux deployment and assumes POSIX filesystem semantics.
+Container and Quadlet deployment artifacts live in [`../deploy/`](../deploy/).
 
 Run the service with `ORACY_CONFIG` set to a TOML configuration file and
 `OPENAI_API_KEY` set to a valid OpenAI credential:

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -82,18 +82,35 @@ async fn serve_public_and_operator(
     operator_listen_addr: SocketAddr,
     operator_app: axum::Router,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (shutdown_sender, _) = broadcast::channel(1);
-    tokio::spawn(wait_for_shutdown_signal(shutdown_sender.clone()));
+    let ShutdownBroadcast {
+        sender,
+        public_receiver,
+        operator_receiver,
+    } = shutdown_broadcast();
+    tokio::spawn(wait_for_shutdown_signal(sender));
 
     tokio::try_join!(
-        serve(listen_addr, app, shutdown_sender.subscribe()),
-        serve(
-            operator_listen_addr,
-            operator_app,
-            shutdown_sender.subscribe()
-        ),
+        serve(listen_addr, app, public_receiver),
+        serve(operator_listen_addr, operator_app, operator_receiver),
     )?;
     Ok(())
+}
+
+struct ShutdownBroadcast {
+    sender: broadcast::Sender<()>,
+    public_receiver: broadcast::Receiver<()>,
+    operator_receiver: broadcast::Receiver<()>,
+}
+
+fn shutdown_broadcast() -> ShutdownBroadcast {
+    let (sender, public_receiver) = broadcast::channel(1);
+    let operator_receiver = sender.subscribe();
+
+    ShutdownBroadcast {
+        sender,
+        public_receiver,
+        operator_receiver,
+    }
 }
 
 async fn serve(
@@ -130,4 +147,16 @@ fn init_tracing() {
         .with_target(false)
         .compact()
         .init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shutdown_broadcast;
+
+    #[test]
+    fn shutdown_broadcast_has_server_receivers_before_sender_can_be_spawned() {
+        let shutdown = shutdown_broadcast();
+
+        assert_eq!(shutdown.sender.receiver_count(), 2);
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -12,6 +12,7 @@ use oracy_backend::transcription_worker::{
     FfmpegAudioSlicer, FfprobeDurationProbe, OpenAiTranscriptionEngine, WorkerConfig,
     run_worker_loop,
 };
+use tokio::sync::broadcast;
 use tracing::error;
 
 #[tokio::main]
@@ -81,9 +82,16 @@ async fn serve_public_and_operator(
     operator_listen_addr: SocketAddr,
     operator_app: axum::Router,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let (shutdown_sender, _) = broadcast::channel(1);
+    tokio::spawn(wait_for_shutdown_signal(shutdown_sender.clone()));
+
     tokio::try_join!(
-        serve(listen_addr, app),
-        serve(operator_listen_addr, operator_app),
+        serve(listen_addr, app, shutdown_sender.subscribe()),
+        serve(
+            operator_listen_addr,
+            operator_app,
+            shutdown_sender.subscribe()
+        ),
     )?;
     Ok(())
 }
@@ -91,10 +99,27 @@ async fn serve_public_and_operator(
 async fn serve(
     listen_addr: SocketAddr,
     app: axum::Router,
+    mut shutdown: broadcast::Receiver<()>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(listen_addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let _ = shutdown.recv().await;
+        })
+        .await?;
     Ok(())
+}
+
+async fn wait_for_shutdown_signal(shutdown: broadcast::Sender<()>) {
+    let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .expect("install SIGTERM handler");
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = terminate.recv() => {}
+    }
+
+    let _ = shutdown.send(());
 }
 
 fn init_tracing() {

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -20,3 +20,13 @@ fn quadlet_template_mounts_host_bound_state_through_volume_template() {
     assert!(volume.contains("Type=none"));
     assert!(volume.contains("Options=bind"));
 }
+
+#[test]
+fn deployment_readme_manages_the_quadlet_generated_service_unit() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+
+    assert!(readme.contains("systemctl --user start oracy.service"));
+    assert!(readme.contains("systemctl --user status oracy.service"));
+    assert!(!readme.contains("systemctl --user start oracy.container"));
+    assert!(!readme.contains("systemctl --user enable oracy.service"));
+}

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -44,6 +44,14 @@ fn deployment_readme_manages_the_quadlet_generated_service_unit() {
     assert!(!readme.contains("systemctl --user enable oracy.service"));
 }
 
+#[test]
+fn deployment_readme_names_quadlet_rendered_filenames() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+
+    assert!(readme.contains("oracy.container"));
+    assert!(readme.contains("oracy-data.volume"));
+}
+
 fn quadlet_seconds(template: &str, key: &str) -> u64 {
     template
         .lines()

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -1,0 +1,22 @@
+#[test]
+fn quadlet_template_publishes_operator_metrics_on_loopback_by_default() {
+    let template = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
+        .expect("read container Quadlet template");
+
+    assert!(template.contains("PublishPort=@ORACY_PUBLIC_PUBLISH@"));
+    assert!(template.contains("PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090"));
+    assert!(!template.contains("PublishPort=0.0.0.0:@ORACY_OPERATOR_HOST_PORT@:9090"));
+}
+
+#[test]
+fn quadlet_template_mounts_host_bound_state_through_volume_template() {
+    let container = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
+        .expect("read container Quadlet template");
+    let volume = std::fs::read_to_string("../deploy/quadlet/oracy-data.volume.in")
+        .expect("read volume Quadlet template");
+
+    assert!(container.contains("Volume=oracy-data.volume:/var/lib/oracy:rw"));
+    assert!(volume.contains("Device=@ORACY_STATE_DIR@"));
+    assert!(volume.contains("Type=none"));
+    assert!(volume.contains("Options=bind"));
+}

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -22,6 +22,19 @@ fn quadlet_template_mounts_host_bound_state_through_volume_template() {
 }
 
 #[test]
+fn quadlet_template_grants_podman_a_full_thirty_second_stop_window() {
+    let template = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
+        .expect("read container Quadlet template");
+
+    let stop_timeout = quadlet_seconds(&template, "StopTimeout");
+    let timeout_stop_sec = quadlet_seconds(&template, "TimeoutStopSec");
+
+    assert_eq!(stop_timeout, 30);
+    assert_eq!(timeout_stop_sec, 40);
+    assert!(timeout_stop_sec > stop_timeout);
+}
+
+#[test]
 fn deployment_readme_manages_the_quadlet_generated_service_unit() {
     let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
 
@@ -29,4 +42,13 @@ fn deployment_readme_manages_the_quadlet_generated_service_unit() {
     assert!(readme.contains("systemctl --user status oracy.service"));
     assert!(!readme.contains("systemctl --user start oracy.container"));
     assert!(!readme.contains("systemctl --user enable oracy.service"));
+}
+
+fn quadlet_seconds(template: &str, key: &str) -> u64 {
+    template
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{key}=")))
+        .unwrap_or_else(|| panic!("{key} should be declared"))
+        .parse()
+        .unwrap_or_else(|_| panic!("{key} should be declared as plain seconds"))
 }

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -1093,6 +1093,8 @@ fn write_config_without_database_path(tempdir: &TempDir, contents: String) -> st
 }
 
 #[cfg(unix)]
+// FIXME(#86): This probe-then-bind helper has a TOCTOU port race; avoid new
+// process-level integration test reuse until the race-free strategy lands.
 fn unused_loopback_port() -> u16 {
     TcpListener::bind("127.0.0.1:0")
         .expect("bind unused port")

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -1,4 +1,14 @@
 use std::fs;
+#[cfg(unix)]
+use std::io::Read;
+#[cfg(unix)]
+use std::net::{SocketAddr, TcpListener, TcpStream};
+#[cfg(unix)]
+use std::process::{Child, Command, ExitStatus, Stdio};
+#[cfg(unix)]
+use std::thread;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 
 use oracy_backend::bootstrap::{BootstrapError, load_runtime_from_env, load_runtime_from_path};
 use tempfile::TempDir;
@@ -781,6 +791,81 @@ key = "key-one"
 }
 
 #[tokio::test]
+async fn startup_accepts_shipped_deployment_example_config_after_operator_paths_are_bound() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let state_dir = tempdir.path().join("state");
+    let accepted_audio_dir = state_dir.join("accepted-audio");
+    fs::create_dir_all(&accepted_audio_dir).expect("create accepted audio dir");
+
+    let example = fs::read_to_string("../deploy/examples/oracy.toml")
+        .expect("read shipped deployment example config");
+    let configured = example
+        .replace("0.0.0.0:8080", "127.0.0.1:0")
+        .replace("0.0.0.0:9090", "127.0.0.1:1")
+        .replace("/var/lib/oracy", &state_dir.display().to_string())
+        .replace("operator-issued-secret", "key-one");
+    let config_path = tempdir.path().join("oracy.toml");
+    fs::write(&config_path, configured).expect("write operator-bound config");
+
+    load_runtime_from_path(&config_path)
+        .await
+        .expect("deployment example should load once operator paths exist");
+}
+
+#[cfg(unix)]
+#[test]
+fn backend_process_exits_zero_after_sigterm() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let accepted_audio_dir = tempdir.path().join("accepted-audio");
+    fs::create_dir(&accepted_audio_dir).expect("create accepted audio dir");
+    let listen_port = unused_loopback_port();
+    let operator_port = unused_loopback_port();
+    assert_ne!(listen_port, operator_port);
+    let config_path = write_config(
+        &tempdir,
+        format!(
+            r#"
+listen_addr = "127.0.0.1:{listen_port}"
+operator_listen_addr = "127.0.0.1:{operator_port}"
+accepted_audio_dir = "{}"
+
+[[api_keys]]
+api_key_id = "alpha"
+key = "key-one"
+"#,
+            accepted_audio_dir.display()
+        ),
+    );
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_oracy-backend"))
+        .env("ORACY_CONFIG", &config_path)
+        .env("OPENAI_API_KEY", "test-openai-key")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn backend");
+
+    wait_for_tcp_listener(&mut child, listen_port);
+    wait_for_tcp_listener(&mut child, operator_port);
+
+    let signal_status = Command::new("kill")
+        .arg("-TERM")
+        .arg(child.id().to_string())
+        .status()
+        .expect("send SIGTERM");
+    assert!(signal_status.success(), "kill -TERM should succeed");
+
+    let status = wait_for_child_exit(&mut child, Duration::from_secs(5)).unwrap_or_else(|| {
+        panic_with_child_output(&mut child, "backend did not exit after SIGTERM")
+    });
+
+    assert!(
+        status.success(),
+        "SIGTERM should trigger graceful shutdown with exit code 0, got {status}"
+    );
+}
+
+#[tokio::test]
 async fn startup_accepts_relative_accepted_audio_dir_resolved_against_config() {
     let tempdir = TempDir::new().expect("tempdir");
     let expected_dir = tempdir.path().join("accepted-audio");
@@ -1005,4 +1090,69 @@ fn write_config_without_database_path(tempdir: &TempDir, contents: String) -> st
     let path = tempdir.path().join("oracy.toml");
     fs::write(&path, contents.trim_start()).expect("write config");
     path
+}
+
+#[cfg(unix)]
+fn unused_loopback_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind unused port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+#[cfg(unix)]
+fn wait_for_tcp_listener(child: &mut Child, port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let addr: SocketAddr = format!("127.0.0.1:{port}")
+        .parse()
+        .expect("loopback socket address");
+
+    loop {
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
+            return;
+        }
+        if let Some(status) = child.try_wait().expect("poll child") {
+            panic_with_child_output(
+                child,
+                &format!("backend exited before listener {addr} became ready: {status}"),
+            );
+        }
+        if Instant::now() >= deadline {
+            panic_with_child_output(
+                child,
+                &format!("backend listener {addr} did not become ready"),
+            );
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> Option<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("poll child") {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(unix)]
+fn panic_with_child_output(child: &mut Child, message: &str) -> ! {
+    let _ = child.kill();
+    let _ = child.wait();
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    panic!("{message}\nstdout:\n{stdout}\nstderr:\n{stderr}");
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,90 @@
+# Oracy Backend Deployment
+
+This directory contains generic deployment artifacts for the Rust backend.
+The repository owns the image build, service shape, and persistence template;
+operators own concrete host bindings such as paths, ports, permissions, image
+tags, and secrets.
+
+## Build The Image
+
+From the repository root:
+
+```sh
+podman build -t localhost/oracy:0.1.0 .
+```
+
+The image runs `oracy-backend` as PID 1 and includes `ffmpeg` and `ffprobe`.
+Runtime state and secrets are not baked into the image.
+
+## Prepare Host State
+
+Choose a persistent host directory for Oracy state, then create the accepted
+audio directory inside it:
+
+```sh
+mkdir -p /var/lib/oracy/accepted-audio
+```
+
+The backend process inside the container must be able to create and update
+`/var/lib/oracy/oracy.sqlite` and files below `/var/lib/oracy/accepted-audio`.
+On rootless Podman deployments, verify the host ownership and UID/GID mapping
+used by the service account before starting the unit.
+
+## Configure The Backend
+
+Use [`examples/oracy.toml`](examples/oracy.toml) as the starting point for the
+container-mounted config. The default container-internal listeners are:
+
+- `0.0.0.0:8080` for the public API.
+- `0.0.0.0:9090` for operator metrics, published to host loopback by the
+  Quadlet template.
+
+Put the OpenAI credential in an environment file readable by the service
+account, for example:
+
+```sh
+install -m 0600 /dev/null /var/lib/oracy/oracy.env
+printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" > /var/lib/oracy/oracy.env
+```
+
+## Install Quadlets
+
+Copy the templates from [`quadlet/`](quadlet/) into
+`~/.config/containers/systemd/` for the service account and replace the
+`@...@` placeholders with host values.
+
+The operator metrics publish line intentionally defaults to host loopback:
+
+```ini
+PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090
+```
+
+Keep that loopback binding unless another protected operator network surface
+is intentionally provided.
+
+After templating:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user start oracy.container
+systemctl --user status oracy.service
+```
+
+For boot persistence under user-scope systemd, enable lingering for the service
+account through the host provisioning mechanism and enable the generated unit:
+
+```sh
+systemctl --user enable oracy.service
+```
+
+## Operator-Owned Values
+
+- `@ORACY_IMAGE@`: the locally built image tag, such as `localhost/oracy:0.1.0`.
+- `@ORACY_ENV_FILE@`: host path to an environment file containing
+  `OPENAI_API_KEY`.
+- `@ORACY_CONFIG_PATH@`: host path to the backend TOML configuration.
+- `@ORACY_STATE_DIR@`: host directory that persists SQLite and accepted audio.
+- `@ORACY_PUBLIC_PUBLISH@`: public API publish rule, such as
+  `127.0.0.1:8080:8080` or `0.0.0.0:8080:8080`.
+- `@ORACY_OPERATOR_HOST_PORT@`: host loopback port for metrics, normally
+  `9090`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -66,16 +66,14 @@ After templating:
 
 ```sh
 systemctl --user daemon-reload
-systemctl --user start oracy.container
+systemctl --user start oracy.service
 systemctl --user status oracy.service
 ```
 
-For boot persistence under user-scope systemd, enable lingering for the service
-account through the host provisioning mechanism and enable the generated unit:
-
-```sh
-systemctl --user enable oracy.service
-```
+The Quadlet template's `[Install]` relationship makes the generated service
+part of the user default target at `daemon-reload` time. For boot persistence
+under user-scope systemd, enable lingering for the service account through the
+host provisioning mechanism.
 
 ## Operator-Owned Values
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -49,9 +49,12 @@ printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" > /var/lib/oracy/oracy.env
 
 ## Install Quadlets
 
-Copy the templates from [`quadlet/`](quadlet/) into
-`~/.config/containers/systemd/` for the service account and replace the
-`@...@` placeholders with host values.
+Render the templates from [`quadlet/`](quadlet/) into
+`~/.config/containers/systemd/` for the service account, replacing the
+`@...@` placeholders with host values and removing the `.in` suffix:
+
+- `quadlet/oracy.container.in` renders to `oracy.container`.
+- `quadlet/oracy-data.volume.in` renders to `oracy-data.volume`.
 
 The operator metrics publish line intentionally defaults to host loopback:
 

--- a/deploy/examples/oracy.toml
+++ b/deploy/examples/oracy.toml
@@ -1,0 +1,8 @@
+listen_addr = "0.0.0.0:8080"
+operator_listen_addr = "0.0.0.0:9090"
+accepted_audio_dir = "/var/lib/oracy/accepted-audio"
+database_path = "/var/lib/oracy/oracy.sqlite"
+
+[[api_keys]]
+api_key_id = "operator-issued-id"
+key = "operator-issued-secret"

--- a/deploy/quadlet/oracy-data.volume.in
+++ b/deploy/quadlet/oracy-data.volume.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Oracy backend persistent state
+
+[Volume]
+VolumeName=oracy-data
+Device=@ORACY_STATE_DIR@
+Type=none
+Options=bind

--- a/deploy/quadlet/oracy.container.in
+++ b/deploy/quadlet/oracy.container.in
@@ -11,11 +11,12 @@ Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro
 Volume=oracy-data.volume:/var/lib/oracy:rw
 PublishPort=@ORACY_PUBLIC_PUBLISH@
 PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090
+StopTimeout=30
 
 [Service]
 Restart=on-failure
 RestartSec=5
-TimeoutStopSec=30
+TimeoutStopSec=40
 
 [Install]
 WantedBy=default.target

--- a/deploy/quadlet/oracy.container.in
+++ b/deploy/quadlet/oracy.container.in
@@ -1,0 +1,21 @@
+[Unit]
+Description=Oracy backend
+
+[Container]
+Image=@ORACY_IMAGE@
+Pull=never
+ContainerName=oracy
+Environment=ORACY_CONFIG=/etc/oracy/oracy.toml
+EnvironmentFile=@ORACY_ENV_FILE@
+Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro
+Volume=oracy-data.volume:/var/lib/oracy:rw
+PublishPort=@ORACY_PUBLIC_PUBLISH@
+PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090
+
+[Service]
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+
+[Install]
+WantedBy=default.target

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -13,6 +13,10 @@ durability commitments under nominal load.
 behavior. This document describes the infrastructure responsibilities behind
 those settings.
 
+The generic container and Quadlet artifacts that implement this contract ship
+in [`deploy/`](../deploy/). Those artifacts are templates: the repository owns
+the build and service shape, while operators provide concrete host bindings.
+
 ## Audience
 
 This document is for operators standing up Oracy on POSIX Linux


### PR DESCRIPTION
## Summary

- Containerizes the Rust backend with a locked multi-stage build and a slim runtime image that includes `ffmpeg` and `ffprobe`.
- Ships generic Podman Quadlet templates, bind-backed persistence, and an example TOML config so operators can supply host bindings without changing source-owned artifacts.
- Adds graceful SIGTERM/CTRL-C shutdown for the backend listeners so the container stops cleanly under service manager control.

## Changes

- Adds repo-root `Containerfile` and `.containerignore` for `podman build -t localhost/oracy:<tag> .`.
- Adds `deploy/` documentation, example config, and `.container.in` / `.volume.in` templates with loopback-default operator metrics publishing.
- Extends backend tests for SIGTERM exit behavior, shipped deployment config loading, and Quadlet persistence/operator-listener defaults.
- Updates backend CI path filters to include deployment artifacts and adds an image build step.

## GitHub Issue(s)

Closes #84

## Test plan

- `./scripts/backend-ci`
- `cargo test --test deployment_artifacts`
- `podman build -t localhost/oracy:dev .`
- `podman run --rm --entrypoint ffmpeg localhost/oracy:dev -version`
- `podman run --rm --entrypoint ffprobe localhost/oracy:dev -version`
- Container restart-survival smoke: first container created SQLite state and an accepted-audio marker through the bind mount, second container started with the same mount and verified both persisted.
- `git diff --check`
