### PR TITLE
fix(client): make API base URL configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Make the Flutter client's API base URL configurable through
   `ORACY_API_BASE_URL` build defaults and a runtime Settings override, with
-  credential clearing when the effective server URL changes.
+  credential clearing when the effective server URL changes and origin-only
+  server URL validation that rejects path prefixes already supplied by client
+  request paths.
 - Document supported reverse-proxy networking patterns for backend Quadlet
   deployments, including shared container networks, Linux Docker host-gateway
   setup, and firewall requirements for non-loopback public API publishes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Make the Flutter client's API base URL configurable through
+  `ORACY_API_BASE_URL` build defaults and a runtime Settings override, with
+  credential clearing when the effective server URL changes.
 - Document supported reverse-proxy networking patterns for backend Quadlet
   deployments, including shared container networks, Linux Docker host-gateway
   setup, and firewall requirements for non-loopback public API publishes.

--- a/client/README.md
+++ b/client/README.md
@@ -9,3 +9,5 @@ flutter build apk --dart-define=ORACY_API_BASE_URL=https://staging.oracy.app
 ```
 
 Users and developers can also change the server URL at runtime from Settings. Runtime configuration wins over the build-time default until the user resets it. Changing the effective server URL clears the stored API key so credentials for one backend are not sent to another backend.
+
+Configured server URLs must be origin-only values such as `https://staging.oracy.app`. Do not include the API path prefix; client requests already target `/api/v1`.

--- a/client/README.md
+++ b/client/README.md
@@ -1,1 +1,11 @@
 `client/` contains Oracy's Flutter application. Build the app with `cd client && flutter pub get`. For v0.1.0, the client ships on Android and web only; Linux, Windows, macOS, and iOS are explicit non-scope targets. This code is imported as a snapshot from the Python-era repository and is being adapted to the contract in [`spec/api-contract.md`](../spec/api-contract.md): history/search reads use the v0.1.0 voice-note collection contract, and upload submission uses the v0.1.0 chunked transcription-job protocol. The checked-in web runtime assets such as `web/drift_worker.dart.js`, `web/drift_worker.dart.js.map`, and `web/sqlite3.wasm` are intentional generated or vendored snapshot artifacts and should not be hand-edited.
+
+## API server URL
+
+The shipped default API server is `https://api.oracy.app`. Operators distributing a client for a different backend can change the install's default at build time:
+
+```sh
+flutter build apk --dart-define=ORACY_API_BASE_URL=https://staging.oracy.app
+```
+
+Users and developers can also change the server URL at runtime from Settings. Runtime configuration wins over the build-time default until the user resets it. Changing the effective server URL clears the stored API key so credentials for one backend are not sent to another backend.

--- a/client/lib/screens/settings_screen.dart
+++ b/client/lib/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/services/api_client.dart';
 import 'package:oracy/services/preferences_service.dart';
+import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/services/upload_queue_service.dart';
 
 /// Provider for the current API key value (for display purposes).
