### PR TITLE
fix(deploy): surface preserve-via-backup cutover guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Clarify `stop-then-replace` cutover guidance so operators can preserve
+  previous canonical-path substrate through a rollback-window backup before
+  creating the replacement deployment at canonical paths.
+
 ## [0.1.0] - 2026-05-06
 
 - Adopt a documented release discipline with lockstep version checks,

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -185,6 +185,24 @@ fn deployment_readme_classifies_cutover_reversibility_and_data_handling() {
 }
 
 #[test]
+fn deployment_readme_surfaces_stop_then_replace_preserve_via_backup_pattern() {
+    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
+    let cutover = markdown_section(&readme, "Cut Over From An Existing Deployment");
+    let stop_then_replace = text_between(
+        cutover,
+        "Classify every `stop-then-replace` operation before running it:",
+        "Rollback model differs by strategy.",
+    );
+    let normalized = normalize_whitespace(stop_then_replace);
+
+    assert!(stop_then_replace.contains("preserve-via-backup"));
+    assert!(normalized.contains("reclaim canonical paths or names"));
+    assert!(stop_then_replace.contains("/var/lib/oracy.rollback"));
+    assert!(normalized.contains("replacement `/var/lib/oracy`"));
+    assert!(normalized.contains("rollback window is intentionally closed"));
+}
+
+#[test]
 fn deployment_readme_resolves_shared_network_reference_to_ingress_unit() {
     let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
     let normalized = normalize_whitespace(&readme);
@@ -253,6 +271,18 @@ fn markdown_section<'a>(document: &'a str, heading: &str) -> &'a str {
 
 fn normalize_whitespace(document: &str) -> String {
     document.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn text_between<'a>(document: &'a str, start_marker: &str, end_marker: &str) -> &'a str {
+    let start = document
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("{start_marker} should exist"));
+    let after_start = start + start_marker.len();
+    let end = document[after_start..]
+        .find(end_marker)
+        .map_or(document.len(), |offset| after_start + offset);
+
+    &document[start..end]
 }
 
 fn fresh_quadlet_references(section: &str) -> Vec<String> {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -278,6 +278,17 @@ Classify every `stop-then-replace` operation before running it:
 | rollback-window retention | Reversible | The previous state, configuration, secrets, routes, volumes, and host bindings remain available until the operator accepts the replacement and closes the rollback window. |
 | decommission | `irreversible-state` once state or rollback surfaces are removed | Remove previous state, secrets, routes, volumes, or host bindings only after production validation passes and the rollback window is intentionally closed. |
 
+When `stop-then-replace` must reclaim canonical paths or names from the
+start, preserve-via-backup is one realization of rollback-window retention:
+move the previous substrate to a backup location before creating the
+replacement at the canonical location. For example, move previous
+`/var/lib/oracy` to `/var/lib/oracy.rollback`, then create the replacement
+`/var/lib/oracy` for the new stack. Keep that backup substrate, along with the
+previous configuration, secrets, routes, volumes, and host bindings required
+for rollback, until the rollback window is intentionally closed. Operators may
+choose a different rollback substrate, such as an off-host backup, when it
+preserves the same rollback capability.
+
 Rollback model differs by strategy. For `parallel-then-swap`, roll back ingress
 first: restore the previous DNS, proxy route, load-balancer target, or host
 publish that pointed to the previous deployment. Restart or re-enable the


### PR DESCRIPTION
## Summary

- Documents preserve-via-backup as a stop-then-replace realization of rollback-window retention.
- Keeps the guidance scoped to canonical path/name reclamation, with `/var/lib/oracy` and `/var/lib/oracy.rollback` as the concrete operator example.
- Adds section-scoped regression coverage so the guidance remains in the stop-then-replace cutover path.

## Changes

- Updated `deploy/README.md` in the existing deployment cutover section.
- Added a deployment artifact regression test for the stop-then-replace preserve-via-backup pattern.
- Added an Unreleased changelog note for the operator-facing deployment guidance fix.

## GitHub Issue(s)

Closes #104

## Test plan

- RED: `cargo test --test deployment_artifacts deployment_readme_surfaces_stop_then_replace_preserve_via_backup_pattern -- --exact` failed before the README change on missing `preserve-via-backup` guidance.
- GREEN: `cargo test --test deployment_artifacts deployment_readme_surfaces_stop_then_replace_preserve_via_backup_pattern -- --exact`
- `cargo test --test deployment_artifacts`
- `./scripts/backend-ci`
