### PR TITLE
fix(release): define forward metadata rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.1.1] - 2026-05-07
+
 - Clarify `stop-then-replace` cutover guidance so operators can preserve
   previous canonical-path substrate through a rollback-window backup before
   creating the replacement deployment at canonical paths.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,12 @@ Oracy uses one repository tag for all release artifacts. The tag is
 `client/pubspec.yaml` release version is `X.Y.Z` with a platform build suffix
 such as `+1`.
 
+The client build suffix is a monotonically increasing platform build number,
+not a per-release counter. Each released client artifact advances it from the
+previous released value so update channels that require monotonically
+increasing build identifiers can accept upgrades. For example, a release after
+`0.1.0+1` uses `0.1.1+2`.
+
 The tag is the source-truth identity. Artifacts built from the tag must report
 that identity:
 
@@ -24,6 +30,12 @@ that identity:
 
 A releasable commit is on `main`, up to date with `origin/main`, and has a
 clean working tree. `--allow-dirty` is not part of the release path.
+
+Before tagging, the release metadata lives in source. `CHANGELOG.md` has an
+empty `## Unreleased` section and a release heading for `X.Y.Z`; backend and
+client source versions report the same `X.Y.Z` release identity; the client
+build suffix has advanced from the previous released value. These changes land
+on `main` before the tag is cut.
 
 Before tagging:
 
@@ -67,6 +79,12 @@ Operators still own deployment artifacts and host state. Build or promote the
 deployment image from the release tag, tag it with the release identity, update
 the deployment reference to that immutable tag, and validate the live service.
 Registry publishing is not owned by this repository yet.
+
+The repository release ceremony ends when the annotated tag has been pushed,
+the release workflow has completed, and the GitHub Release exists with notes
+sourced from `CHANGELOG.md`. Deployment promotion, deployment-reference
+updates, and live-service validation begin after that boundary and remain
+operator-owned.
 
 Manual GitHub Release creation, when needed after a workflow failure, uses the
 same notes source:

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1062,7 +1062,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oracy-backend"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "base64",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oracy-backend"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Oracy backend: the Rust service that catches voice and keeps it as durable voice notes."
 license = "MIT"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.0+1
+version: 0.1.1+2
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
## Summary

- Defines the forward-release metadata rollup that `RELEASING.md` needs before a patch tag is cut.
- Applies the v0.1.1 release identity across backend, client, lockfile metadata, and changelog.
- Makes the repo ceremony boundary explicit: tag workflow and GitHub Release verification end the repository-owned release; deployment remains operator-owned.

## Changes

- `RELEASING.md` now states the source metadata invariants required before tag-time verification, the monotonic Flutter build suffix rule, and the handoff to operator-owned deployment.
- `CHANGELOG.md` now has an empty `## Unreleased` section and `## [0.1.1] - 2026-05-07` notes.
- Backend metadata reports `0.1.1`; client metadata reports `0.1.1+2`.

## GitHub Issue(s)

Closes #111

## Test plan

- `./scripts/release-check metadata`
- `./scripts/release-check release v0.1.1`
- `./scripts/release-check notes v0.1.1`
- `cargo build --locked --bin oracy-backend` from `backend/`
- `./scripts/release-check release v0.1.1 --backend-bin backend/target/debug/oracy-backend`
