### PR TITLE
feat(release): adopt release discipline and retroactively cut v0.1.0 tag/release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,13 @@ jobs:
         run: |
           test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
 
+      - name: Require tag target on main
+        run: |
+          set -euo pipefail
+          git fetch --force origin refs/heads/main:refs/remotes/origin/main
+          tag_commit="$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")"
+          git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*.*.*"
+    paths:
+      - "CHANGELOG.md"
+      - "RELEASING.md"
+      - "backend/Cargo.toml"
+      - "client/pubspec.yaml"
+      - "Containerfile"
+      - "scripts/release-check"
+      - ".github/workflows/release.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "CHANGELOG.md"
+      - "RELEASING.md"
+      - "backend/Cargo.toml"
+      - "client/pubspec.yaml"
+      - "Containerfile"
+      - "scripts/release-check"
+      - ".github/workflows/release.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  metadata:
+    name: Release metadata
+    if: github.ref_type != 'tag'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check release metadata
+        run: ./scripts/release-check metadata
+
+  publish:
+    name: Publish GitHub Release
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Require annotated tag
+        run: |
+          test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Install container tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Build backend binary
+        working-directory: backend
+        run: cargo build --release --locked --bin oracy-backend
+
+      - name: Build backend container image
+        run: podman build -t "localhost/oracy:$GITHUB_REF_NAME" .
+
+      - name: Verify release artifacts
+        run: |
+          ./scripts/release-check release "$GITHUB_REF_NAME" \
+            --backend-bin backend/target/release/oracy-backend \
+            --container-image "localhost/oracy:$GITHUB_REF_NAME"
+
+      - name: Extract release notes
+        run: ./scripts/release-check notes "$GITHUB_REF_NAME" > release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "Oracy $GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [0.1.0] - 2026-05-06
+
+- Adopt a documented release discipline with lockstep version checks,
+  annotated-tag and GitHub Release publication gates, backend binary
+  `--version` reporting, and local backend container artifact verification.
 - Bound Android Gradle memory and worker defaults so release APK builds fit on
   representative 16 GB developer workstations.
 - Document parallel-then-swap and stop-then-replace cutover strategies for

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,90 @@
+# Releasing Oracy
+
+Audience: the release operator cutting an Oracy repository release. This
+document assumes access to the repository, GitHub, the backend container
+runtime, and the deployment host.
+
+## Release Identity
+
+Oracy uses one repository tag for all release artifacts. The tag is
+`vX.Y.Z`; backend `backend/Cargo.toml` version is `X.Y.Z`; client
+`client/pubspec.yaml` release version is `X.Y.Z` with a platform build suffix
+such as `+1`.
+
+The tag is the source-truth identity. Artifacts built from the tag must report
+that identity:
+
+- `oracy-backend --version` reports `oracy-backend X.Y.Z`.
+- Android release manifests derive `versionName` and `versionCode` from
+  `client/pubspec.yaml`.
+- Backend container images are tagged with the same `X.Y.Z` release identity
+  and run the backend binary that reports that version.
+
+## Pre-Release Gate
+
+A releasable commit is on `main`, up to date with `origin/main`, and has a
+clean working tree. `--allow-dirty` is not part of the release path.
+
+Before tagging:
+
+```sh
+git checkout main
+git pull --ff-only
+git status --short
+./scripts/release-check metadata
+```
+
+The changelog must be ready for the tag: `## Unreleased` is present and empty,
+and the release notes live under `## [X.Y.Z] - YYYY-MM-DD`.
+
+## Atomic Release Operation
+
+A release is one conceptual operation even when the shell uses more than one
+command: changelog rollup, source-version verification, annotated tag, tag
+push, and GitHub Release publication describe the same release boundary.
+
+For `vX.Y.Z`:
+
+```sh
+git tag -a "vX.Y.Z" -m "Oracy vX.Y.Z" -m "Release date: YYYY-MM-DD" -m "Source: CHANGELOG.md [X.Y.Z]"
+git push origin "vX.Y.Z"
+```
+
+The tag must point at the commit whose source files already satisfy the release
+metadata invariants. If a published tag points at a commit that violates those
+invariants, the tag is invalid; delete and re-cut the release rather than
+amending the tagged commit.
+
+## Post-Release Gate
+
+The tag push runs the release workflow. That workflow verifies the annotated
+tag, builds the backend binary, builds a local backend container image tagged
+with the git tag, verifies both artifact version reports, extracts release
+notes from `CHANGELOG.md`, and publishes the GitHub Release.
+
+Operators still own deployment artifacts and host state. Build or promote the
+deployment image from the release tag, tag it with the release identity, update
+the deployment reference to that immutable tag, and validate the live service.
+Registry publishing is not owned by this repository yet.
+
+Manual GitHub Release creation, when needed after a workflow failure, uses the
+same notes source:
+
+```sh
+./scripts/release-check notes "vX.Y.Z" > /tmp/oracy-release-notes.md
+gh release create "vX.Y.Z" --title "Oracy vX.Y.Z" --notes-file /tmp/oracy-release-notes.md
+```
+
+## Tesserine Adaptation
+
+Tesserine ADR-0006, "Release Discipline for Cargo-Workspace Repos", binds the
+principles Oracy follows: clean tree, annotated tag, version metadata before
+tagging, changelog rollup at the tagged commit, and a mechanically verifiable
+version invariant. Oracy adapts those principles without adopting
+`cargo-release`, because `backend/` is a single crate and the repository also
+contains Flutter client and container artifacts.
+
+Tesserine ADR-0010, "Deployment Release Candidates", applies when Oracy starts
+cutting release candidates. Stable releases use `vX.Y.Z`; future release
+candidates use immutable `vX.Y.Z-rc.N` tags and must not deploy from mutable
+branch refs. Oracy does not ship release candidates for `v0.1.0`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,11 +31,12 @@ Before tagging:
 git checkout main
 git pull --ff-only
 git status --short
