### PR TITLE
fix(deploy): document reverse-proxy substrate provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   representative 16 GB developer workstations.
 - Document fresh reverse-proxy substrate provisioning for backend deployments,
   including an operator-owned ingress Quadlet network and persistent TLS state
-  for containerized proxies.
+  for containerized proxies, with the rootless low-port binding requirement
+  and its host-wide security tradeoff.
 - Fix Android release APK SQLite packaging so the Flutter client bundles native
   SQLite through the current `sqlite3` package, with CI coverage for APK native
   library contents and runtime database opening on Android.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Bound Android Gradle memory and worker defaults so release APK builds fit on
   representative 16 GB developer workstations.
+- Document fresh reverse-proxy substrate provisioning for backend deployments,
+  including an operator-owned ingress Quadlet network and persistent TLS state
+  for containerized proxies.
 - Fix Android release APK SQLite packaging so the Flutter client bundles native
   SQLite through the current `sqlite3` package, with CI coverage for APK native
   library contents and runtime database opening on Android.

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -103,6 +103,21 @@ fn deployment_readme_documents_fresh_reverse_proxy_substrate() {
 }
 
 #[test]
+fn deployment_readme_discloses_user_scope_low_port_policy_for_fresh_proxy() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+    let fresh_substrate = markdown_section(&readme, "Provision A Fresh Reverse Proxy Substrate");
+
+    assert!(fresh_substrate.contains("user-scope"));
+    assert!(fresh_substrate.contains("PublishPort=80:80"));
+    assert!(fresh_substrate.contains("PublishPort=443:443"));
+    assert!(fresh_substrate.contains("PublishPort=443:443/udp"));
+    assert!(fresh_substrate.contains("net.ipv4.ip_unprivileged_port_start=80"));
+    assert!(fresh_substrate.contains("1024"));
+    assert!(fresh_substrate.contains("host-wide"));
+    assert!(fresh_substrate.contains("all unprivileged processes"));
+}
+
+#[test]
 fn deployment_readme_constructs_all_fresh_quadlet_references() {
     let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
     let fresh_substrate = markdown_section(&readme, "Provision A Fresh Reverse Proxy Substrate");

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -67,7 +67,7 @@ fn deployment_readme_documents_reverse_proxy_networking_patterns() {
     let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
 
     assert!(readme.contains("127.0.0.1:8080:8080"));
-    assert!(readme.contains("Network=oracy-proxy.network"));
+    assert!(readme.contains("Network=ingress.network"));
     assert!(readme.contains("http://oracy:8080"));
     assert!(readme.contains("When\n  rendering `oracy.container`"));
     assert!(readme.contains("leave the public `PublishPort=` directive out"));
@@ -81,6 +81,35 @@ fn deployment_readme_documents_reverse_proxy_networking_patterns() {
     assert!(readme.contains("0.0.0.0:8080:8080"));
     assert!(readme.contains("is reachability, not protection"));
     assert!(readme.contains("verify that the port is blocked from untrusted networks"));
+}
+
+#[test]
+fn deployment_readme_documents_fresh_reverse_proxy_substrate() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+    let fresh_substrate = markdown_section(&readme, "Provision A Fresh Reverse Proxy Substrate");
+
+    assert!(fresh_substrate.contains("ingress.network"));
+    assert!(fresh_substrate.contains("[Network]"));
+    assert!(fresh_substrate.contains("NetworkName=ingress"));
+    assert!(fresh_substrate.contains("Network=ingress.network"));
+    assert!(fresh_substrate.contains("NetworkAlias=oracy"));
+    assert!(fresh_substrate.contains("http://oracy:8080"));
+    assert!(fresh_substrate.contains("PublishPort=80:80"));
+    assert!(fresh_substrate.contains("PublishPort=443:443"));
+    assert!(fresh_substrate.contains("PublishPort=443:443/udp"));
+    assert!(fresh_substrate.contains("/data"));
+    assert!(fresh_substrate.contains("/config"));
+    assert!(fresh_substrate.contains("TLS"));
+}
+
+#[test]
+fn deployment_readme_resolves_shared_network_reference_to_ingress_unit() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+    let normalized = normalize_whitespace(&readme);
+
+    assert!(normalized.contains("operator-owned `ingress.network` unit"));
+    assert!(readme.contains("`ingress.network` Quadlet"));
+    assert!(!readme.contains("oracy-proxy.network"));
 }
 
 #[test]