@@ -27,15 +28,25 @@ class SettingsScreen extends ConsumerStatefulWidget {
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   final _apiKeyController = TextEditingController();
+  final _serverUrlController = TextEditingController();
   final _formKey = GlobalKey<FormState>();
+  final _serverFormKey = GlobalKey<FormState>();
   bool _isLoading = false;
   bool _obscureApiKey = true;
   bool _hasExistingKey = false;
+  bool _hasServerOverride = false;
 
   @override
   void initState() {
     super.initState();
+    _loadServerUrl();
     _loadExistingKey();
+  }
+
+  void _loadServerUrl() {
+    final preferences = ref.read(preferencesServiceProvider);
+    _serverUrlController.text = preferences.apiBaseUrl;
+    _hasServerOverride = preferences.apiBaseUrlOverride != null;
   }
 
   Future<void> _loadExistingKey() async {
@@ -51,6 +62,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   void dispose() {
     _apiKeyController.dispose();
+    _serverUrlController.dispose();
     super.dispose();
   }
 
@@ -145,6 +157,115 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
         );
       }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  String? _validateServerUrl(String? value) {
+    try {
+      normalizeApiBaseUrl(value ?? '');
+      return null;
+    } on FormatException catch (e) {
+      return e.message;
+    }
+  }
+
+  Future<bool> _confirmServerUrlChange(String nextBaseUrl) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Change Server'),
+            content: Text(
+              'Changing the server URL clears your stored API key. '
+              'You will need to enter an API key for $nextBaseUrl.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('Change Server'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+
+  void _refreshApiConfiguration() {
+    ref.invalidate(preferencesServiceProvider);
+    ref.invalidate(apiClientFactoryProvider);
+    ref.invalidate(apiClientProvider);
+    ref.invalidate(transcriptionServiceProvider);
+    ref.invalidate(uploadQueueServiceProvider);
+    ref.invalidate(hasApiKeyProvider);
+    ref.invalidate(apiKeyDisplayProvider);
+  }
+
+  Future<void> _applyServerUrl(String nextBaseUrl) async {
+    final preferences = ref.read(preferencesServiceProvider);
+    final storage = ref.read(secureStorageProvider);
+
+    if (nextBaseUrl == normalizeApiBaseUrl(kDefaultBaseUrl)) {
+      await preferences.clearApiBaseUrlOverride();
+    } else {
+      await preferences.setApiBaseUrlOverride(nextBaseUrl);
+    }
+    await storage.deleteApiKey();
+
+    _refreshApiConfiguration();
+
+    if (mounted) {
+      setState(() {
+        _hasExistingKey = false;
+        _hasServerOverride = preferences.apiBaseUrlOverride != null;
+        _serverUrlController.text = preferences.apiBaseUrl;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Server URL updated')));
+    }
+  }
+
+  Future<void> _saveServerUrl() async {
+    if (!_serverFormKey.currentState!.validate()) return;
+
+    final preferences = ref.read(preferencesServiceProvider);
+    final nextBaseUrl = normalizeApiBaseUrl(_serverUrlController.text);
+    if (nextBaseUrl == preferences.apiBaseUrl) {
+      setState(() => _serverUrlController.text = nextBaseUrl);
+      return;
+    }
+
+    final confirmed = await _confirmServerUrlChange(nextBaseUrl);
+    if (!confirmed) return;
+
+    setState(() => _isLoading = true);
+    try {
+      await _applyServerUrl(nextBaseUrl);
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _resetServerUrl() async {
+    final preferences = ref.read(preferencesServiceProvider);
+    if (preferences.apiBaseUrlOverride == null) return;
+
+    final defaultBaseUrl = normalizeApiBaseUrl(kDefaultBaseUrl);
+    final confirmed = await _confirmServerUrlChange(defaultBaseUrl);
+    if (!confirmed) return;
+
+    setState(() => _isLoading = true);
+    try {
+      await _applyServerUrl(defaultBaseUrl);
     } finally {
       if (mounted) {
         setState(() => _isLoading = false);
@@ -272,7 +393,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
               const SizedBox(height: 32),
 
-              // Server URL Section (informational for now)
               Text(
                 'Server',
                 style: theme.textTheme.titleMedium?.copyWith(
@@ -280,11 +400,43 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
               ),
               const SizedBox(height: 8),
-              Card(
-                child: ListTile(
-                  leading: const Icon(Icons.dns),
-                  title: const Text('Server URL'),
-                  subtitle: const Text(kDefaultBaseUrl),
+              Form(
+                key: _serverFormKey,
+                child: Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        TextFormField(
+                          controller: _serverUrlController,
+                          keyboardType: TextInputType.url,
+                          decoration: const InputDecoration(
+                            labelText: 'Server URL',
+                            hintText: kDefaultBaseUrl,
+                            border: OutlineInputBorder(),
+                            prefixIcon: Icon(Icons.dns),
+                          ),
+                          validator: _validateServerUrl,
+                          onFieldSubmitted: (_) => _saveServerUrl(),
+                        ),
+                        const SizedBox(height: 12),
+                        FilledButton.icon(
+                          onPressed: _isLoading ? null : _saveServerUrl,
+                          icon: const Icon(Icons.save),
+                          label: const Text('Save Server URL'),
+                        ),
+                        if (_hasServerOverride) ...[
+                          const SizedBox(height: 8),
+                          OutlinedButton.icon(
+                            onPressed: _isLoading ? null : _resetServerUrl,
+                            icon: const Icon(Icons.restore),
+                            label: const Text('Reset to Default'),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
                 ),
               ),
 

--- a/client/lib/screens/settings_screen.dart
+++ b/client/lib/screens/settings_screen.dart
@@ -74,6 +74,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     try {
       final storage = ref.read(secureStorageProvider);
       await storage.setApiKey(_apiKeyController.text.trim());
+      await ref.read(preferencesServiceProvider).markApiKeyBoundToCurrentUrl();
 
       // Invalidate the hasApiKey provider to refresh state
       ref.invalidate(hasApiKeyProvider);
@@ -217,6 +218,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       await preferences.setApiBaseUrlOverride(nextBaseUrl);
     }
     await storage.deleteApiKey();
+    await preferences.markApiKeyBoundToCurrentUrl();
 
     _refreshApiConfiguration();
 

--- a/client/lib/services/api_base_url_config.dart
+++ b/client/lib/services/api_base_url_config.dart
@@ -30,18 +30,12 @@ String normalizeApiBaseUrl(String value) {
     );
   }
 
-  final pathSegments = uri.pathSegments
-      .where((segment) => segment.isNotEmpty)
-      .toList();
-  final normalizedPath = pathSegments.isEmpty
-      ? ''
-      : '/${pathSegments.join('/')}';
+  final hasPath = uri.pathSegments.any((segment) => segment.isNotEmpty);
+  if (hasPath) {
+    throw const FormatException('Server URL must not include a path.');
+  }
 
   return uri
-      .replace(
-        scheme: scheme,
-        host: uri.host.toLowerCase(),
-        path: normalizedPath,
-      )
+      .replace(scheme: scheme, host: uri.host.toLowerCase(), path: '')
       .toString();
 }

--- a/client/lib/services/api_base_url_config.dart
+++ b/client/lib/services/api_base_url_config.dart
@@ -1,0 +1,47 @@
+/// Default API base URL.
+const kDefaultBaseUrl = String.fromEnvironment(
+  'ORACY_API_BASE_URL',
+  defaultValue: 'https://api.oracy.app',
+);
+
+/// Normalize and validate an operator-provided API base URL.
+String normalizeApiBaseUrl(String value) {
+  final uri = Uri.tryParse(value.trim());
+  if (uri == null || !uri.hasScheme) {
+    throw const FormatException('Enter an absolute http or https URL.');
+  }
+
+  final scheme = uri.scheme.toLowerCase();
+  if (scheme != 'http' && scheme != 'https') {
+    throw const FormatException('Server URL must use http or https.');
+  }
+
+  if (uri.host.isEmpty) {
+    throw const FormatException('Server URL must include a host.');
+  }
+
+  if (uri.userInfo.isNotEmpty) {
+    throw const FormatException('Server URL must not include credentials.');
+  }
+
+  if (uri.hasQuery || uri.hasFragment) {
+    throw const FormatException(
+      'Server URL must not include query parameters or fragments.',
+    );
+  }
+
+  final pathSegments = uri.pathSegments
+      .where((segment) => segment.isNotEmpty)
+      .toList();
+  final normalizedPath = pathSegments.isEmpty
+      ? ''
+      : '/${pathSegments.join('/')}';
+
+  return uri
+      .replace(
+        scheme: scheme,
+        host: uri.host.toLowerCase(),
+        path: normalizedPath,
+      )
+      .toString();
+}

--- a/client/lib/services/api_client.dart
+++ b/client/lib/services/api_client.dart
@@ -11,6 +11,8 @@ export 'package:oracy/services/api_base_url_config.dart'
 /// Key used to store the API key in secure storage.
 const kApiKeyStorageKey = 'oracy_api_key';
 
+typedef CredentialBindingReconciler = Future<void> Function();
+
 /// Service for secure storage of sensitive data.
 class SecureStorageService {
   final FlutterSecureStorage _storage;
@@ -47,20 +49,32 @@ final secureStorageProvider = Provider<SecureStorageService>((ref) {
 /// Interceptor that adds Bearer token authentication to requests.
 class AuthInterceptor extends Interceptor {
   final SecureStorageService _storage;
+  final CredentialBindingReconciler? _reconcileCredentialBinding;
   final void Function()? onAuthError;
 
-  AuthInterceptor(this._storage, {this.onAuthError});
+  AuthInterceptor(
+    this._storage, {
+    CredentialBindingReconciler? reconcileCredentialBinding,
+    this.onAuthError,
+  }) : _reconcileCredentialBinding = reconcileCredentialBinding;
 
   @override
   void onRequest(
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) async {
-    final apiKey = await _storage.getApiKey();
-    if (apiKey != null && apiKey.isNotEmpty) {
-      options.headers['Authorization'] = 'Bearer $apiKey';
+    try {
+      await _reconcileCredentialBinding?.call();
+      final apiKey = await _storage.getApiKey();
+      if (apiKey != null && apiKey.isNotEmpty) {
+        options.headers['Authorization'] = 'Bearer $apiKey';
+      }
+      handler.next(options);
+    } catch (e, stackTrace) {
+      handler.reject(
+        DioException(requestOptions: options, error: e, stackTrace: stackTrace),
+      );
     }
-    handler.next(options);
   }
 
   @override
@@ -93,10 +107,15 @@ class ApiClientConfig {
 /// Factory for creating configured Dio instances.
 class ApiClientFactory {
   final SecureStorageService _storage;
+  final CredentialBindingReconciler? _reconcileCredentialBinding;
   final ApiClientConfig config;
   void Function()? onAuthError;
 
-  ApiClientFactory(this._storage, {this.config = const ApiClientConfig()});
+  ApiClientFactory(
+    this._storage, {
+    CredentialBindingReconciler? reconcileCredentialBinding,
+    this.config = const ApiClientConfig(),
+  }) : _reconcileCredentialBinding = reconcileCredentialBinding;
 
   /// Create a new Dio instance with authentication.
   Dio createClient() {
@@ -114,7 +133,13 @@ class ApiClientFactory {
     );
 
     // Add auth interceptor
-    dio.interceptors.add(AuthInterceptor(_storage, onAuthError: onAuthError));
+    dio.interceptors.add(
+      AuthInterceptor(
+        _storage,
+        reconcileCredentialBinding: _reconcileCredentialBinding,
+        onAuthError: onAuthError,
+      ),
+    );
 
     // Add logging in debug mode
     assert(() {
@@ -142,6 +167,10 @@ final apiClientFactoryProvider = Provider<ApiClientFactory>((ref) {
   final preferences = ref.watch(preferencesServiceProvider);
   return ApiClientFactory(
     storage,
+    reconcileCredentialBinding: () => preferences.reconcileApiCredentialBinding(
+      hasApiKey: storage.hasApiKey,
+      deleteApiKey: storage.deleteApiKey,
+    ),
     config: ApiClientConfig(baseUrl: preferences.apiBaseUrl),
   );
 });
@@ -157,5 +186,10 @@ final apiClientProvider = Provider<Dio>((ref) {
 /// Provider for checking if the user has configured an API key.
 final hasApiKeyProvider = FutureProvider<bool>((ref) async {
   final storage = ref.watch(secureStorageProvider);
+  final preferences = ref.watch(preferencesServiceProvider);
+  await preferences.reconcileApiCredentialBinding(
+    hasApiKey: storage.hasApiKey,
+    deleteApiKey: storage.deleteApiKey,
+  );
   return storage.hasApiKey();
 });

--- a/client/lib/services/api_client.dart
+++ b/client/lib/services/api_client.dart
@@ -2,12 +2,14 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:oracy/services/api_base_url_config.dart';
+import 'package:oracy/services/preferences_service.dart';
+
+export 'package:oracy/services/api_base_url_config.dart'
+    show kDefaultBaseUrl, normalizeApiBaseUrl;
 
 /// Key used to store the API key in secure storage.
 const kApiKeyStorageKey = 'oracy_api_key';
-
-/// Default API base URL.
-const kDefaultBaseUrl = 'https://api.oracy.app';
 
 /// Service for secure storage of sensitive data.
 class SecureStorageService {
@@ -137,7 +139,11 @@ class ApiClientFactory {
 /// Provider for API client factory.
 final apiClientFactoryProvider = Provider<ApiClientFactory>((ref) {
   final storage = ref.watch(secureStorageProvider);
-  return ApiClientFactory(storage);
+  final preferences = ref.watch(preferencesServiceProvider);
+  return ApiClientFactory(
+    storage,
+    config: ApiClientConfig(baseUrl: preferences.apiBaseUrl),
+  );
 });
 
 /// Provider for the main Dio client.

--- a/client/lib/services/background_sync_service.dart
+++ b/client/lib/services/background_sync_service.dart
@@ -6,9 +6,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:oracy/db/database.dart';
 import 'package:oracy/services/api_client.dart';
+import 'package:oracy/services/preferences_service.dart';
 import 'package:oracy/services/recording_recovery_service.dart';
 import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/services/upload_retry_policy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 
 /// Unique name for the background sync task.
@@ -32,6 +34,12 @@ typedef BackgroundTranscriptionServiceFactory =
     TranscriptionService Function(String apiKey);
 typedef BackgroundRecordingReconciler = Future<int> Function(AppDatabase db);
 
+Future<String> readBackgroundApiBaseUrl() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.reload();
+  return PreferencesService(prefs).apiBaseUrl;
+}
+
 /// Top-level callback dispatcher for workmanager.
 ///
 /// This must be a top-level function and cannot be a class method.
@@ -45,6 +53,7 @@ void callbackDispatcher() {
       final connectivity = Connectivity();
       const storage = FlutterSecureStorage();
       final db = AppDatabase();
+      final apiBaseUrl = await readBackgroundApiBaseUrl();
 
       try {
         return await runBackgroundSyncPass(
@@ -54,7 +63,7 @@ void callbackDispatcher() {
           createTranscriptionService: (apiKey) {
             final dio = Dio(
               BaseOptions(
-                baseUrl: kDefaultBaseUrl,
+                baseUrl: apiBaseUrl,
                 headers: {'Authorization': 'Bearer $apiKey'},
                 connectTimeout: const Duration(seconds: 30),
                 receiveTimeout: const Duration(minutes: 5),

--- a/client/lib/services/background_sync_service.dart
+++ b/client/lib/services/background_sync_service.dart
@@ -30,14 +30,28 @@ const Duration staleUploadingRestoreThreshold = Duration(minutes: 10);
 
 typedef ConnectivityCheck = Future<List<ConnectivityResult>> Function();
 typedef ApiKeyReader = Future<String?> Function();
+typedef ApiKeyDeleter = Future<void> Function();
 typedef BackgroundTranscriptionServiceFactory =
     TranscriptionService Function(String apiKey);
 typedef BackgroundRecordingReconciler = Future<int> Function(AppDatabase db);
 
-Future<String> readBackgroundApiBaseUrl() async {
+Future<String> readBackgroundApiBaseUrl({
+  ApiKeyReader? readApiKey,
+  ApiKeyDeleter? deleteApiKey,
+}) async {
   final prefs = await SharedPreferences.getInstance();
   await prefs.reload();
-  return PreferencesService(prefs).apiBaseUrl;
+  final preferences = PreferencesService(prefs);
+  if (readApiKey != null && deleteApiKey != null) {
+    await preferences.reconcileApiCredentialBinding(
+      hasApiKey: () async {
+        final apiKey = await readApiKey();
+        return apiKey != null && apiKey.isNotEmpty;
+      },
+      deleteApiKey: deleteApiKey,
+    );
+  }
+  return preferences.apiBaseUrl;
 }
 
 /// Top-level callback dispatcher for workmanager.
@@ -53,7 +67,10 @@ void callbackDispatcher() {
       final connectivity = Connectivity();
       const storage = FlutterSecureStorage();
       final db = AppDatabase();
-      final apiBaseUrl = await readBackgroundApiBaseUrl();
+      final apiBaseUrl = await readBackgroundApiBaseUrl(
+        readApiKey: () => storage.read(key: kApiKeyStorageKey),
+        deleteApiKey: () => storage.delete(key: kApiKeyStorageKey),
+      );
 
       try {
         return await runBackgroundSyncPass(

--- a/client/lib/services/preferences_service.dart
+++ b/client/lib/services/preferences_service.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 class PreferenceKeys {
   static const String autoCopyToClipboard = 'auto_copy_to_clipboard';
   static const String apiBaseUrl = 'api_base_url';
+  static const String lastEffectiveApiBaseUrl = 'last_effective_api_base_url';
 }
 
 /// Service for managing user preferences.
@@ -28,12 +29,43 @@ class PreferencesService {
     if (value == null || value.trim().isEmpty) {
       return null;
     }
-    return normalizeApiBaseUrl(value);
+    try {
+      return normalizeApiBaseUrl(value);
+    } on FormatException {
+      return null;
+    }
   }
 
   /// Effective API base URL for this install.
   String get apiBaseUrl =>
       apiBaseUrlOverride ?? normalizeApiBaseUrl(kDefaultBaseUrl);
+
+  /// Last effective API base URL that stored credentials were bound to.
+  String? get lastEffectiveApiBaseUrl =>
+      _prefs.getString(PreferenceKeys.lastEffectiveApiBaseUrl);
+
+  /// Record that the currently stored API key belongs to the current server.
+  Future<void> markApiKeyBoundToCurrentUrl() async {
+    await _prefs.setString(PreferenceKeys.lastEffectiveApiBaseUrl, apiBaseUrl);
+  }
+
+  /// Ensure any stored API key is only used with its bound server URL.
+  Future<void> reconcileApiCredentialBinding({
+    required Future<bool> Function() hasApiKey,
+    required Future<void> Function() deleteApiKey,
+  }) async {
+    final currentBaseUrl = apiBaseUrl;
+    final lastBaseUrl = lastEffectiveApiBaseUrl;
+
+    if (lastBaseUrl != currentBaseUrl && await hasApiKey()) {
+      await deleteApiKey();
+    }
+
+    await _prefs.setString(
+      PreferenceKeys.lastEffectiveApiBaseUrl,
+      currentBaseUrl,
+    );
+  }
 
   /// Store a runtime API base URL override.
   Future<void> setApiBaseUrlOverride(String value) async {

--- a/client/lib/services/preferences_service.dart
+++ b/client/lib/services/preferences_service.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:oracy/services/api_base_url_config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Keys for shared preferences.
 class PreferenceKeys {
   static const String autoCopyToClipboard = 'auto_copy_to_clipboard';
+  static const String apiBaseUrl = 'api_base_url';
 }
 
 /// Service for managing user preferences.
@@ -19,6 +21,32 @@ class PreferencesService {
 
   set autoCopyToClipboard(bool value) =>
       _prefs.setBool(PreferenceKeys.autoCopyToClipboard, value);
+
+  /// Runtime override for the API base URL, if one has been configured.
+  String? get apiBaseUrlOverride {
+    final value = _prefs.getString(PreferenceKeys.apiBaseUrl);
+    if (value == null || value.trim().isEmpty) {
+      return null;
+    }
+    return normalizeApiBaseUrl(value);
+  }
+
+  /// Effective API base URL for this install.
+  String get apiBaseUrl =>
+      apiBaseUrlOverride ?? normalizeApiBaseUrl(kDefaultBaseUrl);
+
+  /// Store a runtime API base URL override.
+  Future<void> setApiBaseUrlOverride(String value) async {
+    await _prefs.setString(
+      PreferenceKeys.apiBaseUrl,
+      normalizeApiBaseUrl(value),
+    );
+  }
+
+  /// Remove the runtime API base URL override.
+  Future<void> clearApiBaseUrlOverride() async {
+    await _prefs.remove(PreferenceKeys.apiBaseUrl);
+  }
 }
 
 /// Provider for SharedPreferences instance.

--- a/client/lib/services/transcription_service.dart
+++ b/client/lib/services/transcription_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/db/database.dart';
 import 'package:oracy/models/voice_note.dart';
 import 'package:oracy/services/api_client.dart';
+import 'package:oracy/services/preferences_service.dart';
 import 'package:oracy/services/upload_retry_policy.dart';
 import 'package:uuid/uuid.dart';
 
@@ -711,6 +712,12 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
 
     // Check for API key first
     final storage = ref.read(secureStorageProvider);
+    await ref
+        .read(preferencesServiceProvider)
+        .reconcileApiCredentialBinding(
+          hasApiKey: storage.hasApiKey,
+          deleteApiKey: storage.deleteApiKey,
+        );
     final hasKey = await storage.hasApiKey();
     if (kDebugMode) {
       debugPrint('[TRANSCRIPTION] hasApiKey: $hasKey');

--- a/client/lib/services/upload_queue_service.dart
+++ b/client/lib/services/upload_queue_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/db/database.dart';
 import 'package:oracy/services/api_client.dart';
 import 'package:oracy/services/background_sync_service.dart';
+import 'package:oracy/services/preferences_service.dart';
 import 'package:oracy/services/recording_recovery_service.dart';
 import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/services/upload_retry_policy.dart';
@@ -239,12 +240,19 @@ final uploadQueueServiceProvider = Provider<UploadQueueService?>((ref) {
 
   final db = ref.watch(appDatabaseProvider);
   final storage = ref.watch(secureStorageProvider);
+  final preferences = ref.watch(preferencesServiceProvider);
   final transcriptionService = ref.watch(transcriptionServiceProvider);
 
   final service = UploadQueueService(
     db: db,
     transcriptionService: transcriptionService,
-    hasApiKey: storage.hasApiKey,
+    hasApiKey: () async {
+      await preferences.reconcileApiCredentialBinding(
+        hasApiKey: storage.hasApiKey,
+        deleteApiKey: storage.deleteApiKey,
+      );
+      return storage.hasApiKey();
+    },
   );
 
   // Start the service

--- a/client/test/api_base_url_config_test.dart
+++ b/client/test/api_base_url_config_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:oracy/services/api_client.dart';
+import 'package:oracy/services/preferences_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test(
+    'Given no operator configuration, When the API base URL is resolved, Then the documented default is used',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+
+      expect(service.apiBaseUrl, normalizeApiBaseUrl(kDefaultBaseUrl));
+      expect(service.apiBaseUrlOverride, isNull);
+    },
+  );
+
+  test(
+    'Given a build-time API base URL define, When the default is read, Then it follows that define',
+    () {
+      const buildTimeDefault = String.fromEnvironment(
+        'ORACY_API_BASE_URL',
+        defaultValue: 'https://api.oracy.app',
+      );
+
+      expect(kDefaultBaseUrl, buildTimeDefault);
+    },
+  );
+
+  test(
+    'Given an operator override, When the API base URL is resolved, Then the normalized override wins',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+
+      await service.setApiBaseUrlOverride(' HTTPS://staging.oracy.app/api/ ');
+
+      expect(service.apiBaseUrlOverride, 'https://staging.oracy.app/api');
+      expect(service.apiBaseUrl, 'https://staging.oracy.app/api');
+    },
+  );
+
+  test(
+    'Given invalid API base URL values, When normalization runs, Then they are rejected',
+    () {
+      for (final value in [
+        '',
+        '/api',
+        'ftp://staging.oracy.app',
+        'https://user:pass@staging.oracy.app',
+        'https://staging.oracy.app/api?token=abc',
+        'https://staging.oracy.app/api#fragment',
+      ]) {
+        expect(() => normalizeApiBaseUrl(value), throwsFormatException);
+      }
+    },
+  );
+
+  test(
+    'Given an API base URL override, When a Dio client is created, Then requests use that override',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      await PreferencesService(
+        prefs,
+      ).setApiBaseUrlOverride('https://staging.oracy.app');
+
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final dio = container.read(apiClientProvider);
+
+      expect(dio.options.baseUrl, 'https://staging.oracy.app');
+    },
+  );
+}

--- a/client/test/api_base_url_config_test.dart
+++ b/client/test/api_base_url_config_test.dart
@@ -1,8 +1,46 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/services/api_client.dart';
 import 'package:oracy/services/preferences_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import 'helpers/test_utils.dart';
+
+class _CapturedRequest {
+  final Map<String, dynamic> headers;
+
+  const _CapturedRequest({required this.headers});
+}
+
+class _CapturingAdapter implements HttpClientAdapter {
+  final requests = <_CapturedRequest>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(
+      _CapturedRequest(headers: Map<String, dynamic>.from(options.headers)),
+    );
+
+    return ResponseBody.fromString(
+      jsonEncode({'ok': true}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
 
 void main() {
   setUp(() {
@@ -38,10 +76,10 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final service = PreferencesService(prefs);
 
-      await service.setApiBaseUrlOverride(' HTTPS://staging.oracy.app/api/ ');
+      await service.setApiBaseUrlOverride(' HTTPS://staging.oracy.app/ ');
 
-      expect(service.apiBaseUrlOverride, 'https://staging.oracy.app/api');
-      expect(service.apiBaseUrl, 'https://staging.oracy.app/api');
+      expect(service.apiBaseUrlOverride, 'https://staging.oracy.app');
+      expect(service.apiBaseUrl, 'https://staging.oracy.app');
     },
   );
 
@@ -54,10 +92,107 @@ void main() {
         'ftp://staging.oracy.app',
         'https://user:pass@staging.oracy.app',
         'https://staging.oracy.app/api?token=abc',
+        'https://staging.oracy.app/api',
         'https://staging.oracy.app/api#fragment',
       ]) {
         expect(() => normalizeApiBaseUrl(value), throwsFormatException);
       }
+    },
+  );
+
+  test(
+    'Given an origin URL with redundant casing and a trailing slash, When normalization runs, Then the origin is normalized',
+    () {
+      expect(
+        normalizeApiBaseUrl(' HTTPS://STAGING.ORACY.APP/ '),
+        'https://staging.oracy.app',
+      );
+    },
+  );
+
+  test(
+    'Given a stored API key bound to a previous effective URL, When the effective URL is reconciled, Then the key is cleared and rebound',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+      await service.markApiKeyBoundToCurrentUrl();
+      await service.setApiBaseUrlOverride('https://staging.oracy.app');
+      final storage = MockSecureStorage(apiKey: 'oracy_sk_existing');
+
+      await service.reconcileApiCredentialBinding(
+        hasApiKey: storage.hasApiKey,
+        deleteApiKey: storage.deleteApiKey,
+      );
+
+      expect(await storage.hasApiKey(), isFalse);
+      expect(service.lastEffectiveApiBaseUrl, 'https://staging.oracy.app');
+    },
+  );
+
+  test(
+    'Given no persisted URL and no API key, When the effective URL is reconciled, Then the current URL is recorded',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+      final storage = MockSecureStorage();
+
+      await service.reconcileApiCredentialBinding(
+        hasApiKey: storage.hasApiKey,
+        deleteApiKey: storage.deleteApiKey,
+      );
+
+      expect(await storage.hasApiKey(), isFalse);
+      expect(service.lastEffectiveApiBaseUrl, service.apiBaseUrl);
+    },
+  );
+
+  test(
+    'Given no persisted URL and an API key, When the effective URL is reconciled, Then the uncertain key is cleared silently',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+      final storage = MockSecureStorage(apiKey: 'oracy_sk_existing');
+
+      await service.reconcileApiCredentialBinding(
+        hasApiKey: storage.hasApiKey,
+        deleteApiKey: storage.deleteApiKey,
+      );
+
+      expect(await storage.hasApiKey(), isFalse);
+      expect(service.lastEffectiveApiBaseUrl, service.apiBaseUrl);
+    },
+  );
+
+  test(
+    'Given a previously persisted pathful override, When the effective URL is resolved, Then the invalid override is ignored',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        PreferenceKeys.apiBaseUrl: 'https://staging.oracy.app/api',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+
+      expect(service.apiBaseUrlOverride, isNull);
+      expect(service.apiBaseUrl, normalizeApiBaseUrl(kDefaultBaseUrl));
+    },
+  );
+
+  test(
+    'Given a runtime override keeps the effective URL stable, When the build default changes, Then the key remains bound',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+      await service.setApiBaseUrlOverride('https://staging.oracy.app');
+      await service.markApiKeyBoundToCurrentUrl();
+      final storage = MockSecureStorage(apiKey: 'oracy_sk_existing');
+
+      await service.reconcileApiCredentialBinding(
+        hasApiKey: storage.hasApiKey,
+        deleteApiKey: storage.deleteApiKey,
+      );
+
+      expect(await storage.hasApiKey(), isTrue);
+      expect(service.lastEffectiveApiBaseUrl, 'https://staging.oracy.app');
     },
   );
 
@@ -77,6 +212,32 @@ void main() {
       final dio = container.read(apiClientProvider);
 
       expect(dio.options.baseUrl, 'https://staging.oracy.app');
+    },
+  );
+
+  test(
+    'Given a stored API key bound to a previous effective URL, When a Dio request is prepared, Then the stale key is not sent',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final preferences = PreferencesService(prefs);
+      await preferences.markApiKeyBoundToCurrentUrl();
+      await preferences.setApiBaseUrlOverride('https://staging.oracy.app');
+      final storage = MockSecureStorage(apiKey: 'oracy_sk_existing');
+      final adapter = _CapturingAdapter();
+      final dio = ApiClientFactory(
+        storage,
+        reconcileCredentialBinding: () =>
+            preferences.reconcileApiCredentialBinding(
+              hasApiKey: storage.hasApiKey,
+              deleteApiKey: storage.deleteApiKey,
+            ),
+        config: ApiClientConfig(baseUrl: preferences.apiBaseUrl),
+      ).createClient()..httpClientAdapter = adapter;
+
+      await dio.get('/api/v1/voice-notes');
+
+      expect(await storage.hasApiKey(), isFalse);
+      expect(adapter.requests.single.headers, isNot(contains('Authorization')));
     },
   );
 }

--- a/client/test/background_sync_service_test.dart
+++ b/client/test/background_sync_service_test.dart
@@ -7,8 +7,10 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oracy/db/database.dart';
 import 'package:oracy/services/background_sync_service.dart';
+import 'package:oracy/services/preferences_service.dart';
 import 'package:oracy/services/recording_recovery_service.dart';
 import 'package:oracy/services/transcription_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'helpers/test_utils.dart';
 
@@ -71,6 +73,7 @@ void main() {
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('oracy_bg_sync_test_');
     db = AppDatabase(NativeDatabase.memory());
+    SharedPreferences.setMockInitialValues({});
   });
 
   tearDown(() async {
@@ -85,6 +88,20 @@ void main() {
     await file.writeAsBytes(List<int>.filled(2048, 1));
     return file;
   }
+
+  test(
+    'Given an API base URL override, When background sync loads configuration, Then it uses the same normalized server URL',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      await PreferencesService(
+        prefs,
+      ).setApiBaseUrlOverride(' https://staging.oracy.app/api/ ');
+
+      final apiBaseUrl = await readBackgroundApiBaseUrl();
+
+      expect(apiBaseUrl, 'https://staging.oracy.app/api');
+    },
+  );
 
   test(
     'Given a background sync pass, When an uploading row is stale, Then it is restored to failed and returned to the pending queue',

--- a/client/test/background_sync_service_test.dart
+++ b/client/test/background_sync_service_test.dart
@@ -95,11 +95,44 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       await PreferencesService(
         prefs,
-      ).setApiBaseUrlOverride(' https://staging.oracy.app/api/ ');
+      ).setApiBaseUrlOverride(' https://staging.oracy.app/ ');
 
       final apiBaseUrl = await readBackgroundApiBaseUrl();
 
-      expect(apiBaseUrl, 'https://staging.oracy.app/api');
+      expect(apiBaseUrl, 'https://staging.oracy.app');
+    },
+  );
+
+  test(
+    'Given a background API key bound to a previous URL, When background sync loads configuration, Then the key is cleared before use',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final preferences = PreferencesService(prefs);
+      await preferences.markApiKeyBoundToCurrentUrl();
+      await preferences.setApiBaseUrlOverride('https://staging.oracy.app');
+      final events = <String>[];
+      var apiKey = 'oracy_sk_existing';
+
+      final apiBaseUrl = await readBackgroundApiBaseUrl(
+        readApiKey: () async {
+          events.add('read-for-reconcile');
+          return apiKey;
+        },
+        deleteApiKey: () async {
+          events.add('delete-stale-key');
+          apiKey = '';
+        },
+      );
+      events.add('read-for-sync');
+
+      expect(apiBaseUrl, 'https://staging.oracy.app');
+      expect(apiKey, isEmpty);
+      expect(events, [
+        'read-for-reconcile',
+        'delete-stale-key',
+        'read-for-sync',
+      ]);
+      expect(preferences.lastEffectiveApiBaseUrl, 'https://staging.oracy.app');
     },
   );
 

--- a/client/test/settings_screen_test.dart
+++ b/client/test/settings_screen_test.dart
@@ -45,7 +45,7 @@ void main() {
 
       await tester.enterText(
         find.widgetWithText(TextFormField, 'Server URL'),
-        ' https://staging.oracy.app/api/ ',
+        ' https://staging.oracy.app/ ',
       );
       await tester.tap(find.text('Save Server URL'));
       await tester.pumpAndSettle();
@@ -53,7 +53,8 @@ void main() {
       await tester.pumpAndSettle();
 
       final service = PreferencesService(prefs);
-      expect(service.apiBaseUrlOverride, 'https://staging.oracy.app/api');
+      expect(service.apiBaseUrlOverride, 'https://staging.oracy.app');
+      expect(service.lastEffectiveApiBaseUrl, 'https://staging.oracy.app');
       expect(await storage.hasApiKey(), isFalse);
       expect(find.text('API Key Configured'), findsNothing);
     },
@@ -76,6 +77,10 @@ void main() {
 
       expect(service.apiBaseUrlOverride, isNull);
       expect(service.apiBaseUrl, kDefaultBaseUrl);
+      expect(
+        service.lastEffectiveApiBaseUrl,
+        normalizeApiBaseUrl(kDefaultBaseUrl),
+      );
       expect(await storage.hasApiKey(), isFalse);
     },
   );
@@ -99,6 +104,29 @@ void main() {
       expect(PreferencesService(prefs).apiBaseUrlOverride, isNull);
       expect(await storage.hasApiKey(), isTrue);
       expect(find.text('Change Server'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Given a saved API key, When the key is stored, Then it is bound to the current effective server URL',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final storage = MockSecureStorage();
+
+      await pumpSettings(tester, prefs: prefs, storage: storage);
+
+      await tester.ensureVisible(find.widgetWithText(TextFormField, 'API Key'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'API Key'),
+        'oracy_sk_new_key',
+      );
+      await tester.tap(find.text('Save API Key'));
+      await tester.pumpAndSettle();
+
+      final service = PreferencesService(prefs);
+      expect(await storage.getApiKey(), 'oracy_sk_new_key');
+      expect(service.lastEffectiveApiBaseUrl, service.apiBaseUrl);
     },
   );
 }

--- a/client/test/settings_screen_test.dart
+++ b/client/test/settings_screen_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:oracy/screens/settings_screen.dart';
+import 'package:oracy/services/api_client.dart';
+import 'package:oracy/services/preferences_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'helpers/test_utils.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<void> pumpSettings(
+    WidgetTester tester, {
+    required SharedPreferences prefs,
+    required MockSecureStorage storage,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStorageProvider.overrideWith((_) => storage),
+        ],
+        child: const MaterialApp(home: SettingsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.drag(
+      find.byType(SingleChildScrollView),
+      const Offset(0, -500),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'Given an existing API key, When the server URL is changed and confirmed, Then the override is stored and the API key is cleared',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final storage = MockSecureStorage(apiKey: 'oracy_sk_existing');
+
+      await pumpSettings(tester, prefs: prefs, storage: storage);
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Server URL'),
+        ' https://staging.oracy.app/api/ ',
+      );
+      await tester.tap(find.text('Save Server URL'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Change Server'));
+      await tester.pumpAndSettle();
+
+      final service = PreferencesService(prefs);
+      expect(service.apiBaseUrlOverride, 'https://staging.oracy.app/api');
+      expect(await storage.hasApiKey(), isFalse);
+      expect(find.text('API Key Configured'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Given a server URL override, When reset to default is confirmed, Then the override is removed and the API key is cleared',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = PreferencesService(prefs);
+      await service.setApiBaseUrlOverride('https://staging.oracy.app');
+      final storage = MockSecureStorage(apiKey: 'oracy_sk_existing');
+
+      await pumpSettings(tester, prefs: prefs, storage: storage);
+
+      await tester.tap(find.text('Reset to Default'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Change Server'));
+      await tester.pumpAndSettle();
+
+      expect(service.apiBaseUrlOverride, isNull);
+      expect(service.apiBaseUrl, kDefaultBaseUrl);
+      expect(await storage.hasApiKey(), isFalse);
+    },
+  );
+
+  testWidgets(
+    'Given an invalid server URL, When saving the server setting, Then validation blocks the change',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final storage = MockSecureStorage(apiKey: 'oracy_sk_existing');
+
+      await pumpSettings(tester, prefs: prefs, storage: storage);
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Server URL'),
+        'ftp://staging.oracy.app',
+      );
+      await tester.tap(find.text('Save Server URL'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Server URL must use http or https.'), findsOneWidget);
+      expect(PreferencesService(prefs).apiBaseUrlOverride, isNull);
+      expect(await storage.hasApiKey(), isTrue);
+      expect(find.text('Change Server'), findsNothing);
+    },
+  );
+}

--- a/client/test/transcription_persistence_test.dart
+++ b/client/test/transcription_persistence_test.dart
@@ -8,8 +8,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oracy/db/database.dart';
 import 'package:oracy/services/api_client.dart';
+import 'package:oracy/services/preferences_service.dart';
 import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/services/upload_retry_policy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'helpers/test_utils.dart';
 
@@ -288,10 +290,14 @@ void main() {
   late Directory tempDir;
   late AppDatabase db;
   late ProviderContainer container;
+  late SharedPreferences prefs;
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('oracy_test_');
     db = AppDatabase(NativeDatabase.memory());
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await PreferencesService(prefs).markApiKeyBoundToCurrentUrl();
   });
 
   tearDown(() async {
@@ -313,6 +319,7 @@ void main() {
   ProviderContainer createContainer(TranscriptionService service) {
     return ProviderContainer(
       overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
         secureStorageProvider.overrideWith(
           (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
         ),
@@ -329,6 +336,7 @@ void main() {
       final storage = _BlockingHasApiKeyStorage();
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith((_) => storage),
           appDatabaseProvider.overrideWithValue(db),
           transcriptionServiceProvider.overrideWith(
@@ -366,6 +374,7 @@ void main() {
       final audioFile = await createAudioFile('missing_key.wav');
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith((_) => MockSecureStorage()),
           appDatabaseProvider.overrideWithValue(db),
           transcriptionServiceProvider.overrideWith(
@@ -481,6 +490,7 @@ void main() {
       final audioFile = await createAudioFile('auth_retry.wav');
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith((_) => storage),
           appDatabaseProvider.overrideWithValue(db),
           transcriptionServiceProvider.overrideWith(
@@ -533,6 +543,7 @@ void main() {
       final service = _RetryableForegroundTranscriptionService();
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith(
             (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
           ),
@@ -577,6 +588,7 @@ void main() {
       final service = _RecordingTimestampTranscriptionService();
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith(
             (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
           ),
@@ -597,7 +609,9 @@ void main() {
   test(
     'Given a queued native recording filename contains a capture timestamp, When recordedAt is derived, Then the filename timestamp wins over queue creation time',
     () {
-      container = ProviderContainer();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
       final filenameTimestamp = DateTime.utc(2026, 4, 21, 18, 29, 55);
       final upload = PendingUpload(
         id: 1,
@@ -616,7 +630,9 @@ void main() {
   test(
     'Given a recovered queued native recording filename contains a capture timestamp, When recordedAt is derived, Then the filename timestamp wins over queue creation time',
     () {
-      container = ProviderContainer();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
       final filenameTimestamp = DateTime.utc(2026, 4, 21, 18, 29, 55);
       final upload = PendingUpload(
         id: 1,
@@ -635,7 +651,9 @@ void main() {
   test(
     'Given a queued recording filename has no capture timestamp, When recordedAt is derived, Then queue creation time is used',
     () {
-      container = ProviderContainer();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
       final upload = PendingUpload(
         id: 1,
         audioPath: '${tempDir.path}/oracy_recording_orphaned.wav',
@@ -656,6 +674,7 @@ void main() {
       final service = _FreshAttemptForegroundTranscriptionService();
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith(
             (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
           ),
@@ -692,6 +711,7 @@ void main() {
       final audioFile = await createAudioFile('deleted_replay.wav');
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith(
             (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
           ),
@@ -864,6 +884,7 @@ void main() {
       final audioFile = await createAudioFile('cleanup_pending.wav');
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith(
             (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
           ),
@@ -911,7 +932,9 @@ void main() {
   test(
     'Given a retryable upload has exhausted automatic retries, When another retryable failure is recorded, Then it becomes a terminal failure for manual recovery',
     () async {
-      container = ProviderContainer();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
       final audioFile = await createAudioFile('exhausted_retry.wav');
       final uploadId = await db.ensurePendingUpload(audioPath: audioFile.path);
       await (db.update(
@@ -951,7 +974,9 @@ void main() {
   test(
     'Given a terminal job failure is retryable by the client, When the failure is recorded, Then the queued upload receives a fresh idempotency key',
     () async {
-      container = ProviderContainer();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
       final audioFile = await createAudioFile('fresh_attempt.wav');
       final uploadId = await db.ensurePendingUpload(audioPath: audioFile.path);
       final originalUpload = await db.getUploadById(uploadId);

--- a/client/test/upload_queue_service_test.dart
+++ b/client/test/upload_queue_service_test.dart
@@ -11,8 +11,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oracy/db/database.dart';
 import 'package:oracy/services/api_client.dart';
+import 'package:oracy/services/preferences_service.dart';
 import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/services/upload_queue_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'helpers/test_utils.dart';
 
@@ -116,12 +118,16 @@ void main() {
 
   late Directory tempDir;
   late AppDatabase db;
+  late SharedPreferences prefs;
   late ConnectivityPlatform originalConnectivityPlatform;
   late _FakeConnectivityPlatform fakeConnectivityPlatform;
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('oracy_upload_queue_test_');
     db = AppDatabase(NativeDatabase.memory());
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await PreferencesService(prefs).markApiKeyBoundToCurrentUrl();
     originalConnectivityPlatform = ConnectivityPlatform.instance;
     fakeConnectivityPlatform = _FakeConnectivityPlatform([
       ConnectivityResult.wifi,
@@ -175,6 +181,7 @@ void main() {
       final transcriptionService = _CountingTranscriptionService();
       final container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith((_) => storage),
           appDatabaseProvider.overrideWithValue(db),
           transcriptionServiceProvider.overrideWith(
@@ -203,6 +210,7 @@ void main() {
       final transcriptionService = _CountingTranscriptionService();
       final container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           secureStorageProvider.overrideWith((_) => storage),
           appDatabaseProvider.overrideWithValue(db),
           transcriptionServiceProvider.overrideWith(


### PR DESCRIPTION
## Summary

- Makes the Flutter API base URL configurable for non-default Oracy deployments.
- Adds a build-time `ORACY_API_BASE_URL` default plus a runtime Settings override used by foreground and background clients.
- Binds stored API keys to the last effective server URL and clears stale or uncertain keys before foreground or background clients can use them.
- Requires configured server URLs to be origin-only so existing `/api/v1` request paths cannot be duplicated.

## Changes

- Adds shared base URL normalization and preference-backed effective URL resolution.
- Rejects pathful configured server URLs and documents the origin-only operator contract.
- Replaces the Settings server URL display with editable save/reset controls and confirmation before applying changes.
- Threads the same configured URL through Riverpod Dio creation and Workmanager background sync.
- Reconciles credential bindings before foreground key checks, Dio auth headers, upload queue processing, and background sync key reads.
- Documents operator configuration and records the user-visible change in the changelog.

## GitHub Issue(s)

Closes #91

## Test plan

- `cd client && flutter analyze`
- `cd client && flutter test`
