### PR TITLE
feat(client-web): durable restart resume for web submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Persist web submission audio bytes and attempt metadata so browser reloads
+  can resume interrupted uploads with the original `Idempotency-Key` instead of
+  creating duplicate backend attempts.
 - Clarify `stop-then-replace` cutover guidance so operators can preserve
   previous canonical-path substrate through a rollback-window backup before
   creating the replacement deployment at canonical paths.

--- a/client/lib/app.dart
+++ b/client/lib/app.dart
@@ -76,6 +76,11 @@ class _HomePageState extends ConsumerState<HomePage>
       }
       HomeWidgetService.setOnRecordCallback(_startRecordingFromWidget);
       _setupTranscriptionListener();
+      if (kIsWeb) {
+        unawaited(
+          ref.read(transcriptionProvider.notifier).resumeRecoverableUpload(),
+        );
+      }
     });
   }
 

--- a/client/lib/db/database.dart
+++ b/client/lib/db/database.dart
@@ -69,12 +69,39 @@ class PendingUploads extends Table {
   ];
 }
 
-@DriftDatabase(tables: [PendingUploads])
+/// Browser-side audio bytes and multipart metadata for durable web retries.
+class WebUploadPayloads extends Table {
+  /// Stable key shared with the backend idempotency key for this attempt.
+  TextColumn get idempotencyKey => text()();
+
+  /// Original browser blob URL or durable upload source.
+  TextColumn get audioPath => text()();
+
+  /// Audio bytes required for chunk replay after a browser reload.
+  BlobColumn get audioBytes => blob()();
+
+  /// Multipart filename derived from the original web recording metadata.
+  TextColumn get filename => text()();
+
+  /// Optional multipart content type.
+  TextColumn get contentType => text().nullable()();
+
+  /// When this payload was first persisted.
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+
+  /// When this payload was last refreshed.
+  DateTimeColumn get updatedAt => dateTime().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {idempotencyKey};
+}
+
+@DriftDatabase(tables: [PendingUploads, WebUploadPayloads])
 class AppDatabase extends _$AppDatabase {
   AppDatabase([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -89,6 +116,9 @@ class AppDatabase extends _$AppDatabase {
           'ON pending_uploads (audio_path)',
         );
         await _backfillMissingIdempotencyKeys();
+      }
+      if (from < 4) {
+        await m.createTable(webUploadPayloads);
       }
     },
   );
@@ -218,12 +248,31 @@ class AppDatabase extends _$AppDatabase {
 
   /// Replace the idempotency key before starting an intentional fresh attempt.
   Future<int> replaceUploadIdempotencyKey(int id) {
-    return (update(pendingUploads)..where((t) => t.id.equals(id))).write(
-      PendingUploadsCompanion(
-        idempotencyKey: Value(_uuid.v4()),
-        updatedAt: Value(DateTime.now()),
-      ),
-    );
+    return transaction(() async {
+      final upload = await getUploadById(id);
+      if (upload == null) {
+        return 0;
+      }
+
+      final previousKey = upload.idempotencyKey;
+      final nextKey = _uuid.v4();
+      final updated =
+          await (update(pendingUploads)..where((t) => t.id.equals(id))).write(
+            PendingUploadsCompanion(
+              idempotencyKey: Value(nextKey),
+              updatedAt: Value(DateTime.now()),
+            ),
+          );
+
+      if (previousKey != null && previousKey.isNotEmpty) {
+        await _replaceWebUploadPayloadIdempotencyKey(
+          previousKey: previousKey,
+          nextKey: nextKey,
+        );
+      }
+
+      return updated;
+    });
   }
 
   /// Mark upload as permanently failed and excluded from automatic retries.
@@ -250,7 +299,7 @@ class AppDatabase extends _$AppDatabase {
   /// Mark upload as completed and optionally delete the record.
   Future<int> markAsCompleted(int id, {bool deleteRecord = true}) async {
     if (deleteRecord) {
-      return (delete(pendingUploads)..where((t) => t.id.equals(id))).go();
+      return deletePendingUpload(id);
     }
     return updateUploadStatus(id, UploadStatus.completed);
   }
@@ -281,9 +330,34 @@ class AppDatabase extends _$AppDatabase {
         );
   }
 
+  /// Restore every uploading row after a browser restart.
+  Future<int> restoreUploadingUploadsAfterRestart() {
+    return (update(
+      pendingUploads,
+    )..where((t) => t.status.equals(UploadStatus.uploading.index))).write(
+      PendingUploadsCompanion(
+        status: Value(UploadStatus.failed.index),
+        errorMessage: const Value('Upload interrupted before completion.'),
+        updatedAt: Value(DateTime.now()),
+      ),
+    );
+  }
+
   /// Delete a pending upload by ID.
   Future<int> deletePendingUpload(int id) {
-    return (delete(pendingUploads)..where((t) => t.id.equals(id))).go();
+    return transaction(() async {
+      final upload = await getUploadById(id);
+      final deleted = await (delete(
+        pendingUploads,
+      )..where((t) => t.id.equals(id))).go();
+
+      final key = upload?.idempotencyKey;
+      if (key != null && key.isNotEmpty) {
+        await deleteWebUploadPayload(key);
+      }
+
+      return deleted;
+    });
   }
 
   /// Get uploads whose server work succeeded but local file cleanup still needs retrying.
@@ -338,6 +412,84 @@ class AppDatabase extends _$AppDatabase {
               t.createdAt.isSmallerThanValue(cutoff),
         ))
         .go();
+  }
+
+  /// Store or refresh durable browser audio bytes for a queued web upload.
+  Future<int> upsertWebUploadPayload({
+    required String idempotencyKey,
+    required String audioPath,
+    required List<int> bytes,
+    required String filename,
+    String? contentType,
+  }) {
+    return into(webUploadPayloads).insert(
+      WebUploadPayloadsCompanion.insert(
+        idempotencyKey: idempotencyKey,
+        audioPath: audioPath,
+        audioBytes: Uint8List.fromList(bytes),
+        filename: filename,
+        contentType: Value(contentType),
+        updatedAt: Value(DateTime.now()),
+      ),
+      mode: InsertMode.insertOrReplace,
+    );
+  }
+
+  /// Load durable browser audio bytes by the upload idempotency key.
+  Future<WebUploadPayload?> getWebUploadPayload(String idempotencyKey) {
+    return (select(
+      webUploadPayloads,
+    )..where((t) => t.idempotencyKey.equals(idempotencyKey))).getSingleOrNull();
+  }
+
+  /// Delete durable browser audio bytes for a completed or discarded upload.
+  Future<int> deleteWebUploadPayload(String idempotencyKey) {
+    return (delete(
+      webUploadPayloads,
+    )..where((t) => t.idempotencyKey.equals(idempotencyKey))).go();
+  }
+
+  /// Remove stale browser payloads that are no longer referenced by the queue.
+  Future<int> cleanupStaleWebUploadPayloads({
+    Duration maxAge = const Duration(days: 7),
+  }) async {
+    final cutoff = DateTime.now().subtract(maxAge);
+    final queuedKeys = (await select(pendingUploads).get())
+        .map((upload) => upload.idempotencyKey)
+        .whereType<String>()
+        .where((key) => key.isNotEmpty)
+        .toSet();
+    final stalePayloads = await (select(
+      webUploadPayloads,
+    )..where((t) => t.createdAt.isSmallerThanValue(cutoff))).get();
+
+    var removed = 0;
+    for (final payload in stalePayloads) {
+      if (queuedKeys.contains(payload.idempotencyKey)) {
+        continue;
+      }
+      removed += await deleteWebUploadPayload(payload.idempotencyKey);
+    }
+    return removed;
+  }
+
+  Future<void> _replaceWebUploadPayloadIdempotencyKey({
+    required String previousKey,
+    required String nextKey,
+  }) async {
+    final payload = await getWebUploadPayload(previousKey);
+    if (payload == null) {
+      return;
+    }
+
+    await upsertWebUploadPayload(
+      idempotencyKey: nextKey,
+      audioPath: payload.audioPath,
+      bytes: payload.audioBytes,
+      filename: payload.filename,
+      contentType: payload.contentType,
+    );
+    await deleteWebUploadPayload(previousKey);
   }
 
   Future<void> _dedupePendingUploadsByAudioPath() async {

--- a/client/lib/db/database.dart
+++ b/client/lib/db/database.dart
@@ -86,6 +86,9 @@ class WebUploadPayloads extends Table {
   /// Optional multipart content type.
   TextColumn get contentType => text().nullable()();
 
+  /// Original recording timestamp supplied by the foreground recorder.
+  DateTimeColumn get recordedAt => dateTime().nullable()();
+
   /// When this payload was first persisted.
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
 
@@ -101,7 +104,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -119,6 +122,9 @@ class AppDatabase extends _$AppDatabase {
       }
       if (from < 4) {
         await m.createTable(webUploadPayloads);
+      }
+      if (from >= 4 && from < 5) {
+        await m.addColumn(webUploadPayloads, webUploadPayloads.recordedAt);
       }
     },
   );