@@ -138,4 +167,8 @@ fn markdown_section<'a>(document: &'a str, heading: &str) -> &'a str {
         .map_or(document.len(), |offset| after_heading + offset);
 
     &document[start..end]
+}
+
+fn normalize_whitespace(document: &str) -> String {
+    document.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -103,6 +103,28 @@ fn deployment_readme_documents_fresh_reverse_proxy_substrate() {
 }
 
 #[test]
+fn deployment_readme_constructs_all_fresh_quadlet_references() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+    let fresh_substrate = markdown_section(&readme, "Provision A Fresh Reverse Proxy Substrate");
+
+    for reference in fresh_quadlet_references(fresh_substrate) {
+        let (name, unit_type, construction_key) = reference_unit_construction(&reference)
+            .unwrap_or_else(|| {
+                panic!("{reference} should use a Quadlet unit suffix covered by this test")
+            });
+
+        assert!(
+            fresh_substrate.contains(unit_type),
+            "{reference} should document a {unit_type} unit"
+        );
+        assert!(
+            fresh_substrate.contains(&format!("{construction_key}={name}")),
+            "{reference} should document {construction_key}={name}"
+        );
+    }
+}
+
+#[test]
 fn deployment_readme_resolves_shared_network_reference_to_ingress_unit() {
     let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
     let normalized = normalize_whitespace(&readme);
@@ -171,4 +193,40 @@ fn markdown_section<'a>(document: &'a str, heading: &str) -> &'a str {
 
 fn normalize_whitespace(document: &str) -> String {
     document.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn fresh_quadlet_references(section: &str) -> Vec<String> {
+    let mut references = Vec::new();
+
+    for line in section.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let Some(reference) = (match key {
+            "Network" => Some(value),
+            "Volume" => value.split_once(':').map(|(source, _)| source),
+            _ => None,
+        }) else {
+            continue;
+        };
+
+        if reference.ends_with(".network") || reference.ends_with(".volume") {
+            references.push(reference.to_owned());
+        }
+    }
+
+    references.sort();
+    references.dedup();
+    references
+}
+
+fn reference_unit_construction(reference: &str) -> Option<(&str, &'static str, &'static str)> {
+    reference
+        .strip_suffix(".network")
+        .map(|name| (name, "[Network]", "NetworkName"))
+        .or_else(|| {
+            reference
+                .strip_suffix(".volume")
+                .map(|name| (name, "[Volume]", "VolumeName"))
+        })
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -165,6 +165,24 @@ Leave Oracy's public API `PublishPort=` directive out in this topology. The
 proxy reaches the backend through `http://oracy:8080` on the ingress network,
 and the public internet reaches only the proxy.
 
+Create the Caddy state volumes in the same Quadlet directory:
+
+```ini
+[Unit]
+Description=Operator reverse proxy TLS state
+
+[Volume]
+VolumeName=caddy-data
+```
+
+```ini
+[Unit]
+Description=Operator reverse proxy config state
+
+[Volume]
+VolumeName=caddy-config
+```
+
 The concrete proxy is operator scope. A Caddy Quadlet is one illustrative
 containerized proxy shape:
 
@@ -201,10 +219,10 @@ oracy.example.com {
 ```
 
 Persist the proxy's TLS state. For Caddy, `/data` carries certificates and
-other state, and `/config` carries persistent configuration state. Back those
-paths with named or host-backed volumes such as `caddy-data.volume` and
-`caddy-config.volume`; a stateless proxy container loses certificates on
-restart and can create avoidable ACME rate-limit pressure.
+other state, and `/config` carries persistent configuration state. The
+`caddy-data.volume` and `caddy-config.volume` units above back those container
+paths with named Podman volumes; a stateless proxy container loses
+certificates on restart and can create avoidable ACME rate-limit pressure.
 
 ## Operator-Owned Values
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -184,7 +184,13 @@ VolumeName=caddy-config
 ```
 
 The concrete proxy is operator scope. A Caddy Quadlet is one illustrative
-containerized proxy shape:
+containerized proxy shape. Because this user-scope rootless example publishes
+host ports 80 and 443, the host must allow unprivileged low-port binding before
+the proxy starts. Standard rootless Linux rejects host ports below 1024; for
+this example, provision `net.ipv4.ip_unprivileged_port_start=80` or lower
+through the host's persistent sysctl mechanism. That sysctl is host-wide: it
+allows all unprivileged processes on the host, not only this Caddy container,
+to bind ports at or above the configured floor.
 
 ```ini
 [Unit]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -73,12 +73,12 @@ client traffic:
   and add a shared network, for example:
 
   ```ini
-  Network=oracy-proxy.network
+  Network=ingress.network
   NetworkAlias=oracy
   ```
 
-  For Podman Quadlets, provide the matching operator-owned
-  `oracy-proxy.network` unit or replace the example with your existing network.
+  For Podman Quadlets, provide the matching operator-owned `ingress.network`
+  unit or replace the example with your existing network.
   Put the proxy on the same network and proxy to `http://oracy:8080`. Docker
   Compose services in the same project use shared service DNS by default; use
   the Compose service name or network alias `oracy` for the backend service.
@@ -130,6 +130,81 @@ The Quadlet template's `[Install]` relationship makes the generated service
 part of the user default target at `daemon-reload` time. For boot persistence
 under user-scope systemd, enable lingering for the service account through the
 host provisioning mechanism.
+
+## Provision A Fresh Reverse Proxy Substrate
+
+If the host does not already have a reverse proxy, provision the ingress fabric
+as operator-owned infrastructure before joining Oracy to it. The ingress
+network and proxy are not Oracy artifacts; Oracy only needs a private route to
+the proxy.
+
+For Podman Quadlet deployments, create an `ingress.network` Quadlet in the same
+user-scope Quadlet directory as the persistent services:
+
+```ini
+[Unit]
+Description=Operator ingress network
+
+[Network]
+NetworkName=ingress
+
+[Install]
+WantedBy=default.target
+```
+
+`NetworkName=ingress` gives the Podman network an operator-owned name instead
+of an app-specific name. Render `oracy.container` with the shared-network
+shape from the install section:
+
+```ini
+Network=ingress.network
+NetworkAlias=oracy
+```
+
+Leave Oracy's public API `PublishPort=` directive out in this topology. The
+proxy reaches the backend through `http://oracy:8080` on the ingress network,
+and the public internet reaches only the proxy.
+
+The concrete proxy is operator scope. A Caddy Quadlet is one illustrative
+containerized proxy shape:
+
+```ini
+[Unit]
+Description=Operator reverse proxy
+
+[Container]
+Image=docker.io/library/caddy:2
+ContainerName=ingress-proxy
+Network=ingress.network
+PublishPort=80:80
+PublishPort=443:443
+PublishPort=443:443/udp
+Volume=/var/lib/caddy/Caddyfile:/etc/caddy/Caddyfile:ro,Z
+Volume=caddy-data.volume:/data:rw,Z
+Volume=caddy-config.volume:/config:rw,Z
+
+[Service]
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+The Caddyfile for that proxy would route the public site to Oracy by its
+network alias:
+
+```caddyfile
+oracy.example.com {
+	reverse_proxy http://oracy:8080
+}
+```
+
+Persist the proxy's TLS state. For Caddy, `/data` carries certificates and
+other state, and `/config` carries persistent configuration state. Back those
+paths with named or host-backed volumes such as `caddy-data.volume` and
+`caddy-config.volume`; a stateless proxy container loses certificates on
+restart and can create avoidable ACME rate-limit pressure.
 
 ## Operator-Owned Values
 


### PR DESCRIPTION
## Summary

- Documents the fresh reverse-proxy substrate path for operators without an existing proxy.
- Replaces the app-specific shared-network example with an operator-owned ingress network.
- Adds deployment artifact regressions for the new section and resolved shared-network reference.

## Changes

- `deploy/README.md` now includes an operator-owned `ingress.network` Quadlet example and a Caddy-style containerized proxy example with persistent TLS state.
- `backend/tests/deployment_artifacts.rs` asserts the fresh substrate section exists and that the shared-network reference resolves to the ingress Quadlet guidance.
- `CHANGELOG.md` records the operator-facing deployment documentation fix.

## GitHub Issue(s)

Closes #97

## Test plan

- RED: `cargo test --test deployment_artifacts` failed on the missing fresh substrate section, old `oracy-proxy.network` reference, and dangling network-unit reference.
- `cargo test --test deployment_artifacts`
- `cargo fmt --check`
- `git diff --check`
- `./scripts/backend-ci`
