### PR TITLE
fix(deploy): document reverse-proxy networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Document supported reverse-proxy networking patterns for backend Quadlet
-  deployments, including shared container networks and firewall requirements
-  for non-loopback public API publishes.
+  deployments, including shared container networks, Linux Docker host-gateway
+  setup, and firewall requirements for non-loopback public API publishes.
 - Fix the backend Quadlet template's SELinux handling so dedicated
   config and state mounts work under default confined Podman on
   SELinux-enforcing hosts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Document supported reverse-proxy networking patterns for backend Quadlet
+  deployments, including shared container networks and firewall requirements
+  for non-loopback public API publishes.
 - Fix the backend Quadlet template's SELinux handling so dedicated
   config and state mounts work under default confined Podman on
   SELinux-enforcing hosts.

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -72,6 +72,10 @@ fn deployment_readme_documents_reverse_proxy_networking_patterns() {
     assert!(readme.contains("remove the public `PublishPort=@ORACY_PUBLIC_PUBLISH@` line"));
     assert!(readme.contains("host.containers.internal"));
     assert!(readme.contains("host.docker.internal"));
+    assert!(readme.contains("--add-host=host.docker.internal:host-gateway"));
+    assert!(readme.contains("extra_hosts"));
+    assert!(readme.contains("host.docker.internal:host-gateway"));
+    assert!(readme.contains("host-gateway"));
     assert!(readme.contains("0.0.0.0:8080:8080"));
     assert!(readme.contains("is reachability, not protection"));
     assert!(readme.contains("verify that the port is blocked from untrusted networks"));

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -63,6 +63,34 @@ fn deployment_readme_names_quadlet_rendered_filenames() {
 }
 
 #[test]
+fn deployment_readme_documents_reverse_proxy_networking_patterns() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+
+    assert!(readme.contains("127.0.0.1:8080:8080"));
+    assert!(readme.contains("Network=oracy-proxy.network"));
+    assert!(readme.contains("http://oracy:8080"));
+    assert!(readme.contains("remove the public `PublishPort=@ORACY_PUBLIC_PUBLISH@` line"));
+    assert!(readme.contains("host.containers.internal"));
+    assert!(readme.contains("host.docker.internal"));
+    assert!(readme.contains("0.0.0.0:8080:8080"));
+    assert!(readme.contains("is reachability, not protection"));
+    assert!(readme.contains("verify that the port is blocked from untrusted networks"));
+}
+
+#[test]
+fn deployment_contract_supports_common_reverse_proxy_topologies() {
+    let contract =
+        std::fs::read_to_string("../spec/deployment.md").expect("read deployment contract");
+    let public_api = markdown_section(&contract, "Public API Reverse Proxy");
+
+    assert!(public_api.contains("host-system reverse proxy"));
+    assert!(public_api.contains("shared container network"));
+    assert!(public_api.contains("isolated container reverse proxy"));
+    assert!(public_api.contains("operator-managed firewall"));
+    assert!(public_api.contains("non-loopback binding is reachability, not protection"));
+}
+
+#[test]
 fn deployment_contract_documents_selinux_labeling_for_all_state_storage() {
     let contract =
         std::fs::read_to_string("../spec/deployment.md").expect("read deployment contract");

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -69,7 +69,9 @@ fn deployment_readme_documents_reverse_proxy_networking_patterns() {
     assert!(readme.contains("127.0.0.1:8080:8080"));
     assert!(readme.contains("Network=oracy-proxy.network"));
     assert!(readme.contains("http://oracy:8080"));
-    assert!(readme.contains("remove the public `PublishPort=@ORACY_PUBLIC_PUBLISH@` line"));
+    assert!(readme.contains("When\n  rendering `oracy.container`"));
+    assert!(readme.contains("leave the public `PublishPort=` directive out"));
+    assert!(!readme.contains("remove the public `PublishPort=@ORACY_PUBLIC_PUBLISH@` line"));
     assert!(readme.contains("host.containers.internal"));
     assert!(readme.contains("host.docker.internal"));
     assert!(readme.contains("--add-host=host.docker.internal:host-gateway"));

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -84,6 +84,15 @@ fn deployment_readme_documents_reverse_proxy_networking_patterns() {
 }
 
 #[test]
+fn deployment_readme_keeps_backend_deployment_guidance_linux_scoped() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+
+    assert!(!readme.contains("Docker Desktop"));
+    assert!(!readme.contains("macOS"));
+    assert!(!readme.contains("Windows"));
+}
+
+#[test]
 fn deployment_contract_supports_common_reverse_proxy_topologies() {
     let contract =
         std::fs::read_to_string("../spec/deployment.md").expect("read deployment contract");

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,6 +61,43 @@ Render the templates from [`quadlet/`](quadlet/) into
 - `quadlet/oracy.container.in` renders to `oracy.container`.
 - `quadlet/oracy-data.volume.in` renders to `oracy-data.volume`.
 
+Choose the public API network surface for the reverse proxy that will receive
+client traffic:
+
+- Host-system reverse proxy: keep Oracy published only to host loopback, for
+  example `@ORACY_PUBLIC_PUBLISH@=127.0.0.1:8080:8080`, and proxy to
+  `http://127.0.0.1:8080`.
+- Shared container network: if the reverse proxy can join the same Docker or
+  Podman network as Oracy, do not publish the public API on the host. After
+  rendering `oracy.container`, remove the public `PublishPort=@ORACY_PUBLIC_PUBLISH@` line
+  and add a shared network, for example:
+
+  ```ini
+  Network=oracy-proxy.network
+  NetworkAlias=oracy
+  ```
+
+  For Podman Quadlets, provide the matching operator-owned
+  `oracy-proxy.network` unit or replace the example with your existing network.
+  Put the proxy on the same network and proxy to `http://oracy:8080`. Docker
+  Compose services in the same project use shared service DNS by default; use
+  the Compose service name or network alias `oracy` for the backend service.
+- Isolated container reverse proxy: if the proxy cannot share Oracy's
+  container network, publish Oracy on a host address reachable from that proxy,
+  for example `@ORACY_PUBLIC_PUBLISH@=0.0.0.0:8080:8080`, and proxy through the
+  runtime's host gateway name such as `host.containers.internal` for Podman or
+  `host.docker.internal` for Docker.
+
+  A non-loopback publish such as `0.0.0.0:8080:8080` is reachability, not protection.
+  Use it only with operator-managed firewall rules or equivalent host network
+  policy, and verify that the port is blocked from untrusted networks before
+  treating the binding as protected. Prefer binding to a specific private host
+  interface over `0.0.0.0` when the deployment has one.
+
+A proxy running in an isolated container cannot reach an Oracy port published
+only on host loopback unless the proxy shares the host network namespace. In
+that case, use the host-system pattern intentionally.
+
 The operator metrics publish line intentionally defaults to host loopback:
 
 ```ini
@@ -91,6 +128,7 @@ host provisioning mechanism.
 - `@ORACY_CONFIG_PATH@`: host path to the backend TOML configuration.
 - `@ORACY_STATE_DIR@`: host directory that persists SQLite and accepted audio.
 - `@ORACY_PUBLIC_PUBLISH@`: public API publish rule, such as
-  `127.0.0.1:8080:8080` or `0.0.0.0:8080:8080`.
+  `127.0.0.1:8080:8080` or `0.0.0.0:8080:8080`. Omit the rendered public
+  publish line for shared container-network proxy deployments.
 - `@ORACY_OPERATOR_HOST_PORT@`: host loopback port for metrics, normally
   `9090`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,10 +88,8 @@ client traffic:
   runtime's host gateway name such as `host.containers.internal` for Podman or
   `host.docker.internal` for Docker.
 
-  Docker Desktop provides `host.docker.internal` automatically on macOS and
-  Windows. Docker on Linux does not; add the host gateway name to the isolated
-  proxy container with `--add-host=host.docker.internal:host-gateway` or, in
-  Compose:
+  For Docker on Linux, add the host gateway name to the isolated proxy
+  container with `--add-host=host.docker.internal:host-gateway` or, in Compose:
 
   ```yaml
   extra_hosts:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -68,8 +68,8 @@ client traffic:
   example `@ORACY_PUBLIC_PUBLISH@=127.0.0.1:8080:8080`, and proxy to
   `http://127.0.0.1:8080`.
 - Shared container network: if the reverse proxy can join the same Docker or
-  Podman network as Oracy, do not publish the public API on the host. After
-  rendering `oracy.container`, remove the public `PublishPort=@ORACY_PUBLIC_PUBLISH@` line
+  Podman network as Oracy, do not publish the public API on the host. When
+  rendering `oracy.container`, leave the public `PublishPort=` directive out
   and add a shared network, for example:
 
   ```ini

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,6 +88,19 @@ client traffic:
   runtime's host gateway name such as `host.containers.internal` for Podman or
   `host.docker.internal` for Docker.
 
+  Docker Desktop provides `host.docker.internal` automatically on macOS and
+  Windows. Docker on Linux does not; add the host gateway name to the isolated
+  proxy container with `--add-host=host.docker.internal:host-gateway` or, in
+  Compose:
+
+  ```yaml
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  ```
+
+  Podman provides `host.containers.internal` automatically and does not need
+  this Docker-specific mapping.
+
   A non-loopback publish such as `0.0.0.0:8080:8080` is reachability, not protection.
   Use it only with operator-managed firewall rules or equivalent host network
   policy, and verify that the port is blocked from untrusted networks before

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -117,6 +117,32 @@ splitting before OpenAI transcription requests. Operators must provide
 `ffmpeg` and `ffprobe` on `PATH` for the backend process. Startup fails if
 either tool is missing or cannot execute.
 
+## Public API Reverse Proxy
+
+The backend's public API listener is intended to sit behind an
+operator-managed reverse proxy for internet-facing deployments. Operators must
+place the public listener on a network surface reachable by that proxy and not
+broader than the deployment's access-control boundary.
+
+Supported `v0.1.0` reverse-proxy topologies are:
+
+- A host-system reverse proxy reaches Oracy through a host-loopback publish.
+- A shared container network lets the proxy reach Oracy by container DNS, with
+  no host public API publish required.
+- An isolated container reverse proxy reaches Oracy through the container
+  runtime's host gateway and a non-loopback host publish.
+
+Loopback binding is the preferred default when the proxy runs on the host or
+shares the host network namespace. A proxy running in an isolated container
+cannot reach a host-loopback-only publish by using the host gateway; the backend
+must instead share the proxy's container network or publish on a host address
+reachable from that container.
+
+For isolated proxy containers, non-loopback binding is reachability, not protection.
+Operators must provide an operator-managed firewall, host network policy, or
+equivalent control and verify that the published port is blocked from untrusted
+networks.
+
 ## Operator Metrics
 
 The backend exposes Prometheus-compatible metrics from an operator listener


### PR DESCRIPTION
## Summary

- Documents the supported reverse-proxy networking patterns for backend Quadlet deployments.
- Adds shared container-network guidance so containerized proxies can reach Oracy without publishing the backend port on the host.
- Makes non-loopback public API publishes explicit about operator-managed firewall protection and verification.

## Changes

- `deploy/README.md` now covers host-system proxy, shared container network, and isolated container host-gateway topologies.
- `spec/deployment.md` now records the public API reverse-proxy deployment contract and loopback limitation for isolated proxy containers.
- `backend/tests/deployment_artifacts.rs` asserts the README and contract keep documenting the chosen topology invariants.
- `CHANGELOG.md` records the operator-facing deployment documentation fix.

## GitHub Issue(s)

Closes #89

## Test plan

- `cargo test --test deployment_artifacts`
- `cargo fmt --check`
- `git diff --check`
- `./scripts/backend-ci`