@@ -421,6 +427,7 @@ class AppDatabase extends _$AppDatabase {
     required List<int> bytes,
     required String filename,
     String? contentType,
+    DateTime? recordedAt,
   }) {
     return into(webUploadPayloads).insert(
       WebUploadPayloadsCompanion.insert(
@@ -429,6 +436,7 @@ class AppDatabase extends _$AppDatabase {
         audioBytes: Uint8List.fromList(bytes),
         filename: filename,
         contentType: Value(contentType),
+        recordedAt: Value(recordedAt?.toUtc()),
         updatedAt: Value(DateTime.now()),
       ),
       mode: InsertMode.insertOrReplace,
@@ -488,6 +496,7 @@ class AppDatabase extends _$AppDatabase {
       bytes: payload.audioBytes,
       filename: payload.filename,
       contentType: payload.contentType,
+      recordedAt: payload.recordedAt,
     );
     await deleteWebUploadPayload(previousKey);
   }

--- a/client/lib/db/database.g.dart
+++ b/client/lib/db/database.g.dart
@@ -645,6 +645,17 @@ class $WebUploadPayloadsTable extends WebUploadPayloads
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _recordedAtMeta = const VerificationMeta(
+    'recordedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> recordedAt = GeneratedColumn<DateTime>(
+    'recorded_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',
   );
@@ -675,6 +686,7 @@ class $WebUploadPayloadsTable extends WebUploadPayloads
     audioBytes,
     filename,
     contentType,
+    recordedAt,
     createdAt,
     updatedAt,
   ];
@@ -734,6 +746,12 @@ class $WebUploadPayloadsTable extends WebUploadPayloads
         ),
       );
     }
+    if (data.containsKey('recorded_at')) {
+      context.handle(
+        _recordedAtMeta,
+        recordedAt.isAcceptableOrUnknown(data['recorded_at']!, _recordedAtMeta),
+      );
+    }
     if (data.containsKey('created_at')) {
       context.handle(
         _createdAtMeta,
@@ -775,6 +793,10 @@ class $WebUploadPayloadsTable extends WebUploadPayloads
         DriftSqlType.string,
         data['${effectivePrefix}content_type'],
       ),
+      recordedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}recorded_at'],
+      ),
       createdAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}created_at'],
@@ -809,6 +831,9 @@ class WebUploadPayload extends DataClass
   /// Optional multipart content type.
   final String? contentType;
 
+  /// Original recording timestamp supplied by the foreground recorder.
+  final DateTime? recordedAt;
+
   /// When this payload was first persisted.
   final DateTime createdAt;
 
@@ -820,6 +845,7 @@ class WebUploadPayload extends DataClass
     required this.audioBytes,
     required this.filename,
     this.contentType,
+    this.recordedAt,
     required this.createdAt,
     this.updatedAt,
   });
@@ -832,6 +858,9 @@ class WebUploadPayload extends DataClass
     map['filename'] = Variable<String>(filename);
     if (!nullToAbsent || contentType != null) {
       map['content_type'] = Variable<String>(contentType);
+    }
+    if (!nullToAbsent || recordedAt != null) {
+      map['recorded_at'] = Variable<DateTime>(recordedAt);
     }
     map['created_at'] = Variable<DateTime>(createdAt);
     if (!nullToAbsent || updatedAt != null) {
@@ -849,6 +878,9 @@ class WebUploadPayload extends DataClass
       contentType: contentType == null && nullToAbsent
           ? const Value.absent()
           : Value(contentType),
+      recordedAt: recordedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(recordedAt),
       createdAt: Value(createdAt),
       updatedAt: updatedAt == null && nullToAbsent
           ? const Value.absent()
@@ -867,6 +899,7 @@ class WebUploadPayload extends DataClass
       audioBytes: serializer.fromJson<Uint8List>(json['audioBytes']),
       filename: serializer.fromJson<String>(json['filename']),
       contentType: serializer.fromJson<String?>(json['contentType']),
+      recordedAt: serializer.fromJson<DateTime?>(json['recordedAt']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime?>(json['updatedAt']),
     );
@@ -880,6 +913,7 @@ class WebUploadPayload extends DataClass
       'audioBytes': serializer.toJson<Uint8List>(audioBytes),
       'filename': serializer.toJson<String>(filename),
       'contentType': serializer.toJson<String?>(contentType),
+      'recordedAt': serializer.toJson<DateTime?>(recordedAt),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime?>(updatedAt),
     };
@@ -891,6 +925,7 @@ class WebUploadPayload extends DataClass
     Uint8List? audioBytes,
     String? filename,
     Value<String?> contentType = const Value.absent(),
+    Value<DateTime?> recordedAt = const Value.absent(),
     DateTime? createdAt,
     Value<DateTime?> updatedAt = const Value.absent(),
   }) => WebUploadPayload(
@@ -899,6 +934,7 @@ class WebUploadPayload extends DataClass
     audioBytes: audioBytes ?? this.audioBytes,
     filename: filename ?? this.filename,
     contentType: contentType.present ? contentType.value : this.contentType,
+    recordedAt: recordedAt.present ? recordedAt.value : this.recordedAt,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
   );
@@ -915,6 +951,9 @@ class WebUploadPayload extends DataClass
       contentType: data.contentType.present
           ? data.contentType.value
           : this.contentType,
+      recordedAt: data.recordedAt.present
+          ? data.recordedAt.value
+          : this.recordedAt,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -928,6 +967,7 @@ class WebUploadPayload extends DataClass
           ..write('audioBytes: $audioBytes, ')
           ..write('filename: $filename, ')
           ..write('contentType: $contentType, ')
+          ..write('recordedAt: $recordedAt, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
@@ -941,6 +981,7 @@ class WebUploadPayload extends DataClass
     $driftBlobEquality.hash(audioBytes),
     filename,
     contentType,
+    recordedAt,
     createdAt,
     updatedAt,
   );
@@ -953,6 +994,7 @@ class WebUploadPayload extends DataClass
           $driftBlobEquality.equals(other.audioBytes, this.audioBytes) &&
           other.filename == this.filename &&
           other.contentType == this.contentType &&
+          other.recordedAt == this.recordedAt &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
 }
@@ -963,6 +1005,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
   final Value<Uint8List> audioBytes;
   final Value<String> filename;
   final Value<String?> contentType;
+  final Value<DateTime?> recordedAt;
   final Value<DateTime> createdAt;
   final Value<DateTime?> updatedAt;
   final Value<int> rowid;
@@ -972,6 +1015,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
     this.audioBytes = const Value.absent(),
     this.filename = const Value.absent(),
     this.contentType = const Value.absent(),
+    this.recordedAt = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -982,6 +1026,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
     required Uint8List audioBytes,
     required String filename,
     this.contentType = const Value.absent(),
+    this.recordedAt = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -995,6 +1040,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
     Expression<Uint8List>? audioBytes,
     Expression<String>? filename,
     Expression<String>? contentType,
+    Expression<DateTime>? recordedAt,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
     Expression<int>? rowid,
@@ -1005,6 +1051,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
       if (audioBytes != null) 'audio_bytes': audioBytes,
       if (filename != null) 'filename': filename,
       if (contentType != null) 'content_type': contentType,
+      if (recordedAt != null) 'recorded_at': recordedAt,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (rowid != null) 'rowid': rowid,
@@ -1017,6 +1064,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
     Value<Uint8List>? audioBytes,
     Value<String>? filename,
     Value<String?>? contentType,
+    Value<DateTime?>? recordedAt,
     Value<DateTime>? createdAt,
     Value<DateTime?>? updatedAt,
     Value<int>? rowid,
@@ -1027,6 +1075,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
       audioBytes: audioBytes ?? this.audioBytes,
       filename: filename ?? this.filename,
       contentType: contentType ?? this.contentType,
+      recordedAt: recordedAt ?? this.recordedAt,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       rowid: rowid ?? this.rowid,
@@ -1051,6 +1100,9 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
     if (contentType.present) {
       map['content_type'] = Variable<String>(contentType.value);
     }
