### PR TITLE
fix(deploy): make Quadlet mounts work under SELinux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix the backend Quadlet template's SELinux handling so dedicated
+  config and state mounts work under default confined Podman on
+  SELinux-enforcing hosts.
 - Add backend container and Quadlet deployment templates, including
   bind-backed persistence, example configuration, loopback-default operator
   metrics publishing, and graceful SIGTERM shutdown.

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -62,6 +62,19 @@ fn deployment_readme_names_quadlet_rendered_filenames() {
     assert!(readme.contains("oracy-data.volume"));
 }
 
+#[test]
+fn deployment_contract_documents_selinux_labeling_for_all_state_storage() {
+    let contract =
+        std::fs::read_to_string("../spec/deployment.md").expect("read deployment contract");
+    let accepted_audio = markdown_section(&contract, "Accepted Audio Directory");
+    let sqlite_database = markdown_section(&contract, "SQLite Database File");
+
+    assert!(accepted_audio.contains("On SELinux-enforcing hosts"));
+    assert!(sqlite_database.contains("On SELinux-enforcing hosts"));
+    assert!(sqlite_database.contains("parent directory"));
+    assert!(sqlite_database.contains("SQLite sidecar files"));
+}
+
 fn quadlet_seconds(template: &str, key: &str) -> u64 {
     template
         .lines()
@@ -69,4 +82,17 @@ fn quadlet_seconds(template: &str, key: &str) -> u64 {
         .unwrap_or_else(|| panic!("{key} should be declared"))
         .parse()
         .unwrap_or_else(|_| panic!("{key} should be declared as plain seconds"))
+}
+
+fn markdown_section<'a>(document: &'a str, heading: &str) -> &'a str {
+    let start_marker = format!("## {heading}");
+    let start = document
+        .find(&start_marker)
+        .unwrap_or_else(|| panic!("{heading} section should exist"));
+    let after_heading = start + start_marker.len();
+    let end = document[after_heading..]
+        .find("\n## ")
+        .map_or(document.len(), |offset| after_heading + offset);
+
+    &document[start..end]
 }

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -22,6 +22,16 @@ fn quadlet_template_mounts_host_bound_state_through_volume_template() {
 }
 
 #[test]
+fn quadlet_template_privately_relabels_selinux_visible_mounts() {
+    let template = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
+        .expect("read container Quadlet template");
+
+    assert!(template.contains("Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro,Z"));
+    assert!(template.contains("Volume=oracy-data.volume:/var/lib/oracy:rw,Z"));
+    assert!(!template.contains("SecurityLabelDisable=true"));
+}
+
+#[test]
 fn quadlet_template_grants_podman_a_full_thirty_second_stop_window() {
     let template = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
         .expect("read container Quadlet template");

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,6 +30,11 @@ The backend process inside the container must be able to create and update
 On rootless Podman deployments, verify the host ownership and UID/GID mapping
 used by the service account before starting the unit.
 
+The shipped Quadlet template privately relabels the mounted config file and
+state volume for confined Podman containers on SELinux-enforcing hosts. Use
+host paths dedicated to this Oracy service; do not share those paths with other
+containers.
+
 ## Configure The Backend
 
 Use [`examples/oracy.toml`](examples/oracy.toml) as the starting point for the

--- a/deploy/quadlet/oracy.container.in
+++ b/deploy/quadlet/oracy.container.in
@@ -7,8 +7,8 @@ Pull=never
 ContainerName=oracy
 Environment=ORACY_CONFIG=/etc/oracy/oracy.toml
 EnvironmentFile=@ORACY_ENV_FILE@
-Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro
-Volume=oracy-data.volume:/var/lib/oracy:rw
+Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro,Z
+Volume=oracy-data.volume:/var/lib/oracy:rw,Z
 PublishPort=@ORACY_PUBLIC_PUBLISH@
 PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090
 StopTimeout=30

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -46,6 +46,9 @@ Operators must provide a directory with these properties:
 - Contents survive backend restarts.
 - Contents are on a volume that persists across container or host reboots in
   the operator's deployment.
+- On SELinux-enforcing hosts, the directory is labeled so a confined Podman
+  container can read and write it. The shipped Quadlet template satisfies this
+  for dedicated Oracy state paths through private Podman relabeling.
 
 Capacity must cover active chunked-submission state. The directory holds chunks
 while jobs are in `accepting_chunks`, plus composed audio while jobs are in

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -71,6 +71,10 @@ Operators must provide a database path with these properties:
 - The database file and its WAL and SHM siblings survive backend restarts.
 - The database file and its WAL and SHM siblings are on a volume that persists
   across container or host reboots in the operator's deployment.
+- On SELinux-enforcing hosts, the parent directory is labeled so a confined
+  Podman container can create and write the database file and SQLite sidecar
+  files. The shipped Quadlet template satisfies this for dedicated Oracy state
+  paths through private Podman relabeling.
 
 SQLite relies on filesystem support for `fsync` and atomic rename for
 crash-safety. Filesystems or mounts that weaken those semantics do not satisfy


### PR DESCRIPTION
## Summary

- Adds private SELinux relabeling to the shipped Quadlet config and state mounts so default confined Podman can read/write the operator-provided paths.
- Documents that dedicated Oracy state paths satisfy SELinux labeling for both accepted audio storage and the SQLite database parent directory.
- Adds deployment artifact regression coverage for the SELinux mount invariant and class-complete storage-path contract coverage while preserving default confinement.

## Changes

- `deploy/quadlet/oracy.container.in` now uses `ro,Z` for the mounted config file and `rw,Z` for the bind-backed state volume.
- `deploy/README.md`, `spec/deployment.md`, and `CHANGELOG.md` record the SELinux-enforcing host behavior and dedicated-path expectation.
- `spec/deployment.md` now mirrors the SELinux labeling requirement in the SQLite database section for WAL/SHM sidecar creation under the database parent directory.
- `backend/tests/deployment_artifacts.rs` asserts the relabel options, rejects `SecurityLabelDisable=true`, and verifies both operator-provided storage sections document SELinux labeling obligations.

## GitHub Issue(s)

Closes #87

## Test plan

- `cargo test --test deployment_artifacts`
- `cargo fmt --check`
- `git diff --check`
- Quadlet generator dry-run confirms rendered `podman run` includes `-v ...:ro,Z` and `-v ...:rw,Z`.
- `./scripts/backend-ci`