-./scripts/release-check metadata
+./scripts/release-check release "vX.Y.Z"
 ```
 
-The changelog must be ready for the tag: `## Unreleased` is present and empty,
-and the release notes live under `## [X.Y.Z] - YYYY-MM-DD`.
+The release check must target the tag being cut. It verifies that source
+versions match `X.Y.Z`, `## Unreleased` is present and empty, and the release
+notes live under `## [X.Y.Z] - YYYY-MM-DD`.
 
 ## Atomic Release Operation
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::net::SocketAddr;
 
 use oracy_backend::abandonment_sweeper::{AbandonmentSweeperConfig, run_abandonment_sweeper_loop};
@@ -17,11 +18,39 @@ use tracing::error;
 
 #[tokio::main]
 async fn main() {
+    match startup_command(env::args().skip(1)) {
+        StartupCommand::Run => {}
+        StartupCommand::Version => {
+            println!("oracy-backend {}", env!("CARGO_PKG_VERSION"));
+            return;
+        }
+        StartupCommand::UsageError(message) => {
+            eprintln!("{message}");
+            eprintln!("usage: oracy-backend [--version]");
+            std::process::exit(2);
+        }
+    }
+
     init_tracing();
 
     if let Err(error) = run().await {
         error!("{error}");
         std::process::exit(1);
+    }
+}
+
+enum StartupCommand {
+    Run,
+    Version,
+    UsageError(String),
+}
+
+fn startup_command(mut args: impl Iterator<Item = String>) -> StartupCommand {
+    match (args.next(), args.next()) {
+        (None, None) => StartupCommand::Run,
+        (Some(flag), None) if flag == "--version" => StartupCommand::Version,
+        (Some(flag), None) => StartupCommand::UsageError(format!("unknown argument: {flag}")),
+        _ => StartupCommand::UsageError("too many arguments".to_owned()),
     }
 }
 

--- a/backend/tests/startup.rs
+++ b/backend/tests/startup.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::io::Read;
 #[cfg(unix)]
 use std::net::{SocketAddr, TcpListener, TcpStream};
-#[cfg(unix)]
 use std::process::{Child, Command, ExitStatus, Stdio};
 #[cfg(unix)]
 use std::thread;