+    if (recordedAt.present) {
+      map['recorded_at'] = Variable<DateTime>(recordedAt.value);
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
@@ -1071,6 +1123,7 @@ class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
           ..write('audioBytes: $audioBytes, ')
           ..write('filename: $filename, ')
           ..write('contentType: $contentType, ')
+          ..write('recordedAt: $recordedAt, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('rowid: $rowid')
@@ -1380,6 +1433,7 @@ typedef $$WebUploadPayloadsTableCreateCompanionBuilder =
       required Uint8List audioBytes,
       required String filename,
       Value<String?> contentType,
+      Value<DateTime?> recordedAt,
       Value<DateTime> createdAt,
       Value<DateTime?> updatedAt,
       Value<int> rowid,
@@ -1391,6 +1445,7 @@ typedef $$WebUploadPayloadsTableUpdateCompanionBuilder =
       Value<Uint8List> audioBytes,
       Value<String> filename,
       Value<String?> contentType,
+      Value<DateTime?> recordedAt,
       Value<DateTime> createdAt,
       Value<DateTime?> updatedAt,
       Value<int> rowid,
@@ -1427,6 +1482,11 @@ class $$WebUploadPayloadsTableFilterComposer
 
   ColumnFilters<String> get contentType => $composableBuilder(
     column: $table.contentType,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get recordedAt => $composableBuilder(
+    column: $table.recordedAt,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -1475,6 +1535,11 @@ class $$WebUploadPayloadsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<DateTime> get recordedAt => $composableBuilder(
+    column: $table.recordedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
     column: $table.createdAt,
     builder: (column) => ColumnOrderings(column),
@@ -1513,6 +1578,11 @@ class $$WebUploadPayloadsTableAnnotationComposer
 
   GeneratedColumn<String> get contentType => $composableBuilder(
     column: $table.contentType,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get recordedAt => $composableBuilder(
+    column: $table.recordedAt,
     builder: (column) => column,
   );
 
@@ -1568,6 +1638,7 @@ class $$WebUploadPayloadsTableTableManager
                 Value<Uint8List> audioBytes = const Value.absent(),
                 Value<String> filename = const Value.absent(),
                 Value<String?> contentType = const Value.absent(),
+                Value<DateTime?> recordedAt = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime?> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -1577,6 +1648,7 @@ class $$WebUploadPayloadsTableTableManager
                 audioBytes: audioBytes,
                 filename: filename,
                 contentType: contentType,
+                recordedAt: recordedAt,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
                 rowid: rowid,
@@ -1588,6 +1660,7 @@ class $$WebUploadPayloadsTableTableManager
                 required Uint8List audioBytes,
                 required String filename,
                 Value<String?> contentType = const Value.absent(),
+                Value<DateTime?> recordedAt = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime?> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -1597,6 +1670,7 @@ class $$WebUploadPayloadsTableTableManager
                 audioBytes: audioBytes,
                 filename: filename,
                 contentType: contentType,
+                recordedAt: recordedAt,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
                 rowid: rowid,

--- a/client/lib/db/database.g.dart
+++ b/client/lib/db/database.g.dart
@@ -584,15 +584,515 @@ class PendingUploadsCompanion extends UpdateCompanion<PendingUpload> {
   }
 }
 
+class $WebUploadPayloadsTable extends WebUploadPayloads
+    with TableInfo<$WebUploadPayloadsTable, WebUploadPayload> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $WebUploadPayloadsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idempotencyKeyMeta = const VerificationMeta(
+    'idempotencyKey',
+  );
+  @override
+  late final GeneratedColumn<String> idempotencyKey = GeneratedColumn<String>(
+    'idempotency_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _audioPathMeta = const VerificationMeta(
+    'audioPath',
+  );
+  @override
+  late final GeneratedColumn<String> audioPath = GeneratedColumn<String>(
+    'audio_path',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _audioBytesMeta = const VerificationMeta(
+    'audioBytes',
+  );
+  @override
+  late final GeneratedColumn<Uint8List> audioBytes = GeneratedColumn<Uint8List>(
+    'audio_bytes',
+    aliasedName,
+    false,
+    type: DriftSqlType.blob,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _filenameMeta = const VerificationMeta(
+    'filename',
+  );
+  @override
+  late final GeneratedColumn<String> filename = GeneratedColumn<String>(
+    'filename',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _contentTypeMeta = const VerificationMeta(
+    'contentType',
+  );
+  @override
+  late final GeneratedColumn<String> contentType = GeneratedColumn<String>(
+    'content_type',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    idempotencyKey,
+    audioPath,
+    audioBytes,
+    filename,
+    contentType,
+    createdAt,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'web_upload_payloads';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<WebUploadPayload> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('idempotency_key')) {
+      context.handle(
+        _idempotencyKeyMeta,
+        idempotencyKey.isAcceptableOrUnknown(
+          data['idempotency_key']!,
+          _idempotencyKeyMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_idempotencyKeyMeta);
+    }
+    if (data.containsKey('audio_path')) {
+      context.handle(
+        _audioPathMeta,
+        audioPath.isAcceptableOrUnknown(data['audio_path']!, _audioPathMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_audioPathMeta);
+    }
+    if (data.containsKey('audio_bytes')) {
+      context.handle(
+        _audioBytesMeta,
+        audioBytes.isAcceptableOrUnknown(data['audio_bytes']!, _audioBytesMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_audioBytesMeta);
+    }
+    if (data.containsKey('filename')) {
+      context.handle(
+        _filenameMeta,
+        filename.isAcceptableOrUnknown(data['filename']!, _filenameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_filenameMeta);
+    }
+    if (data.containsKey('content_type')) {
+      context.handle(
+        _contentTypeMeta,
+        contentType.isAcceptableOrUnknown(
+          data['content_type']!,
+          _contentTypeMeta,
+        ),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {idempotencyKey};
+  @override
+  WebUploadPayload map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return WebUploadPayload(
+      idempotencyKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}idempotency_key'],
+      )!,
+      audioPath: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}audio_path'],
+      )!,
+      audioBytes: attachedDatabase.typeMapping.read(
+        DriftSqlType.blob,
+        data['${effectivePrefix}audio_bytes'],
+      )!,
+      filename: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}filename'],
+      )!,
+      contentType: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}content_type'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      ),
+    );
+  }
+
+  @override
+  $WebUploadPayloadsTable createAlias(String alias) {
+    return $WebUploadPayloadsTable(attachedDatabase, alias);
+  }
+}
+
+class WebUploadPayload extends DataClass
+    implements Insertable<WebUploadPayload> {
+  /// Stable key shared with the backend idempotency key for this attempt.
+  final String idempotencyKey;
+
+  /// Original browser blob URL or durable upload source.
+  final String audioPath;
+
+  /// Audio bytes required for chunk replay after a browser reload.
+  final Uint8List audioBytes;
+
+  /// Multipart filename derived from the original web recording metadata.
+  final String filename;
+
+  /// Optional multipart content type.
+  final String? contentType;
+
+  /// When this payload was first persisted.
+  final DateTime createdAt;
+
+  /// When this payload was last refreshed.
+  final DateTime? updatedAt;
+  const WebUploadPayload({
+    required this.idempotencyKey,
+    required this.audioPath,
+    required this.audioBytes,
+    required this.filename,
+    this.contentType,
+    required this.createdAt,
+    this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['idempotency_key'] = Variable<String>(idempotencyKey);
+    map['audio_path'] = Variable<String>(audioPath);
+    map['audio_bytes'] = Variable<Uint8List>(audioBytes);
+    map['filename'] = Variable<String>(filename);
+    if (!nullToAbsent || contentType != null) {
+      map['content_type'] = Variable<String>(contentType);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    if (!nullToAbsent || updatedAt != null) {
+      map['updated_at'] = Variable<DateTime>(updatedAt);
+    }
+    return map;
+  }
+
+  WebUploadPayloadsCompanion toCompanion(bool nullToAbsent) {
+    return WebUploadPayloadsCompanion(
+      idempotencyKey: Value(idempotencyKey),
+      audioPath: Value(audioPath),
+      audioBytes: Value(audioBytes),
+      filename: Value(filename),
+      contentType: contentType == null && nullToAbsent
+          ? const Value.absent()
+          : Value(contentType),
+      createdAt: Value(createdAt),
+      updatedAt: updatedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(updatedAt),
+    );
+  }
+
+  factory WebUploadPayload.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return WebUploadPayload(
+      idempotencyKey: serializer.fromJson<String>(json['idempotencyKey']),
+      audioPath: serializer.fromJson<String>(json['audioPath']),
+      audioBytes: serializer.fromJson<Uint8List>(json['audioBytes']),
+      filename: serializer.fromJson<String>(json['filename']),
+      contentType: serializer.fromJson<String?>(json['contentType']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime?>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'idempotencyKey': serializer.toJson<String>(idempotencyKey),
+      'audioPath': serializer.toJson<String>(audioPath),
+      'audioBytes': serializer.toJson<Uint8List>(audioBytes),
+      'filename': serializer.toJson<String>(filename),
+      'contentType': serializer.toJson<String?>(contentType),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime?>(updatedAt),
+    };
+  }
+
+  WebUploadPayload copyWith({
+    String? idempotencyKey,
+    String? audioPath,
+    Uint8List? audioBytes,
+    String? filename,
+    Value<String?> contentType = const Value.absent(),
+    DateTime? createdAt,
+    Value<DateTime?> updatedAt = const Value.absent(),
+  }) => WebUploadPayload(
+    idempotencyKey: idempotencyKey ?? this.idempotencyKey,
+    audioPath: audioPath ?? this.audioPath,
+    audioBytes: audioBytes ?? this.audioBytes,
+    filename: filename ?? this.filename,
+    contentType: contentType.present ? contentType.value : this.contentType,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+  );
+  WebUploadPayload copyWithCompanion(WebUploadPayloadsCompanion data) {
+    return WebUploadPayload(
+      idempotencyKey: data.idempotencyKey.present
+          ? data.idempotencyKey.value
+          : this.idempotencyKey,
+      audioPath: data.audioPath.present ? data.audioPath.value : this.audioPath,
+      audioBytes: data.audioBytes.present
+          ? data.audioBytes.value
+          : this.audioBytes,
+      filename: data.filename.present ? data.filename.value : this.filename,
+      contentType: data.contentType.present
+          ? data.contentType.value
+          : this.contentType,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WebUploadPayload(')
+          ..write('idempotencyKey: $idempotencyKey, ')
+          ..write('audioPath: $audioPath, ')
+          ..write('audioBytes: $audioBytes, ')
+          ..write('filename: $filename, ')
+          ..write('contentType: $contentType, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    idempotencyKey,
+    audioPath,
+    $driftBlobEquality.hash(audioBytes),
+    filename,
+    contentType,
+    createdAt,
+    updatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is WebUploadPayload &&
+          other.idempotencyKey == this.idempotencyKey &&
+          other.audioPath == this.audioPath &&
+          $driftBlobEquality.equals(other.audioBytes, this.audioBytes) &&
+          other.filename == this.filename &&
+          other.contentType == this.contentType &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class WebUploadPayloadsCompanion extends UpdateCompanion<WebUploadPayload> {
+  final Value<String> idempotencyKey;
+  final Value<String> audioPath;
+  final Value<Uint8List> audioBytes;
+  final Value<String> filename;
+  final Value<String?> contentType;
+  final Value<DateTime> createdAt;
+  final Value<DateTime?> updatedAt;
+  final Value<int> rowid;
+  const WebUploadPayloadsCompanion({
+    this.idempotencyKey = const Value.absent(),
+    this.audioPath = const Value.absent(),
+    this.audioBytes = const Value.absent(),
+    this.filename = const Value.absent(),
+    this.contentType = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  WebUploadPayloadsCompanion.insert({
+    required String idempotencyKey,
+    required String audioPath,
+    required Uint8List audioBytes,
+    required String filename,
+    this.contentType = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : idempotencyKey = Value(idempotencyKey),
+       audioPath = Value(audioPath),
+       audioBytes = Value(audioBytes),
+       filename = Value(filename);
+  static Insertable<WebUploadPayload> custom({
+    Expression<String>? idempotencyKey,
+    Expression<String>? audioPath,
+    Expression<Uint8List>? audioBytes,
+    Expression<String>? filename,
+    Expression<String>? contentType,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (idempotencyKey != null) 'idempotency_key': idempotencyKey,
+      if (audioPath != null) 'audio_path': audioPath,
+      if (audioBytes != null) 'audio_bytes': audioBytes,
+      if (filename != null) 'filename': filename,
+      if (contentType != null) 'content_type': contentType,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  WebUploadPayloadsCompanion copyWith({
+    Value<String>? idempotencyKey,
+    Value<String>? audioPath,
+    Value<Uint8List>? audioBytes,
+    Value<String>? filename,
+    Value<String?>? contentType,
+    Value<DateTime>? createdAt,
+    Value<DateTime?>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return WebUploadPayloadsCompanion(
+      idempotencyKey: idempotencyKey ?? this.idempotencyKey,
+      audioPath: audioPath ?? this.audioPath,
+      audioBytes: audioBytes ?? this.audioBytes,
+      filename: filename ?? this.filename,
+      contentType: contentType ?? this.contentType,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (idempotencyKey.present) {
+      map['idempotency_key'] = Variable<String>(idempotencyKey.value);
+    }
+    if (audioPath.present) {
+      map['audio_path'] = Variable<String>(audioPath.value);
+    }
+    if (audioBytes.present) {
+      map['audio_bytes'] = Variable<Uint8List>(audioBytes.value);
+    }
+    if (filename.present) {
+      map['filename'] = Variable<String>(filename.value);
+    }
+    if (contentType.present) {
+      map['content_type'] = Variable<String>(contentType.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WebUploadPayloadsCompanion(')
+          ..write('idempotencyKey: $idempotencyKey, ')
+          ..write('audioPath: $audioPath, ')
+          ..write('audioBytes: $audioBytes, ')
+          ..write('filename: $filename, ')
+          ..write('contentType: $contentType, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
   late final $PendingUploadsTable pendingUploads = $PendingUploadsTable(this);
+  late final $WebUploadPayloadsTable webUploadPayloads =
+      $WebUploadPayloadsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [pendingUploads];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    pendingUploads,
+    webUploadPayloads,
+  ];
 }
 
 typedef $$PendingUploadsTableCreateCompanionBuilder =
@@ -873,10 +1373,269 @@ typedef $$PendingUploadsTableProcessedTableManager =
       PendingUpload,
       PrefetchHooks Function()
     >;
+typedef $$WebUploadPayloadsTableCreateCompanionBuilder =
+    WebUploadPayloadsCompanion Function({
+      required String idempotencyKey,
+      required String audioPath,
+      required Uint8List audioBytes,
+      required String filename,
+      Value<String?> contentType,
+      Value<DateTime> createdAt,
+      Value<DateTime?> updatedAt,
+      Value<int> rowid,
+    });
+typedef $$WebUploadPayloadsTableUpdateCompanionBuilder =
+    WebUploadPayloadsCompanion Function({
+      Value<String> idempotencyKey,
+      Value<String> audioPath,
+      Value<Uint8List> audioBytes,
+      Value<String> filename,
+      Value<String?> contentType,
+      Value<DateTime> createdAt,
+      Value<DateTime?> updatedAt,
+      Value<int> rowid,
+    });
+
+class $$WebUploadPayloadsTableFilterComposer
+    extends Composer<_$AppDatabase, $WebUploadPayloadsTable> {
+  $$WebUploadPayloadsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get idempotencyKey => $composableBuilder(
+    column: $table.idempotencyKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get audioPath => $composableBuilder(
+    column: $table.audioPath,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<Uint8List> get audioBytes => $composableBuilder(
+    column: $table.audioBytes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get filename => $composableBuilder(
+    column: $table.filename,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get contentType => $composableBuilder(
+    column: $table.contentType,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$WebUploadPayloadsTableOrderingComposer
+    extends Composer<_$AppDatabase, $WebUploadPayloadsTable> {
+  $$WebUploadPayloadsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get idempotencyKey => $composableBuilder(
+    column: $table.idempotencyKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get audioPath => $composableBuilder(
+    column: $table.audioPath,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<Uint8List> get audioBytes => $composableBuilder(
+    column: $table.audioBytes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get filename => $composableBuilder(
+    column: $table.filename,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get contentType => $composableBuilder(
+    column: $table.contentType,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$WebUploadPayloadsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $WebUploadPayloadsTable> {
+  $$WebUploadPayloadsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get idempotencyKey => $composableBuilder(
+    column: $table.idempotencyKey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get audioPath =>
+      $composableBuilder(column: $table.audioPath, builder: (column) => column);
+
+  GeneratedColumn<Uint8List> get audioBytes => $composableBuilder(
+    column: $table.audioBytes,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get filename =>
+      $composableBuilder(column: $table.filename, builder: (column) => column);
+
+  GeneratedColumn<String> get contentType => $composableBuilder(
+    column: $table.contentType,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$WebUploadPayloadsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $WebUploadPayloadsTable,
+          WebUploadPayload,
+          $$WebUploadPayloadsTableFilterComposer,
+          $$WebUploadPayloadsTableOrderingComposer,
+          $$WebUploadPayloadsTableAnnotationComposer,
+          $$WebUploadPayloadsTableCreateCompanionBuilder,
+          $$WebUploadPayloadsTableUpdateCompanionBuilder,
+          (
+            WebUploadPayload,
+            BaseReferences<
+              _$AppDatabase,
+              $WebUploadPayloadsTable,
+              WebUploadPayload
+            >,
+          ),
+          WebUploadPayload,
+          PrefetchHooks Function()
+        > {
+  $$WebUploadPayloadsTableTableManager(
+    _$AppDatabase db,
+    $WebUploadPayloadsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$WebUploadPayloadsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$WebUploadPayloadsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$WebUploadPayloadsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> idempotencyKey = const Value.absent(),
+                Value<String> audioPath = const Value.absent(),
+                Value<Uint8List> audioBytes = const Value.absent(),
+                Value<String> filename = const Value.absent(),
+                Value<String?> contentType = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime?> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => WebUploadPayloadsCompanion(
+                idempotencyKey: idempotencyKey,
+                audioPath: audioPath,
+                audioBytes: audioBytes,
+                filename: filename,
+                contentType: contentType,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String idempotencyKey,
+                required String audioPath,
+                required Uint8List audioBytes,
+                required String filename,
+                Value<String?> contentType = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime?> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => WebUploadPayloadsCompanion.insert(
+                idempotencyKey: idempotencyKey,
+                audioPath: audioPath,
+                audioBytes: audioBytes,
+                filename: filename,
+                contentType: contentType,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$WebUploadPayloadsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $WebUploadPayloadsTable,
+      WebUploadPayload,
+      $$WebUploadPayloadsTableFilterComposer,
+      $$WebUploadPayloadsTableOrderingComposer,
+      $$WebUploadPayloadsTableAnnotationComposer,
+      $$WebUploadPayloadsTableCreateCompanionBuilder,
+      $$WebUploadPayloadsTableUpdateCompanionBuilder,
+      (
+        WebUploadPayload,
+        BaseReferences<
+          _$AppDatabase,
+          $WebUploadPayloadsTable,
+          WebUploadPayload
+        >,
+      ),
+      WebUploadPayload,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
   $AppDatabaseManager(this._db);
   $$PendingUploadsTableTableManager get pendingUploads =>
       $$PendingUploadsTableTableManager(_db, _db.pendingUploads);
+  $$WebUploadPayloadsTableTableManager get webUploadPayloads =>
+      $$WebUploadPayloadsTableTableManager(_db, _db.webUploadPayloads);
 }

--- a/client/lib/services/transcription_service.dart
+++ b/client/lib/services/transcription_service.dart
@@ -784,6 +784,35 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
           )
         : null;
 
+    WebUploadPayload? durablePayload;
+    try {
+      durablePayload = queuedUpload == null
+          ? null
+          : await _ensureDurableQueuedFileData(
+              queuedUpload,
+              recordedAt: foregroundAttempt?.recordedAt,
+            );
+    } catch (e, stackTrace) {
+      final classification = classifyUploadFailure(e);
+      await _markQueuedUploadFailed(
+        queuedUploadId,
+        classification: classification,
+      );
+      _handleForegroundFailure(foregroundAttempt, classification);
+
+      if (kDebugMode) {
+        debugPrint('[TRANSCRIPTION] Caught exception: $e');
+        debugPrint('[TRANSCRIPTION] Stack trace: $stackTrace');
+      }
+      state = TranscriptionError(
+        classification.message,
+        errorType: classification.errorType,
+        filePath: filePath,
+        isRetryable: classification.isRetryable,
+      );
+      return;
+    }
+
     // Check for API key first
     final storage = ref.read(secureStorageProvider);
     await ref
@@ -825,12 +854,6 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
 
     try {
       final service = ref.read(transcriptionServiceProvider);
-      final durablePayload = queuedUpload == null
-          ? null
-          : await _ensureDurableQueuedFileData(
-              queuedUpload,
-              recordedAt: foregroundAttempt?.recordedAt,
-            );
 
       state = const TranscriptionUploading(progress: 0.0);
 

--- a/client/lib/services/transcription_service.dart
+++ b/client/lib/services/transcription_service.dart
@@ -25,6 +25,8 @@ final _uuid = const Uuid();
 
 typedef TranscriptionSleep = Future<void> Function(Duration duration);
 typedef TranscriptionNow = DateTime Function();
+typedef FileDataReader =
+    Future<FileData> Function(String filePath, {String? idempotencyKey});
 
 Future<void> _defaultSleep(Duration duration) => Future.delayed(duration);
 
@@ -165,7 +167,19 @@ final localFileDeleterProvider = Provider<LocalFileDeleter>((ref) {
 });
 
 final foregroundTranscriptionsAreQueuedProvider = Provider<bool>((ref) {
-  return !kIsWeb;
+  return true;
+});
+
+final fileDataReaderProvider = Provider<FileDataReader>((ref) {
+  final platformReader = platform.getFileData;
+  if (!kIsWeb) {
+    return platformReader;
+  }
+
+  return durableWebFileDataReader(
+    ref.watch(appDatabaseProvider),
+    platformReader,
+  );
 });
 
 class TranscriptionError extends TranscriptionState {
@@ -397,14 +411,17 @@ class TranscriptionService {
   final Duration pollInterval;
   final TranscriptionSleep _sleep;
   final TranscriptionNow _now;
+  final FileDataReader _readFileData;
 
   TranscriptionService(
     this._dio, {
     this.pollInterval = defaultTranscriptionPollInterval,
     TranscriptionSleep sleep = _defaultSleep,
     TranscriptionNow? now,
+    FileDataReader? fileDataReader,
   }) : _sleep = sleep,
-       _now = now ?? DateTime.now;
+       _now = now ?? DateTime.now,
+       _readFileData = fileDataReader ?? platform.getFileData;
 
   /// Upload an audio file through the v0.1.0 transcription-job protocol.
   /// On native platforms, filePath is a file system path.
@@ -426,7 +443,10 @@ class TranscriptionService {
     if (kDebugMode) {
       debugPrint('[TRANSCRIPTION_SERVICE] Calling platform.getFileData...');
     }
-    final fileData = await platform.getFileData(filePath);
+    final fileData = await _readFileData(
+      filePath,
+      idempotencyKey: idempotencyKey,
+    );
     if (kDebugMode) {
       debugPrint(
         '[TRANSCRIPTION_SERVICE] Got ${fileData.bytes.length} bytes, filename: ${fileData.filename}',
@@ -579,6 +599,53 @@ class FileData {
   });
 }
 
+FileDataReader durableWebFileDataReader(
+  AppDatabase db,
+  FileDataReader fallbackReader,
+) {
+  return (String filePath, {String? idempotencyKey}) async {
+    if (idempotencyKey != null && idempotencyKey.isNotEmpty) {
+      final persisted = await db.getWebUploadPayload(idempotencyKey);
+      if (persisted != null) {
+        return FileData(
+          bytes: persisted.audioBytes,
+          filename: persisted.filename,
+          contentType: dioMediaTypeFromString(persisted.contentType),
+        );
+      }
+    }
+
+    final fileData = await fallbackReader(
+      filePath,
+      idempotencyKey: idempotencyKey,
+    );
+    if (idempotencyKey != null && idempotencyKey.isNotEmpty) {
+      await db.upsertWebUploadPayload(
+        idempotencyKey: idempotencyKey,
+        audioPath: filePath,
+        bytes: fileData.bytes,
+        filename: fileData.filename,
+        contentType: fileData.contentType?.toString(),
+      );
+    }
+    return fileData;
+  };
+}
+
+DioMediaType? dioMediaTypeFromString(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+
+  final mediaType = value.split(';').first.trim().toLowerCase();
+  final parts = mediaType.split('/');
+  if (parts.length != 2 || parts.any((part) => part.isEmpty)) {
+    return null;
+  }
+
+  return DioMediaType(parts[0], parts[1]);
+}
+
 MultipartFile multipartFileFromFileData(FileData fileData) {
   return MultipartFile.fromBytes(
     fileData.bytes,
@@ -593,6 +660,10 @@ String? audioFormatFromFilename(String filename) {
     'm4a' || 'mp3' || 'wav' || 'webm' => extension,
     _ => null,
   };
+}
+
+bool _requiresDurableQueuedFileData(String filePath) {
+  return filePath.startsWith('blob:');
 }
 
 List<Uint8List> chunkAudio(Uint8List bytes) {
@@ -654,7 +725,10 @@ int? _recordingTimestampFromPath(String audioPath) {
 /// Provider for transcription service.
 final transcriptionServiceProvider = Provider<TranscriptionService>((ref) {
   final dio = ref.watch(apiClientProvider);
-  return TranscriptionService(dio);
+  return TranscriptionService(
+    dio,
+    fileDataReader: ref.watch(fileDataReaderProvider),
+  );
 });
 
 /// Notifier for managing transcription state.
@@ -833,9 +907,26 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
       return null;
     }
 
-    return ref
-        .read(appDatabaseProvider)
-        .ensurePendingUpload(audioPath: filePath, language: language);
+    final db = ref.read(appDatabaseProvider);
+    final uploadId = await db.ensurePendingUpload(
+      audioPath: filePath,
+      language: language,
+    );
+    final upload = await db.getUploadById(uploadId);
+
+    if (_requiresDurableQueuedFileData(filePath) &&
+        upload?.idempotencyKey != null) {
+      final idempotencyKey = upload!.idempotencyKey!;
+      final persisted = await db.getWebUploadPayload(idempotencyKey);
+      if (persisted == null) {
+        await ref.read(fileDataReaderProvider)(
+          filePath,
+          idempotencyKey: idempotencyKey,
+        );
+      }
+    }
+
+    return uploadId;
   }
 
   _ForegroundTranscriptionAttempt _ensureForegroundAttempt(
@@ -897,6 +988,25 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
       uploadId,
       classification,
     );
+  }
+
+  /// Resume the oldest queued upload after a browser restart.
+  Future<bool> resumeRecoverableUpload() async {
+    if (state is! TranscriptionIdle) {
+      return false;
+    }
+
+    final db = ref.read(appDatabaseProvider);
+    await db.cleanupStaleWebUploadPayloads();
+    await db.restoreUploadingUploadsAfterRestart();
+    final pendingUploads = await db.getPendingUploads();
+    if (pendingUploads.isEmpty) {
+      return false;
+    }
+
+    final upload = pendingUploads.first;
+    await _transcribe(upload.audioPath, language: upload.language);
+    return true;
   }
 
   /// Retry the last failed transcription.

--- a/client/lib/services/transcription_service.dart
+++ b/client/lib/services/transcription_service.dart
@@ -776,7 +776,7 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
     final queuedUpload = queuedUploadId == null
         ? null
         : await db.getUploadById(queuedUploadId);
-    final foregroundAttempt = queuedUpload == null
+    final foregroundAttempt = queuedUpload == null || recordedAt != null
         ? _ensureForegroundAttempt(
             filePath,
             language: language,
@@ -825,6 +825,12 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
 
     try {
       final service = ref.read(transcriptionServiceProvider);
+      final durablePayload = queuedUpload == null
+          ? null
+          : await _ensureDurableQueuedFileData(
+              queuedUpload,
+              recordedAt: foregroundAttempt?.recordedAt,
+            );
 
       state = const TranscriptionUploading(progress: 0.0);
 
@@ -833,9 +839,10 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
         language: language,
         idempotencyKey:
             queuedUpload?.idempotencyKey ?? foregroundAttempt!.idempotencyKey,
-        recordedAt: queuedUpload == null
-            ? foregroundAttempt!.recordedAt
-            : recordedAtForQueuedUpload(queuedUpload),
+        recordedAt:
+            foregroundAttempt?.recordedAt ??
+            durablePayload?.recordedAt?.toUtc() ??
+            recordedAtForQueuedUpload(queuedUpload!),
         onProgress: (progress) {
           // Only update if still in uploading state
           if (state is TranscriptionUploading) {
@@ -912,21 +919,52 @@ class TranscriptionNotifier extends Notifier<TranscriptionState> {
       audioPath: filePath,
       language: language,
     );
-    final upload = await db.getUploadById(uploadId);
-
-    if (_requiresDurableQueuedFileData(filePath) &&
-        upload?.idempotencyKey != null) {
-      final idempotencyKey = upload!.idempotencyKey!;
-      final persisted = await db.getWebUploadPayload(idempotencyKey);
-      if (persisted == null) {
-        await ref.read(fileDataReaderProvider)(
-          filePath,
-          idempotencyKey: idempotencyKey,
-        );
-      }
-    }
 
     return uploadId;
+  }
+
+  Future<WebUploadPayload?> _ensureDurableQueuedFileData(
+    PendingUpload upload, {
+    DateTime? recordedAt,
+  }) async {
+    if (!_requiresDurableQueuedFileData(upload.audioPath) ||
+        upload.idempotencyKey == null) {
+      return null;
+    }
+
+    final db = ref.read(appDatabaseProvider);
+    final idempotencyKey = upload.idempotencyKey!;
+    final normalizedRecordedAt = recordedAt?.toUtc();
+    final persisted = await db.getWebUploadPayload(idempotencyKey);
+    if (persisted != null) {
+      if (normalizedRecordedAt != null &&
+          persisted.recordedAt?.toUtc() != normalizedRecordedAt) {
+        await db.upsertWebUploadPayload(
+          idempotencyKey: idempotencyKey,
+          audioPath: persisted.audioPath,
+          bytes: persisted.audioBytes,
+          filename: persisted.filename,
+          contentType: persisted.contentType,
+          recordedAt: normalizedRecordedAt,
+        );
+        return db.getWebUploadPayload(idempotencyKey);
+      }
+      return persisted;
+    }
+
+    final fileData = await ref.read(fileDataReaderProvider)(
+      upload.audioPath,
+      idempotencyKey: idempotencyKey,
+    );
+    await db.upsertWebUploadPayload(
+      idempotencyKey: idempotencyKey,
+      audioPath: upload.audioPath,
+      bytes: fileData.bytes,
+      filename: fileData.filename,
+      contentType: fileData.contentType?.toString(),
+      recordedAt: normalizedRecordedAt,
+    );
+    return db.getWebUploadPayload(idempotencyKey);
   }
 
   _ForegroundTranscriptionAttempt _ensureForegroundAttempt(

--- a/client/lib/services/transcription_service_io.dart
+++ b/client/lib/services/transcription_service_io.dart
@@ -3,7 +3,7 @@
 import 'dart:io';
 import 'transcription_service.dart';
 
-Future<FileData> getFileData(String filePath) async {
+Future<FileData> getFileData(String filePath, {String? idempotencyKey}) async {
   final file = File(filePath);
   if (!await file.exists()) {
     throw Exception('Audio file not found: $filePath');

--- a/client/lib/services/transcription_service_stub.dart
+++ b/client/lib/services/transcription_service_stub.dart
@@ -3,7 +3,7 @@
 
 import 'transcription_service.dart';
 
-Future<FileData> getFileData(String filePath) {
+Future<FileData> getFileData(String filePath, {String? idempotencyKey}) {
   throw UnsupportedError('Platform not supported');
 }
 

--- a/client/lib/services/transcription_service_web.dart
+++ b/client/lib/services/transcription_service_web.dart
@@ -6,7 +6,7 @@ import 'package:web/web.dart' as web;
 import 'transcription_service.dart';
 import 'web_recording_upload_metadata.dart';
 
-Future<FileData> getFileData(String filePath) async {
+Future<FileData> getFileData(String filePath, {String? idempotencyKey}) async {
   // On web, filePath is a blob URL (e.g., blob:https://oracy.app/...)
   // We need to fetch the blob and convert it to bytes
 

--- a/client/test/database_migration_test.dart
+++ b/client/test/database_migration_test.dart
@@ -79,4 +79,69 @@ void main() {
       );
     },
   );
+
+  test(
+    'Given a schema 4 web payload exists, When it is upgraded, Then the recording timestamp column is nullable',
+    () async {
+      final legacyDb = sqlite.sqlite3.open(dbFile.path);
+      legacyDb.execute('''
+        CREATE TABLE pending_uploads (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          audio_path TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          retry_count INTEGER NOT NULL DEFAULT 0,
+          status INTEGER NOT NULL DEFAULT 0,
+          error_message TEXT,
+          updated_at INTEGER,
+          language TEXT,
+          idempotency_key TEXT
+        );
+      ''');
+      legacyDb.execute('''
+        CREATE UNIQUE INDEX pending_uploads_audio_path_unique
+        ON pending_uploads (audio_path);
+      ''');
+      legacyDb.execute('''
+        CREATE TABLE web_upload_payloads (
+          idempotency_key TEXT NOT NULL PRIMARY KEY,
+          audio_path TEXT NOT NULL,
+          audio_bytes BLOB NOT NULL,
+          filename TEXT NOT NULL,
+          content_type TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER
+        );
+      ''');
+      legacyDb.execute('''
+        INSERT INTO web_upload_payloads (
+          idempotency_key,
+          audio_path,
+          audio_bytes,
+          filename,
+          content_type,
+          created_at,
+          updated_at
+        ) VALUES (
+          'legacy-web-key',
+          'blob:https://oracy.test/legacy',
+          x'010203',
+          'recording_1234.webm',
+          NULL,
+          1713300000000,
+          NULL
+        );
+      ''');
+      legacyDb.execute('PRAGMA user_version = 4;');
+      legacyDb.close();
+
+      final db = AppDatabase(NativeDatabase(dbFile));
+      addTearDown(db.close);
+
+      final payload = await db.getWebUploadPayload('legacy-web-key');
+
+      expect(payload, isNotNull);
+      expect(payload!.recordedAt, isNull);
+      expect(payload.audioPath, 'blob:https://oracy.test/legacy');
+    },
+  );
 }

--- a/client/test/pending_upload_database_test.dart
+++ b/client/test/pending_upload_database_test.dart
@@ -120,4 +120,24 @@ void main() {
       expect(await db.getWebUploadPayload('orphaned-key'), isNull);
     },
   );
+
+  test(
+    'Given durable web audio bytes include a recording timestamp, When the payload is stored, Then the timestamp is persisted',
+    () async {
+      final recordedAt = DateTime.utc(2026, 4, 21, 18, 29, 55);
+
+      await db.upsertWebUploadPayload(
+        idempotencyKey: 'timestamped-key',
+        audioPath: 'blob:https://oracy.test/timestamped',
+        bytes: [1, 2, 3],
+        filename: 'recording_1234.webm',
+        recordedAt: recordedAt,
+      );
+
+      final payload = await db.getWebUploadPayload('timestamped-key');
+
+      expect(payload, isNotNull);
+      expect(payload!.recordedAt!.toUtc(), recordedAt);
+    },
+  );
 }

--- a/client/test/pending_upload_database_test.dart
+++ b/client/test/pending_upload_database_test.dart
@@ -89,4 +89,35 @@ void main() {
       expect(storedUploads, hasLength(1));
     },
   );
+
+  test(
+    'Given durable web audio bytes are stored for a queued upload, When stale web payload cleanup runs, Then referenced bytes remain and orphaned stale bytes are removed',
+    () async {
+      await db.addPendingUpload(
+        audioPath: 'blob:https://oracy.test/live',
+        idempotencyKey: 'live-key',
+      );
+      await db.upsertWebUploadPayload(
+        idempotencyKey: 'live-key',
+        audioPath: 'blob:https://oracy.test/live',
+        bytes: [1, 2, 3],
+        filename: 'recording_1234.webm',
+      );
+      await db.upsertWebUploadPayload(
+        idempotencyKey: 'orphaned-key',
+        audioPath: 'blob:https://oracy.test/orphaned',
+        bytes: [4, 5, 6],
+        filename: 'recording_5678.wav',
+        contentType: 'audio/wav',
+      );
+
+      final removed = await db.cleanupStaleWebUploadPayloads(
+        maxAge: const Duration(days: -1),
+      );
+
+      expect(removed, 1);
+      expect(await db.getWebUploadPayload('live-key'), isNotNull);
+      expect(await db.getWebUploadPayload('orphaned-key'), isNull);
+    },
+  );
 }

--- a/client/test/transcription_persistence_test.dart
+++ b/client/test/transcription_persistence_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:drift/drift.dart' show Value;
@@ -61,6 +62,28 @@ class _RecordingTimestampTranscriptionService extends TranscriptionService {
     required DateTime recordedAt,
     void Function(double progress)? onProgress,
   }) async {
+    recordedAts.add(recordedAt);
+    return TranscriptionSubmissionVoiceNote(createMockVoiceNote());
+  }
+}
+
+class _CapturingTranscriptionService extends TranscriptionService {
+  _CapturingTranscriptionService() : super(Dio());
+
+  final filePaths = <String>[];
+  final idempotencyKeys = <String>[];
+  final recordedAts = <DateTime>[];
+
+  @override
+  Future<TranscriptionSubmissionResult> transcribe(
+    String filePath, {
+    String? language,
+    required String idempotencyKey,
+    required DateTime recordedAt,
+    void Function(double progress)? onProgress,
+  }) async {
+    filePaths.add(filePath);
+    idempotencyKeys.add(idempotencyKey);
     recordedAts.add(recordedAt);
     return TranscriptionSubmissionVoiceNote(createMockVoiceNote());
   }
@@ -738,6 +761,97 @@ void main() {
       expect(
         await container.read(transcriptionProvider.notifier).retry(),
         isFalse,
+      );
+    },
+  );
+
+  test(
+    'Given a web submission was interrupted by reload, When recoverable upload resumes, Then it reuses the stored idempotency key and clears persisted bytes',
+    () async {
+      const blobUrl = 'blob:https://oracy.test/reload';
+      const idempotencyKey = 'stable-web-key';
+      final service = _CapturingTranscriptionService();
+      final uploadId = await db.addPendingUpload(
+        audioPath: blobUrl,
+        language: 'en',
+        idempotencyKey: idempotencyKey,
+      );
+      await db.markAsUploading(uploadId);
+      await db.upsertWebUploadPayload(
+        idempotencyKey: idempotencyKey,
+        audioPath: blobUrl,
+        bytes: [1, 2, 3],
+        filename: 'recording_1234.webm',
+      );
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStorageProvider.overrideWith(
+            (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
+          ),
+          appDatabaseProvider.overrideWithValue(db),
+          transcriptionServiceProvider.overrideWith((_) => service),
+        ],
+      );
+
+      final resumed = await container
+          .read(transcriptionProvider.notifier)
+          .resumeRecoverableUpload();
+
+      expect(resumed, isTrue);
+      expect(
+        container.read(transcriptionProvider),
+        isA<TranscriptionSuccess>(),
+      );
+      expect(service.filePaths, [blobUrl]);
+      expect(service.idempotencyKeys, [idempotencyKey]);
+      expect(service.recordedAts.single, isA<DateTime>());
+      expect(await db.getUploadByAudioPath(blobUrl), isNull);
+      expect(await db.getWebUploadPayload(idempotencyKey), isNull);
+    },
+  );
+
+  test(
+    'Given a web blob submission starts, When it is queued for upload, Then durable bytes are persisted before the transcription service runs',
+    () async {
+      const blobUrl = 'blob:https://oracy.test/fresh';
+      final service = _CapturingTranscriptionService();
+      final readerKeys = <String?>[];
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStorageProvider.overrideWith(
+            (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
+          ),
+          appDatabaseProvider.overrideWithValue(db),
+          transcriptionServiceProvider.overrideWith((_) => service),
+          fileDataReaderProvider.overrideWithValue((
+            String filePath, {
+            String? idempotencyKey,
+          }) async {
+            readerKeys.add(idempotencyKey);
+            await db.upsertWebUploadPayload(
+              idempotencyKey: idempotencyKey!,
+              audioPath: filePath,
+              bytes: [4, 5, 6],
+              filename: 'recording_1234.webm',
+            );
+            return FileData(
+              bytes: Uint8List.fromList([4, 5, 6]),
+              filename: 'recording_1234.webm',
+            );
+          }),
+        ],
+      );
+
+      await container
+          .read(transcriptionProvider.notifier)
+          .transcribe(blobUrl, recordedAt: testRecordingStartedAt);
+
+      expect(readerKeys, [service.idempotencyKeys.single]);
+      expect(
+        container.read(transcriptionProvider),
+        isA<TranscriptionSuccess>(),
       );
     },
   );

--- a/client/test/transcription_persistence_test.dart
+++ b/client/test/transcription_persistence_test.dart
@@ -859,6 +859,55 @@ void main() {
   );
 
   test(
+    'Given no API key is configured for a web blob, When foreground transcription queues it, Then durable bytes remain recoverable for retry',
+    () async {
+      const blobUrl = 'blob:https://oracy.test/missing-key';
+      final service = _CapturingTranscriptionService();
+      final readerKeys = <String?>[];
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStorageProvider.overrideWith((_) => MockSecureStorage()),
+          appDatabaseProvider.overrideWithValue(db),
+          transcriptionServiceProvider.overrideWith((_) => service),
+          fileDataReaderProvider.overrideWithValue((
+            String filePath, {
+            String? idempotencyKey,
+          }) async {
+            readerKeys.add(idempotencyKey);
+            return FileData(
+              bytes: Uint8List.fromList([7, 8, 9]),
+              filename: 'recording_1234.webm',
+            );
+          }),
+        ],
+      );
+
+      await container
+          .read(transcriptionProvider.notifier)
+          .transcribe(blobUrl, recordedAt: testRecordingStartedAt);
+
+      final state = container.read(transcriptionProvider);
+      final storedUpload = await db.getUploadByAudioPath(blobUrl);
+      final payload = await db.getWebUploadPayload(
+        storedUpload!.idempotencyKey!,
+      );
+
+      expect(state, isA<TranscriptionError>());
+      expect(
+        (state as TranscriptionError).errorType,
+        TranscriptionErrorType.auth,
+      );
+      expect(service.filePaths, isEmpty);
+      expect(storedUpload.status, UploadStatus.pending.index);
+      expect(readerKeys, [storedUpload.idempotencyKey]);
+      expect(payload, isNotNull);
+      expect(payload!.audioBytes, Uint8List.fromList([7, 8, 9]));
+      expect(payload.recordedAt?.toUtc(), testRecordingStartedAt);
+    },
+  );
+
+  test(
     'Given durable web blob persistence fails, When foreground upload starts, Then the failure is reported through transcription state',
     () async {
       const blobUrl = 'blob:https://oracy.test/stale';
@@ -888,6 +937,45 @@ void main() {
       final storedUpload = await db.getUploadByAudioPath(blobUrl);
 
       expect(state, isA<TranscriptionError>());
+      expect(service.filePaths, isEmpty);
+      expect(storedUpload, isNotNull);
+      expect(storedUpload!.status, UploadStatus.terminalFailure.index);
+    },
+  );
+
+  test(
+    'Given durable web blob persistence fails before API key configuration, When foreground upload starts, Then the failure is reported through transcription state',
+    () async {
+      const blobUrl = 'blob:https://oracy.test/no-key-stale';
+      final service = _CapturingTranscriptionService();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStorageProvider.overrideWith((_) => MockSecureStorage()),
+          appDatabaseProvider.overrideWithValue(db),
+          transcriptionServiceProvider.overrideWith((_) => service),
+          fileDataReaderProvider.overrideWithValue((
+            String filePath, {
+            String? idempotencyKey,
+          }) async {
+            throw StateError('stale blob URL');
+          }),
+        ],
+      );
+
+      await container
+          .read(transcriptionProvider.notifier)
+          .transcribe(blobUrl, recordedAt: testRecordingStartedAt);
+
+      final state = container.read(transcriptionProvider);
+      final storedUpload = await db.getUploadByAudioPath(blobUrl);
+
+      expect(state, isA<TranscriptionError>());
+      expect(
+        (state as TranscriptionError).errorType,
+        TranscriptionErrorType.unknown,
+      );
+      expect(state.isRetryable, isFalse);
       expect(service.filePaths, isEmpty);
       expect(storedUpload, isNotNull);
       expect(storedUpload!.status, UploadStatus.terminalFailure.index);

--- a/client/test/transcription_persistence_test.dart
+++ b/client/test/transcription_persistence_test.dart
@@ -782,6 +782,7 @@ void main() {
         audioPath: blobUrl,
         bytes: [1, 2, 3],
         filename: 'recording_1234.webm',
+        recordedAt: testRecordingStartedAt,
       );
       container = ProviderContainer(
         overrides: [
@@ -805,7 +806,7 @@ void main() {
       );
       expect(service.filePaths, [blobUrl]);
       expect(service.idempotencyKeys, [idempotencyKey]);
-      expect(service.recordedAts.single, isA<DateTime>());
+      expect(service.recordedAts.single, testRecordingStartedAt);
       expect(await db.getUploadByAudioPath(blobUrl), isNull);
       expect(await db.getWebUploadPayload(idempotencyKey), isNull);
     },
@@ -853,6 +854,43 @@ void main() {
         container.read(transcriptionProvider),
         isA<TranscriptionSuccess>(),
       );
+      expect(service.recordedAts, [testRecordingStartedAt]);
+    },
+  );
+
+  test(
+    'Given durable web blob persistence fails, When foreground upload starts, Then the failure is reported through transcription state',
+    () async {
+      const blobUrl = 'blob:https://oracy.test/stale';
+      final service = _CapturingTranscriptionService();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStorageProvider.overrideWith(
+            (_) => MockSecureStorage(apiKey: 'oracy_sk_test'),
+          ),
+          appDatabaseProvider.overrideWithValue(db),
+          transcriptionServiceProvider.overrideWith((_) => service),
+          fileDataReaderProvider.overrideWithValue((
+            String filePath, {
+            String? idempotencyKey,
+          }) async {
+            throw StateError('stale blob URL');
+          }),
+        ],
+      );
+
+      await container
+          .read(transcriptionProvider.notifier)
+          .transcribe(blobUrl, recordedAt: testRecordingStartedAt);
+
+      final state = container.read(transcriptionProvider);
+      final storedUpload = await db.getUploadByAudioPath(blobUrl);
+
+      expect(state, isA<TranscriptionError>());
+      expect(service.filePaths, isEmpty);
+      expect(storedUpload, isNotNull);
+      expect(storedUpload!.status, UploadStatus.terminalFailure.index);
     },
   );
 

--- a/client/test/web_recording_upload_metadata_test.dart
+++ b/client/test/web_recording_upload_metadata_test.dart
@@ -1,10 +1,22 @@
 import 'dart:typed_data';
 
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:oracy/db/database.dart';
 import 'package:oracy/services/transcription_service.dart';
 import 'package:oracy/services/web_recording_upload_metadata.dart';
 
 void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
   test(
     'Given a web WAV blob, When upload metadata is built, Then the multipart file uses a WAV filename and audio/wav content type',
     () {
@@ -37,6 +49,37 @@ void main() {
 
       expect(metadata.filename, 'recording_5678.webm');
       expect(metadata.contentType, isNull);
+    },
+  );
+
+  test(
+    'Given persisted web audio exists for an idempotency key, When file data is read after reload, Then durable bytes and metadata are returned without fetching the stale blob URL',
+    () async {
+      await db.upsertWebUploadPayload(
+        idempotencyKey: 'stable-key',
+        audioPath: 'blob:https://oracy.test/stale',
+        bytes: [7, 8, 9],
+        filename: 'recording_1234.wav',
+        contentType: 'audio/wav',
+      );
+      var fallbackCalled = false;
+      final reader = durableWebFileDataReader(db, (
+        String filePath, {
+        String? idempotencyKey,
+      }) async {
+        fallbackCalled = true;
+        throw StateError('stale blob URL should not be fetched');
+      });
+
+      final fileData = await reader(
+        'blob:https://oracy.test/stale',
+        idempotencyKey: 'stable-key',
+      );
+
+      expect(fileData.bytes, Uint8List.fromList([7, 8, 9]));
+      expect(fileData.filename, 'recording_1234.wav');
+      expect(fileData.contentType.toString(), 'audio/wav');
+      expect(fallbackCalled, isFalse);
     },
   );
 }


### PR DESCRIPTION
## Summary

- Persists web recording bytes and multipart metadata by idempotency key so browser reloads can replay chunks from durable storage.
- Queues web foreground submissions and resumes stranded browser uploads on app startup with the original `Idempotency-Key`.
- Cleans up completed/discarded web payloads and removes stale unreferenced payloads.

## Changes

- Adds a Drift `web_upload_payloads` table and migration for durable web audio bytes.
- Injects file-data reading into `TranscriptionService`, with a web reader that prefers persisted payloads before fetching blob URLs.
- Adds reload-resume tests, durable payload cleanup tests, and a changelog entry.

## GitHub Issue(s)

Closes #81

## Test plan

- `git diff --check`
- `cd client && flutter analyze`
- `cd client && flutter test`
- `cd client && flutter build web`
