### PR TITLE
fix(client): prevent Android Gradle workstation OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bound Android Gradle memory and worker defaults so release APK builds fit on
+  representative 16 GB developer workstations.
 - Fix Android release APK SQLite packaging so the Flutter client bundles native
   SQLite through the current `sqlite3` package, with CI coverage for APK native
   library contents and runtime database opening on Android.

--- a/client/android/gradle.properties
+++ b/client/android/gradle.properties
@@ -1,2 +1,5 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+# Keep Android release builds within a representative 16 GB developer workstation.
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m
+org.gradle.workers.max=2
 android.useAndroidX=true


### PR DESCRIPTION
## Summary

- Reduces Android Gradle JVM ceilings so release APK builds fit representative 16 GB developer workstations.
- Adds explicit Kotlin daemon sizing and caps Gradle worker concurrency to reduce aggregate JVM pressure.
- Keeps CI on the committed workstation-safe defaults; no operator-facing build command changes are required.

## Changes

- Replaces the previous `-Xmx8G` Gradle daemon setting with a `-Xmx2g` workstation default and smaller metaspace/code-cache ceilings.
- Adds `kotlin.daemon.jvmargs=-Xmx1g ...` so Kotlin compilation does not inherit an unbounded or oversized daemon profile.
- Adds `org.gradle.workers.max=2` to limit concurrent Gradle work during Android release packaging.

## GitHub Issue(s)

Closes #95

## Test plan

- `git diff --check`
- `flutter analyze`
- `flutter test`
- `flutter build apk --release`
- `dart run tool/verify_android_release_sqlite.dart build/app/outputs/flutter-apk/app-release.apk`
- `flutter build web`
- `journalctl -k --since '2026-05-06 08:21:16'` filtered for `oom-kill`, `Out of memory`, and `Killed process` found no matches during the build window.