@@ -14,6 +13,30 @@ use oracy_backend::bootstrap::{BootstrapError, load_runtime_from_env, load_runti
 use tempfile::TempDir;
 
 mod support;
+
+#[test]
+fn backend_version_exits_before_runtime_configuration_is_loaded() {
+    let output = Command::new(env!("CARGO_BIN_EXE_oracy-backend"))
+        .arg("--version")
+        .env_remove("ORACY_CONFIG")
+        .env_remove("OPENAI_API_KEY")
+        .output()
+        .expect("run backend --version");
+
+    assert!(
+        output.status.success(),
+        "--version should exit successfully without runtime configuration"
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout is utf8"),
+        format!("oracy-backend {}\n", env!("CARGO_PKG_VERSION"))
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "--version should not emit stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
 
 #[tokio::test]
 async fn startup_rejects_missing_oracy_config_env() {

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+usage() {
+    cat <<'EOF'
+usage:
+  scripts/release-check metadata
+  scripts/release-check notes vX.Y.Z
+  scripts/release-check release vX.Y.Z [--backend-bin PATH] [--container-image IMAGE]
+EOF
+}
+
+die() {
+    printf 'release-check: %s\n' "$*" >&2
+    exit 1
+}
+
+backend_version() {
+    awk -F '"' '/^version = / { print $2; exit }' "$repo_root/backend/Cargo.toml"
+}
+
+client_version() {
+    awk '/^version:[[:space:]]*/ { print $2; exit }' "$repo_root/client/pubspec.yaml"
+}
+
+release_from_tag() {
+    local tag="$1"
+    [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] || die "release version must look like vX.Y.Z: $tag"
+    printf '%s.%s.%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+}
+
+check_versions_lockstep() {
+    local backend client client_release
+    backend="$(backend_version)"
+    client="$(client_version)"
+    [[ -n "$backend" ]] || die "backend/Cargo.toml version not found"
+    [[ -n "$client" ]] || die "client/pubspec.yaml version not found"
+    client_release="${client%%+*}"
+
+    [[ "$backend" == "$client_release" ]] || die "backend version $backend does not match client release version $client_release"
+}
+
+check_changelog_structure() {
+    local changelog="$repo_root/CHANGELOG.md"
+    [[ -f "$changelog" ]] || die "CHANGELOG.md not found"
+
+    local unreleased_count
+    unreleased_count="$(grep -c '^## Unreleased$' "$changelog" || true)"
+    [[ "$unreleased_count" == "1" ]] || die "CHANGELOG.md must contain exactly one ## Unreleased heading"
+
+    awk '
+        /^## / {
+            if ($0 == "## Unreleased") {
+                if (seen_release) {
+                    print "CHANGELOG.md places ## Unreleased after a release heading" > "/dev/stderr"
+                    exit 1
+                }
+                next
+            }
+
+            if ($0 !~ /^## \[[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\] - [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/) {
+                print "CHANGELOG.md release heading is malformed: " $0 > "/dev/stderr"
+                exit 1
+            }
+
+            seen_release = 1
+        }
+    ' "$changelog" || exit 1
+}
+
+check_unreleased_empty() {
+    awk '
+        $0 == "## Unreleased" {
+            inside = 1
+            next
+        }
+        inside && /^## / {
+            exit bad
+        }
+        inside && NF {
+            print "CHANGELOG.md has unreleased content at tag time: " $0 > "/dev/stderr"
+            bad = 1
+        }
+        END {
+            exit bad
+        }
+    ' "$repo_root/CHANGELOG.md" || exit 1
+}
+
+check_release_heading() {
+    local version="$1"
+    grep -Eq "^## \\[$version\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" "$repo_root/CHANGELOG.md" \
+        || die "CHANGELOG.md has no release heading for [$version]"
+}
+
+check_release_versions() {
+    local version="$1"
+    local backend client client_release
+    backend="$(backend_version)"
+    client="$(client_version)"
+    client_release="${client%%+*}"
+
+    [[ "$backend" == "$version" ]] || die "backend version $backend does not match tag version $version"
+    [[ "$client_release" == "$version" ]] || die "client release version $client_release does not match tag version $version"
+}
+
+check_backend_binary() {
+    local version="$1"
+    local bin="$2"
+    [[ -x "$bin" ]] || die "backend binary is not executable: $bin"
+
+    local output
+    output="$("$bin" --version)"
+    [[ "$output" == "oracy-backend $version" ]] || die "backend binary reports '$output', expected 'oracy-backend $version'"
+}
+
+container_runtime() {
+    if [[ -n "${ORACY_CONTAINER_RUNTIME:-}" ]]; then
+        command -v "$ORACY_CONTAINER_RUNTIME" >/dev/null 2>&1 || die "configured container runtime not found: $ORACY_CONTAINER_RUNTIME"
+        printf '%s\n' "$ORACY_CONTAINER_RUNTIME"
+    elif command -v podman >/dev/null 2>&1; then
+        printf 'podman\n'
+    elif command -v docker >/dev/null 2>&1; then
+        printf 'docker\n'
+    else
+        die "podman or docker is required for --container-image checks"
+    fi
+}
+
+check_container_image() {
+    local version="$1"
+    local image="$2"
+    local runtime output
+    runtime="$(container_runtime)"
+    output="$("$runtime" run --rm "$image" --version)"
+    [[ "$output" == "oracy-backend $version" ]] || die "container image reports '$output', expected 'oracy-backend $version'"
+}
+
+emit_notes() {
+    local version="$1"
+    awk -v prefix="## [$version] - " -v version="$version" '
+        index($0, prefix) == 1 {
+            found = 1
+            inside = 1
+            next
+        }
+        inside && /^## / {
+            exit
+        }
+        inside {
+            lines[++line_count] = $0
+        }
+        END {
+            if (!found) {
+                print "CHANGELOG.md has no release heading for [" version "]" > "/dev/stderr"
+                exit 1
+            }
+
+            first = 1
+            while (first <= line_count && lines[first] == "") {
+                first++
+            }
+
+            last = line_count
+            while (last >= first && lines[last] == "") {
+                last--
+            }
+
+            for (i = first; i <= last; i++) {
+                print lines[i]
+            }
+        }
+    ' "$repo_root/CHANGELOG.md"
+}
+
+run_metadata() {
+    check_versions_lockstep
+    check_changelog_structure
+}
+
+run_release() {
+    local tag="$1"
+    shift
+
+    local version backend_bin="" container_image=""
+    version="$(release_from_tag "$tag")"
+
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --backend-bin)
+                [[ "$#" -ge 2 ]] || die "--backend-bin requires a path"
+                backend_bin="$2"
+                shift 2
+                ;;
+            --container-image)
+                [[ "$#" -ge 2 ]] || die "--container-image requires an image"
+                container_image="$2"
+                shift 2
+                ;;
+            *)
+                die "unknown release option: $1"
+                ;;
+        esac
+    done
+
+    run_metadata
+    check_release_versions "$version"
+    check_release_heading "$version"
+    check_unreleased_empty
+    [[ -z "$backend_bin" ]] || check_backend_binary "$version" "$backend_bin"
+    [[ -z "$container_image" ]] || check_container_image "$version" "$container_image"
+}
+
+main() {
+    [[ "$#" -ge 1 ]] || {
+        usage >&2
+        exit 2
+    }
+
+    case "$1" in
+        metadata)
+            [[ "$#" == 1 ]] || die "metadata takes no arguments"
+            run_metadata
+            ;;
+        notes)
+            [[ "$#" == 2 ]] || die "notes requires exactly one vX.Y.Z argument"
+            emit_notes "$(release_from_tag "$2")"
+            ;;
+        release)
+            [[ "$#" -ge 2 ]] || die "release requires a vX.Y.Z argument"
+            shift
+            run_release "$@"
+            ;;
+        -h|--help|help)
+            usage
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Establishes Oracy's release ceremony for v0.1.0 with release-operator documentation and ADR-0006/0010 adaptation notes.
- Consolidates `CHANGELOG.md` under `## [0.1.0] - 2026-05-06` while leaving `## Unreleased` empty for future work.
- Adds source and artifact guards: backend `--version`, release-check metadata/release/notes modes, and a tag-triggered GitHub Release workflow that verifies the backend binary and local container image.

## Changes

- Adds `RELEASING.md` with release identity, pre-release, atomic release, post-release, and Tesserine adaptation guidance.
- Adds `scripts/release-check` for lockstep version checks, changelog structure, strict tag-time checks, release-note extraction, and binary/container self-report probes.
- Adds `.github/workflows/release.yml` to run metadata checks on release-surface changes and publish GitHub Releases from annotated `v*.*.*` tags.
- Adds `oracy-backend --version` before runtime configuration loading, with startup regression coverage.

## GitHub Issue(s)

Closes #105

## Test plan

- `cargo test --test startup backend_version_exits_before_runtime_configuration_is_loaded` after observing the RED failure before implementation.
- `cargo build --release --locked --bin oracy-backend`
- `podman build -t localhost/oracy:v0.1.0 .`
- `./scripts/release-check metadata`
- `./scripts/release-check release v0.1.0 --backend-bin backend/target/release/oracy-backend --container-image localhost/oracy:v0.1.0`
- `./scripts/release-check notes v0.1.0`
- `bash -n scripts/release-check`
- `git diff --check`
- `./scripts/backend-ci`
