### PR TITLE
docs(deploy): complete Oracy-scoped deployment substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Complete the backend deployment substrate with Oracy-scoped Quadlet ingress,
+  Caddy reverse-proxy, persistent Caddy state volumes, and a templated
+  Caddyfile as the supported deployment recipe.
+
 ## [0.1.1] - 2026-05-07
 
 - Clarify `stop-then-replace` cutover guidance so operators can preserve

--- a/backend/tests/deployment_artifacts.rs
+++ b/backend/tests/deployment_artifacts.rs
@@ -1,259 +1,280 @@
-#[test]
-fn quadlet_template_publishes_operator_metrics_on_loopback_by_default() {
-    let template = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
-        .expect("read container Quadlet template");
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
-    assert!(template.contains("PublishPort=@ORACY_PUBLIC_PUBLISH@"));
-    assert!(template.contains("PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090"));
-    assert!(!template.contains("PublishPort=0.0.0.0:@ORACY_OPERATOR_HOST_PORT@:9090"));
+#[test]
+fn shipped_quadlet_artifacts_define_oracy_scoped_ingress_fabric() {
+    let quadlet_root = deploy_path("quadlet");
+    let container = read_deploy("quadlet/oracy.container.in");
+    let caddy_container = read_deploy("quadlet/oracy-caddy.container.in");
+    let ingress_network = read_deploy("quadlet/oracy-ingress.network");
+    let caddy_data = read_deploy("quadlet/oracy-caddy-data.volume");
+    let caddy_config = read_deploy("quadlet/oracy-caddy-config.volume");
+
+    assert_file_exists(quadlet_root.join("oracy.container.in"));
+    assert_file_exists(quadlet_root.join("oracy-data.volume.in"));
+    assert_file_exists(quadlet_root.join("oracy-ingress.network"));
+    assert_file_exists(quadlet_root.join("oracy-caddy.container.in"));
+    assert_file_exists(quadlet_root.join("oracy-caddy-data.volume"));
+    assert_file_exists(quadlet_root.join("oracy-caddy-config.volume"));
+
+    assert_contains_all(
+        &container,
+        &[
+            "ContainerName=oracy",
+            "Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro,Z",
+            "Volume=oracy-data.volume:/var/lib/oracy:rw,Z",
+            "Network=oracy-ingress.network",
+            "NetworkAlias=oracy",
+            "PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090",
+            "StopTimeout=30",
+            "TimeoutStopSec=40",
+        ],
+    );
+    assert_contains_all(
+        &read_deploy("quadlet/oracy-data.volume.in"),
+        &["Device=@ORACY_STATE_DIR@", "Type=none", "Options=bind"],
+    );
+    assert_contains_all(
+        &caddy_container,
+        &[
+            "ContainerName=oracy-caddy",
+            "Network=oracy-ingress.network",
+            "PublishPort=80:80",
+            "PublishPort=443:443",
+            "PublishPort=443:443/udp",
+            "Volume=@ORACY_CADDYFILE_PATH@:/etc/caddy/Caddyfile:ro,Z",
+            "Volume=oracy-caddy-data.volume:/data:rw,Z",
+            "Volume=oracy-caddy-config.volume:/config:rw,Z",
+        ],
+    );
+    assert_contains_all(
+        &ingress_network,
+        &["[Network]", "NetworkName=oracy-ingress"],
+    );
+    assert_contains_all(&caddy_data, &["[Volume]", "VolumeName=oracy-caddy-data"]);
+    assert_contains_all(
+        &caddy_config,
+        &["[Volume]", "VolumeName=oracy-caddy-config"],
+    );
 }
 
 #[test]
-fn quadlet_template_mounts_host_bound_state_through_volume_template() {
-    let container = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
-        .expect("read container Quadlet template");
-    let volume = std::fs::read_to_string("../deploy/quadlet/oracy-data.volume.in")
-        .expect("read volume Quadlet template");
+fn shipped_caddyfile_template_routes_oracy_public_api() {
+    let caddyfile = read_deploy("examples/Caddyfile.in");
 
-    assert!(container.contains("Volume=oracy-data.volume:/var/lib/oracy:rw"));
-    assert!(volume.contains("Device=@ORACY_STATE_DIR@"));
-    assert!(volume.contains("Type=none"));
-    assert!(volume.contains("Options=bind"));
+    assert_contains_all(
+        &caddyfile,
+        &[
+            "@ORACY_PUBLIC_HOSTNAME@ {",
+            "output stdout",
+            "format json",
+            "reverse_proxy http://oracy:8080",
+            "header_up X-Real-IP {http.request.remote.host}",
+            "read_timeout 300s",
+            "write_timeout 300s",
+            "X-Content-Type-Options nosniff",
+            "X-Frame-Options DENY",
+            "Referrer-Policy strict-origin-when-cross-origin",
+            "-Server",
+        ],
+    );
 }
 
 #[test]
-fn quadlet_template_privately_relabels_selinux_visible_mounts() {
-    let template = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
-        .expect("read container Quadlet template");
+fn template_suffixes_match_placeholder_presence() {
+    for artifact in deploy_files("quadlet")
+        .into_iter()
+        .chain(deploy_files("examples"))
+    {
+        let contents = std::fs::read_to_string(&artifact)
+            .unwrap_or_else(|_| panic!("read {}", artifact.display()));
+        let has_placeholder = !template_variables(&contents).is_empty();
+        let has_template_suffix = artifact
+            .extension()
+            .is_some_and(|extension| extension == "in");
 
-    assert!(template.contains("Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro,Z"));
-    assert!(template.contains("Volume=oracy-data.volume:/var/lib/oracy:rw,Z"));
-    assert!(!template.contains("SecurityLabelDisable=true"));
-}
-
-#[test]
-fn quadlet_template_grants_podman_a_full_thirty_second_stop_window() {
-    let template = std::fs::read_to_string("../deploy/quadlet/oracy.container.in")
-        .expect("read container Quadlet template");
-
-    let stop_timeout = quadlet_seconds(&template, "StopTimeout");
-    let timeout_stop_sec = quadlet_seconds(&template, "TimeoutStopSec");
-
-    assert_eq!(stop_timeout, 30);
-    assert_eq!(timeout_stop_sec, 40);
-    assert!(timeout_stop_sec > stop_timeout);
-}
-
-#[test]
-fn deployment_readme_manages_the_quadlet_generated_service_unit() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-
-    assert!(readme.contains("systemctl --user start oracy.service"));
-    assert!(readme.contains("systemctl --user status oracy.service"));
-    assert!(!readme.contains("systemctl --user start oracy.container"));
-    assert!(!readme.contains("systemctl --user enable oracy.service"));
-}
-
-#[test]
-fn deployment_readme_names_quadlet_rendered_filenames() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-
-    assert!(readme.contains("oracy.container"));
-    assert!(readme.contains("oracy-data.volume"));
-}
-
-#[test]
-fn deployment_readme_documents_reverse_proxy_networking_patterns() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-
-    assert!(readme.contains("127.0.0.1:8080:8080"));
-    assert!(readme.contains("Network=ingress.network"));
-    assert!(readme.contains("http://oracy:8080"));
-    assert!(readme.contains("When\n  rendering `oracy.container`"));
-    assert!(readme.contains("leave the public `PublishPort=` directive out"));
-    assert!(!readme.contains("remove the public `PublishPort=@ORACY_PUBLIC_PUBLISH@` line"));
-    assert!(readme.contains("host.containers.internal"));
-    assert!(readme.contains("host.docker.internal"));
-    assert!(readme.contains("--add-host=host.docker.internal:host-gateway"));
-    assert!(readme.contains("extra_hosts"));
-    assert!(readme.contains("host.docker.internal:host-gateway"));
-    assert!(readme.contains("host-gateway"));
-    assert!(readme.contains("0.0.0.0:8080:8080"));
-    assert!(readme.contains("is reachability, not protection"));
-    assert!(readme.contains("verify that the port is blocked from untrusted networks"));
-}
-
-#[test]
-fn deployment_readme_documents_fresh_reverse_proxy_substrate() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-    let fresh_substrate = markdown_section(&readme, "Provision A Fresh Reverse Proxy Substrate");
-
-    assert!(fresh_substrate.contains("ingress.network"));
-    assert!(fresh_substrate.contains("[Network]"));
-    assert!(fresh_substrate.contains("NetworkName=ingress"));
-    assert!(fresh_substrate.contains("Network=ingress.network"));
-    assert!(fresh_substrate.contains("NetworkAlias=oracy"));
-    assert!(fresh_substrate.contains("http://oracy:8080"));
-    assert!(fresh_substrate.contains("PublishPort=80:80"));
-    assert!(fresh_substrate.contains("PublishPort=443:443"));
-    assert!(fresh_substrate.contains("PublishPort=443:443/udp"));
-    assert!(fresh_substrate.contains("/data"));
-    assert!(fresh_substrate.contains("/config"));
-    assert!(fresh_substrate.contains("TLS"));
-}
-
-#[test]
-fn deployment_readme_discloses_user_scope_low_port_policy_for_fresh_proxy() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-    let fresh_substrate = markdown_section(&readme, "Provision A Fresh Reverse Proxy Substrate");
-
-    assert!(fresh_substrate.contains("user-scope"));
-    assert!(fresh_substrate.contains("PublishPort=80:80"));
-    assert!(fresh_substrate.contains("PublishPort=443:443"));
-    assert!(fresh_substrate.contains("PublishPort=443:443/udp"));
-    assert!(fresh_substrate.contains("net.ipv4.ip_unprivileged_port_start=80"));
-    assert!(fresh_substrate.contains("1024"));
-    assert!(fresh_substrate.contains("host-wide"));
-    assert!(fresh_substrate.contains("all unprivileged processes"));
-}
-
-#[test]
-fn deployment_readme_constructs_all_fresh_quadlet_references() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-    let fresh_substrate = markdown_section(&readme, "Provision A Fresh Reverse Proxy Substrate");
-
-    for reference in fresh_quadlet_references(fresh_substrate) {
-        let (name, unit_type, construction_key) = reference_unit_construction(&reference)
-            .unwrap_or_else(|| {
-                panic!("{reference} should use a Quadlet unit suffix covered by this test")
-            });
-
-        assert!(
-            fresh_substrate.contains(unit_type),
-            "{reference} should document a {unit_type} unit"
-        );
-        assert!(
-            fresh_substrate.contains(&format!("{construction_key}={name}")),
-            "{reference} should document {construction_key}={name}"
+        assert_eq!(
+            has_placeholder,
+            has_template_suffix,
+            "{} should use .in exactly when it contains @VAR@ placeholders",
+            artifact.display()
         );
     }
 }
 
 #[test]
-fn deployment_readme_documents_existing_deployment_cutover_structure() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-    let cutover = markdown_section(&readme, "Cut Over From An Existing Deployment");
-    let normalized = normalize_whitespace(cutover);
+fn deployment_readme_documents_all_shipped_template_variables() {
+    let readme = read_deploy("README.md");
+    let variables = deploy_files("quadlet")
+        .into_iter()
+        .chain(deploy_files("examples"))
+        .flat_map(|path| {
+            let contents = std::fs::read_to_string(&path)
+                .unwrap_or_else(|_| panic!("read {}", path.display()));
+            template_variables(&contents)
+        })
+        .collect::<BTreeSet<_>>();
 
-    assert!(cutover.contains("parallel-then-swap"));
-    assert!(cutover.contains("stop-then-replace"));
-    assert!(cutover.contains("pre-cutover validation"));
-    assert!(cutover.contains("new-stack standup"));
-    assert!(cutover.contains("ingress candidate wiring"));
-    assert!(cutover.contains("candidate validation"));
-    assert!(cutover.contains("swap"));
-    assert!(cutover.contains("decommission"));
-    assert!(cutover.contains("post-cutover validation"));
-    assert!(cutover.contains("rollback"));
-    assert!(cutover.contains("downtime"));
-    assert!(cutover.contains("canonical"));
-    assert!(cutover.contains("stop previous deployment"));
-    assert!(cutover.contains("production validation"));
-    assert!(normalized.contains("has no separate candidate validation phase"));
-    assert!(cutover.contains("previous deployment"));
-    assert!(cutover.contains("previous ingress"));
-    assert!(cutover.contains("Provision A Fresh Reverse Proxy Substrate"));
-    assert!(normalized.contains("If either strategy decouples a reverse proxy"));
+    for variable in variables {
+        assert!(
+            readme.contains(&format!("- `@{variable}@`:")),
+            "README should document @{variable}@ in Operator-Owned Values"
+        );
+    }
 }
 
 #[test]
-fn deployment_readme_classifies_cutover_reversibility_and_data_handling() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-    let cutover = markdown_section(&readme, "Cut Over From An Existing Deployment");
-    let normalized = normalize_whitespace(cutover);
+fn deployment_readme_install_section_names_every_shipped_quadlet() {
+    let readme = read_deploy("README.md");
+    let install = markdown_section(&readme, "Install Quadlets");
 
-    assert!(cutover.contains("reversible"));
-    assert!(cutover.contains("irreversible-state"));
-    assert!(cutover.contains("preserve"));
-    assert!(cutover.contains("discard"));
-    assert!(cutover.contains("capture for separate migration"));
-    assert!(normalized.contains("migration tooling is out of scope"));
-    assert!(normalized.contains("For `parallel-then-swap`, roll back ingress first"));
-    assert!(normalized.contains("For `stop-then-replace`, stop the replacement stack first"));
-    assert!(normalized.contains("accepted by the new stack after public traffic reaches it"));
-    assert!(normalized.contains("preserve the new state for separate reconciliation"));
+    for artifact in deploy_files("quadlet") {
+        let filename = artifact
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("quadlet artifact should have utf-8 filename");
+
+        assert!(
+            install.contains(filename),
+            "Install Quadlets section should name {filename}"
+        );
+    }
 }
 
 #[test]
-fn deployment_readme_surfaces_stop_then_replace_preserve_via_backup_pattern() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-    let cutover = markdown_section(&readme, "Cut Over From An Existing Deployment");
-    let stop_then_replace = text_between(
-        cutover,
-        "Classify every `stop-then-replace` operation before running it:",
-        "Rollback model differs by strategy.",
-    );
-    let normalized = normalize_whitespace(stop_then_replace);
+fn deployment_readme_presents_the_caddy_shared_network_shape_as_canonical() {
+    let readme = read_deploy("README.md");
+    let install = markdown_section(&readme, "Install Quadlets");
+    let deployment_shape = canonical_shape_tokens(&[
+        read_deploy("quadlet/oracy.container.in"),
+        read_deploy("quadlet/oracy-caddy.container.in"),
+        read_deploy("quadlet/oracy-ingress.network"),
+        read_deploy("examples/Caddyfile.in"),
+    ]);
 
-    assert!(stop_then_replace.contains("preserve-via-backup"));
-    assert!(normalized.contains("reclaim canonical paths or names"));
-    assert!(stop_then_replace.contains("/var/lib/oracy.rollback"));
-    assert!(normalized.contains("replacement `/var/lib/oracy`"));
-    assert!(normalized.contains("rollback window is intentionally closed"));
+    for token in deployment_shape {
+        assert!(
+            install.contains(&token),
+            "Install Quadlets section should expose canonical deployment token {token}"
+        );
+    }
 }
 
 #[test]
-fn deployment_readme_resolves_shared_network_reference_to_ingress_unit() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-    let normalized = normalize_whitespace(&readme);
-
-    assert!(normalized.contains("operator-owned `ingress.network` unit"));
-    assert!(readme.contains("`ingress.network` Quadlet"));
-    assert!(!readme.contains("oracy-proxy.network"));
-}
-
-#[test]
-fn deployment_readme_keeps_backend_deployment_guidance_linux_scoped() {
-    let readme = std::fs::read_to_string("../deploy/README.md").expect("read deployment README");
-
-    assert!(!readme.contains("Docker Desktop"));
-    assert!(!readme.contains("macOS"));
-    assert!(!readme.contains("Windows"));
-}
-
-#[test]
-fn deployment_contract_supports_common_reverse_proxy_topologies() {
+fn deployment_contract_names_the_supported_oracy_scoped_ingress_substrate() {
     let contract =
         std::fs::read_to_string("../spec/deployment.md").expect("read deployment contract");
     let public_api = markdown_section(&contract, "Public API Reverse Proxy");
 
-    assert!(public_api.contains("host-system reverse proxy"));
-    assert!(public_api.contains("shared container network"));
-    assert!(public_api.contains("isolated container reverse proxy"));
-    assert!(public_api.contains("operator-managed firewall"));
-    assert!(public_api.contains("non-loopback binding is reachability, not protection"));
+    for token in [
+        "oracy-ingress.network",
+        "oracy-caddy.container",
+        "oracy-caddy-data.volume",
+        "oracy-caddy-config.volume",
+        "Caddy",
+        "http://oracy:8080",
+    ] {
+        assert!(
+            public_api.contains(token),
+            "deployment contract should name supported substrate token {token}"
+        );
+    }
 }
 
-#[test]
-fn deployment_contract_documents_selinux_labeling_for_all_state_storage() {
-    let contract =
-        std::fs::read_to_string("../spec/deployment.md").expect("read deployment contract");
-    let accepted_audio = markdown_section(&contract, "Accepted Audio Directory");
-    let sqlite_database = markdown_section(&contract, "SQLite Database File");
-
-    assert!(accepted_audio.contains("On SELinux-enforcing hosts"));
-    assert!(sqlite_database.contains("On SELinux-enforcing hosts"));
-    assert!(sqlite_database.contains("parent directory"));
-    assert!(sqlite_database.contains("SQLite sidecar files"));
+fn deploy_path(relative: impl AsRef<Path>) -> PathBuf {
+    Path::new("../deploy").join(relative)
 }
 
-fn quadlet_seconds(template: &str, key: &str) -> u64 {
-    template
-        .lines()
-        .find_map(|line| line.strip_prefix(&format!("{key}=")))
-        .unwrap_or_else(|| panic!("{key} should be declared"))
-        .parse()
-        .unwrap_or_else(|_| panic!("{key} should be declared as plain seconds"))
+fn read_deploy(relative: &str) -> String {
+    let path = deploy_path(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("read {}", path.display()))
+}
+
+fn assert_file_exists(path: PathBuf) {
+    assert!(path.is_file(), "{} should exist", path.display());
+}
+
+fn assert_contains_all(document: &str, required: &[&str]) {
+    for item in required {
+        assert!(document.contains(item), "document should contain {item}");
+    }
+}
+
+fn deploy_files(relative: &str) -> Vec<PathBuf> {
+    let root = deploy_path(relative);
+    let mut files = std::fs::read_dir(&root)
+        .unwrap_or_else(|_| panic!("read {}", root.display()))
+        .map(|entry| {
+            entry
+                .unwrap_or_else(|_| panic!("read directory entry from {}", root.display()))
+                .path()
+        })
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+
+    files.sort();
+    files
+}
+
+fn template_variables(contents: &str) -> BTreeSet<String> {
+    let mut variables = BTreeSet::new();
+    let bytes = contents.as_bytes();
+    let mut index = 0;
+
+    while let Some(start_offset) = contents[index..].find('@') {
+        let start = index + start_offset;
+        let Some(end_offset) = contents[start + 1..].find('@') else {
+            break;
+        };
+        let end = start + 1 + end_offset;
+        let candidate = &contents[start + 1..end];
+
+        if !candidate.is_empty()
+            && candidate
+                .bytes()
+                .all(|byte| byte == b'_' || byte.is_ascii_uppercase() || byte.is_ascii_digit())
+            && bytes.get(start) == Some(&b'@')
+            && bytes.get(end) == Some(&b'@')
+        {
+            variables.insert(candidate.to_owned());
+        }
+
+        index = end + 1;
+    }
+
+    variables
+}
+
+fn canonical_shape_tokens(artifacts: &[String]) -> BTreeSet<String> {
+    let mut tokens = BTreeSet::new();
+
+    for artifact in artifacts {
+        for line in artifact.lines() {
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            match key {
+                "ContainerName" | "Network" | "NetworkAlias" | "NetworkName" | "VolumeName"
+                    if !value.starts_with('@') =>
+                {
+                    tokens.insert(value.to_owned());
+                }
+                "Volume" => {
+                    if let Some((source, _)) = value.split_once(':') {
+                        if !source.starts_with('@') {
+                            tokens.insert(source.to_owned());
+                        }
+                    }
+                }
+                "reverse_proxy" => {
+                    tokens.insert(value.trim().to_owned());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    tokens
 }
 
 fn markdown_section<'a>(document: &'a str, heading: &str) -> &'a str {
@@ -267,56 +288,4 @@ fn markdown_section<'a>(document: &'a str, heading: &str) -> &'a str {
         .map_or(document.len(), |offset| after_heading + offset);
 
     &document[start..end]
-}
-
-fn normalize_whitespace(document: &str) -> String {
-    document.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn text_between<'a>(document: &'a str, start_marker: &str, end_marker: &str) -> &'a str {
-    let start = document
-        .find(start_marker)
-        .unwrap_or_else(|| panic!("{start_marker} should exist"));
-    let after_start = start + start_marker.len();
-    let end = document[after_start..]
-        .find(end_marker)
-        .map_or(document.len(), |offset| after_start + offset);
-
-    &document[start..end]
-}
-
-fn fresh_quadlet_references(section: &str) -> Vec<String> {
-    let mut references = Vec::new();
-
-    for line in section.lines() {
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        let Some(reference) = (match key {
-            "Network" => Some(value),
-            "Volume" => value.split_once(':').map(|(source, _)| source),
-            _ => None,
-        }) else {
-            continue;
-        };
-
-        if reference.ends_with(".network") || reference.ends_with(".volume") {
-            references.push(reference.to_owned());
-        }
-    }
-
-    references.sort();
-    references.dedup();
-    references
-}
-
-fn reference_unit_construction(reference: &str) -> Option<(&str, &'static str, &'static str)> {
-    reference
-        .strip_suffix(".network")
-        .map(|name| (name, "[Network]", "NetworkName"))
-        .or_else(|| {
-            reference
-                .strip_suffix(".volume")
-                .map(|name| (name, "[Volume]", "VolumeName"))
-        })
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,9 +1,14 @@
 # Oracy Backend Deployment
 
-This directory contains generic deployment artifacts for the Rust backend.
-The repository owns the image build, service shape, and persistence template;
-operators own concrete host bindings such as paths, ports, permissions, image
-tags, and secrets.
+This directory contains the Oracy-owned deployment substrate for the Rust
+backend. The `v0.1.2` recipe targets Fedora CoreOS with rootless Podman
+Quadlet generators: the backend runs behind an Oracy-scoped Caddy reverse
+proxy on a private Oracy ingress network.
+
+The repository owns the image build, Quadlet service shape, Caddy ingress
+fabric, and persistence templates. Operators own concrete host bindings such
+as paths, image tags, credentials, public hostname, and the host policy that
+allows rootless Caddy to bind public HTTPS ports.
 
 ## Build The Image
 
@@ -30,19 +35,20 @@ The backend process inside the container must be able to create and update
 On rootless Podman deployments, verify the host ownership and UID/GID mapping
 used by the service account before starting the unit.
 
-The shipped Quadlet template privately relabels the mounted config file and
-state volume for confined Podman containers on SELinux-enforcing hosts. Use
-host paths dedicated to this Oracy service; do not share those paths with other
-containers.
+The shipped Quadlet templates privately relabel the mounted backend config,
+backend state, and Caddyfile for confined Podman containers on
+SELinux-enforcing hosts. Use host paths dedicated to this Oracy service; do
+not share those paths with other containers.
 
 ## Configure The Backend
 
 Use [`examples/oracy.toml`](examples/oracy.toml) as the starting point for the
-container-mounted config. The default container-internal listeners are:
+container-mounted backend config. The default container-internal listeners are:
 
-- `0.0.0.0:8080` for the public API.
+- `0.0.0.0:8080` for the public API, reachable only from the Oracy ingress
+  network in the shipped deployment.
 - `0.0.0.0:9090` for operator metrics, published to host loopback by the
-  Quadlet template.
+  backend Quadlet template.
 
 Put the OpenAI credential in an environment file readable by the service
 account, for example:
@@ -52,64 +58,86 @@ install -m 0600 /dev/null /var/lib/oracy/oracy.env
 printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" > /var/lib/oracy/oracy.env
 ```
 
+Render [`examples/Caddyfile.in`](examples/Caddyfile.in) with the public Oracy
+API hostname and place the result at the host path supplied through
+`@ORACY_CADDYFILE_PATH@`.
+
 ## Install Quadlets
 
-Render the templates from [`quadlet/`](quadlet/) into
-`~/.config/containers/systemd/` for the service account, replacing the
-`@...@` placeholders with host values and removing the `.in` suffix:
+Render the templates from [`quadlet/`](quadlet/) and
+[`examples/`](examples/) into the service account's persistent configuration,
+replacing `@...@` placeholders with host values and removing the `.in` suffix
+from rendered files.
+
+Quadlet artifacts:
 
 - `quadlet/oracy.container.in` renders to `oracy.container`.
 - `quadlet/oracy-data.volume.in` renders to `oracy-data.volume`.
+- `quadlet/oracy-ingress.network` copies as `oracy-ingress.network`.
+- `quadlet/oracy-caddy.container.in` renders to `oracy-caddy.container`.
+- `quadlet/oracy-caddy-data.volume` copies as `oracy-caddy-data.volume`.
+- `quadlet/oracy-caddy-config.volume` copies as `oracy-caddy-config.volume`.
 
-Choose the public API network surface for the reverse proxy that will receive
-client traffic:
+Caddy artifact:
 
-- Host-system reverse proxy: keep Oracy published only to host loopback, for
-  example `@ORACY_PUBLIC_PUBLISH@=127.0.0.1:8080:8080`, and proxy to
-  `http://127.0.0.1:8080`.
-- Shared container network: if the reverse proxy can join the same Docker or
-  Podman network as Oracy, do not publish the public API on the host. When
-  rendering `oracy.container`, leave the public `PublishPort=` directive out
-  and add a shared network, for example:
+- `examples/Caddyfile.in` renders to the host path supplied as
+  `@ORACY_CADDYFILE_PATH@`.
 
-  ```ini
-  Network=ingress.network
-  NetworkAlias=oracy
-  ```
+The rendered Quadlet files normally live in
+`~/.config/containers/systemd/` for the service account. The canonical
+deployment shape is:
 
-  For Podman Quadlets, provide the matching operator-owned `ingress.network`
-  unit or replace the example with your existing network.
-  Put the proxy on the same network and proxy to `http://oracy:8080`. Docker
-  Compose services in the same project use shared service DNS by default; use
-  the Compose service name or network alias `oracy` for the backend service.
-- Isolated container reverse proxy: if the proxy cannot share Oracy's
-  container network, publish Oracy on a host address reachable from that proxy,
-  for example `@ORACY_PUBLIC_PUBLISH@=0.0.0.0:8080:8080`, and proxy through the
-  runtime's host gateway name such as `host.containers.internal` for Podman or
-  `host.docker.internal` for Docker.
+- Backend container: `oracy`
+- Reverse proxy container: `oracy-caddy`
+- Shared ingress network unit: `oracy-ingress.network`
+- Podman network name: `oracy-ingress`
+- Backend DNS alias on that network: `oracy`
+- Caddy TLS state volume: `oracy-caddy-data.volume`
+- Caddy config state volume: `oracy-caddy-config.volume`
+- Public site block: `@ORACY_PUBLIC_HOSTNAME@`
 
-  For Docker on Linux, add the host gateway name to the isolated proxy
-  container with `--add-host=host.docker.internal:host-gateway` or, in Compose:
+The backend joins `oracy-ingress.network` and exposes the public API to Caddy
+as `http://oracy:8080`. Caddy owns the public host bindings:
 
-  ```yaml
-  extra_hosts:
-    - "host.docker.internal:host-gateway"
-  ```
+```ini
+PublishPort=80:80
+PublishPort=443:443
+PublishPort=443:443/udp
+```
 
-  Podman provides `host.containers.internal` automatically and does not need
-  this Docker-specific mapping.
+Because this is a user-scope rootless deployment, the host must allow
+unprivileged low-port binding before Caddy starts. Standard rootless Linux
+rejects host ports below `1024`; provision
+`net.ipv4.ip_unprivileged_port_start=80` or lower through the host's persistent
+sysctl mechanism. That sysctl is host-wide: it allows all unprivileged
+processes on the host, not only `oracy-caddy`, to bind ports at or above the
+configured floor.
 
-  A non-loopback publish such as `0.0.0.0:8080:8080` is reachability, not protection.
-  Use it only with operator-managed firewall rules or equivalent host network
-  policy, and verify that the port is blocked from untrusted networks before
-  treating the binding as protected. Prefer binding to a specific private host
-  interface over `0.0.0.0` when the deployment has one.
+Caddy persists TLS and runtime state through named Podman volumes. `/data`
+carries certificates and other TLS state; `/config` carries persistent Caddy
+configuration state. A stateless proxy container loses certificates on restart
+and can create avoidable ACME rate-limit pressure.
 
-A proxy running in an isolated container cannot reach an Oracy port published
-only on host loopback unless the proxy shares the host network namespace. In
-that case, use the host-system pattern intentionally.
+After rendering:
 
-The operator metrics publish line intentionally defaults to host loopback:
+```sh
+systemctl --user daemon-reload
+systemctl --user start oracy-ingress-network.service
+systemctl --user start oracy-data-volume.service
+systemctl --user start oracy-caddy-data-volume.service
+systemctl --user start oracy-caddy-config-volume.service
+systemctl --user start oracy.service
+systemctl --user start oracy-caddy.service
+systemctl --user status oracy.service
+systemctl --user status oracy-caddy.service
+```
+
+The generated container and network services include `[Install]` relationships
+for the user default target. For boot persistence under user-scope systemd,
+enable lingering for the service account through the host provisioning
+mechanism.
+
+The operator metrics publish line intentionally stays on host loopback:
 
 ```ini
 PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090
@@ -118,117 +146,25 @@ PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090
 Keep that loopback binding unless another protected operator network surface
 is intentionally provided.
 
-After templating:
+## Alternate Scenario Audit
 
-```sh
-systemctl --user daemon-reload
-systemctl --user start oracy.service
-systemctl --user status oracy.service
-```
+The retained deployment recipe is the Oracy-scoped shared container network
+using Caddy. It is the primary path because it lets an independent Oracy
+operator deploy backend, ingress network, reverse proxy, and TLS state as one
+self-contained unit. Multi-app hosts keep modularity by running per-app
+ingress fabrics instead of sharing an operator-wide reverse proxy substrate.
 
-The Quadlet template's `[Install]` relationship makes the generated service
-part of the user default target at `daemon-reload` time. For boot persistence
-under user-scope systemd, enable lingering for the service account through the
-host provisioning mechanism.
+The prior host-system reverse-proxy scenario is not retained as a deployment
+recipe. It fits operators who already manage a host-wide ingress layer, but
+that layer is operator-owned infrastructure rather than Oracy-owned substrate;
+keeping it as an equal recipe would preserve the framing this deployment
+surface now rejects.
 
-## Provision A Fresh Reverse Proxy Substrate
-
-If the host does not already have a reverse proxy, provision the ingress fabric
-as operator-owned infrastructure before joining Oracy to it. The ingress
-network and proxy are not Oracy artifacts; Oracy only needs a private route to
-the proxy.
-
-For Podman Quadlet deployments, create an `ingress.network` Quadlet in the same
-user-scope Quadlet directory as the persistent services:
-
-```ini
-[Unit]
-Description=Operator ingress network
-
-[Network]
-NetworkName=ingress
-
-[Install]
-WantedBy=default.target
-```
-
-`NetworkName=ingress` gives the Podman network an operator-owned name instead
-of an app-specific name. Render `oracy.container` with the shared-network
-shape from the install section:
-
-```ini
-Network=ingress.network
-NetworkAlias=oracy
-```
-
-Leave Oracy's public API `PublishPort=` directive out in this topology. The
-proxy reaches the backend through `http://oracy:8080` on the ingress network,
-and the public internet reaches only the proxy.
-
-Create the Caddy state volumes in the same Quadlet directory:
-
-```ini
-[Unit]
-Description=Operator reverse proxy TLS state
-
-[Volume]
-VolumeName=caddy-data
-```
-
-```ini
-[Unit]
-Description=Operator reverse proxy config state
-
-[Volume]
-VolumeName=caddy-config
-```
-
-The concrete proxy is operator scope. A Caddy Quadlet is one illustrative
-containerized proxy shape. Because this user-scope rootless example publishes
-host ports 80 and 443, the host must allow unprivileged low-port binding before
-the proxy starts. Standard rootless Linux rejects host ports below 1024; for
-this example, provision `net.ipv4.ip_unprivileged_port_start=80` or lower
-through the host's persistent sysctl mechanism. That sysctl is host-wide: it
-allows all unprivileged processes on the host, not only this Caddy container,
-to bind ports at or above the configured floor.
-
-```ini
-[Unit]
-Description=Operator reverse proxy
-
-[Container]
-Image=docker.io/library/caddy:2
-ContainerName=ingress-proxy
-Network=ingress.network
-PublishPort=80:80
-PublishPort=443:443
-PublishPort=443:443/udp
-Volume=/var/lib/caddy/Caddyfile:/etc/caddy/Caddyfile:ro,Z
-Volume=caddy-data.volume:/data:rw,Z
-Volume=caddy-config.volume:/config:rw,Z
-
-[Service]
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=default.target
-```
-
-The Caddyfile for that proxy would route the public site to Oracy by its
-network alias:
-
-```caddyfile
-oracy.example.com {
-	reverse_proxy http://oracy:8080
-}
-```
-
-Persist the proxy's TLS state. For Caddy, `/data` carries certificates and
-other state, and `/config` carries persistent configuration state. The
-`caddy-data.volume` and `caddy-config.volume` units above back those container
-paths with named Podman volumes; a stateless proxy container loses
-certificates on restart and can create avoidable ACME rate-limit pressure.
+The prior isolated-container reverse-proxy scenario is not retained as a
+deployment recipe. It fits hosts where a proxy cannot share Oracy's network,
+but it requires a non-loopback backend publish plus host-gateway and firewall
+policy. That is a custom operator topology, not the complete Oracy-scoped
+fabric shipped here.
 
 ## Cut Over From An Existing Deployment
 
@@ -237,15 +173,15 @@ proxy placement, storage layout, and whether the reverse proxy was bundled with
 the old stack. Treat the old system as the previous deployment, previous
 ingress, and previous state. Do not assume its shape when planning cutover.
 If either strategy decouples a reverse proxy that was bundled with the previous
-deployment, use `Provision A Fresh Reverse Proxy Substrate` as the construction
-reference for the new operator-owned ingress fabric.
+deployment, use this Oracy-scoped Caddy ingress substrate as the construction
+reference for the new public path.
 
 Decide the previous state disposition before touching ingress:
 
 | Disposition | Classification | Operator commitment |
 |-------------|----------------|---------------------|
 | `preserve` | Reversible | Keep the previous state readable by the previous deployment until the new public path has passed validation and the rollback window is closed. |
-| `capture for separate migration` | Reversible until the captured copy becomes the only retained source | Stop old writers long enough to take a consistent copy or archive for later migration. The migration tooling is out of scope for `v0.1.0`; this capture only preserves material for separate work. |
+| `capture for separate migration` | Reversible until the captured copy becomes the only retained source | Stop old writers long enough to take a consistent copy or archive for later migration. The migration tooling is out of scope for `v0.1.x`; this capture only preserves material for separate work. |
 | `discard` | `irreversible-state` | Remove previous state only after explicit operator acceptance that the old data and rollback surface are no longer needed. |
 
 Choose the cutover strategy that matches the operator constraint:
@@ -278,14 +214,14 @@ Classify every `stop-then-replace` operation before running it:
 | rollback-window retention | Reversible | The previous state, configuration, secrets, routes, volumes, and host bindings remain available until the operator accepts the replacement and closes the rollback window. |
 | decommission | `irreversible-state` once state or rollback surfaces are removed | Remove previous state, secrets, routes, volumes, or host bindings only after production validation passes and the rollback window is intentionally closed. |
 
-When `stop-then-replace` must reclaim canonical paths or names from the
-start, preserve-via-backup is one realization of rollback-window retention:
-move the previous substrate to a backup location before creating the
-replacement at the canonical location. For example, move previous
-`/var/lib/oracy` to `/var/lib/oracy.rollback`, then create the replacement
-`/var/lib/oracy` for the new stack. Keep that backup substrate, along with the
-previous configuration, secrets, routes, volumes, and host bindings required
-for rollback, until the rollback window is intentionally closed. Operators may
+When `stop-then-replace` must reclaim canonical paths or names from the start,
+preserve-via-backup is one realization of rollback-window retention: move the
+previous substrate to a backup location before creating the replacement at the
+canonical location. For example, move previous `/var/lib/oracy` to
+`/var/lib/oracy.rollback`, then create the replacement `/var/lib/oracy` for
+the new stack. Keep that backup substrate, along with the previous
+configuration, secrets, routes, volumes, and host bindings required for
+rollback, until the rollback window is intentionally closed. Operators may
 choose a different rollback substrate, such as an off-host backup, when it
 preserves the same rollback capability.
 
@@ -296,10 +232,10 @@ previous deployment against preserved previous state, then validate the old
 public path before making more changes. For `stop-then-replace`, stop the
 replacement stack first, restore the previous ingress setting, then restart or
 re-enable the previous deployment against preserved previous state and
-configuration. Under either strategy, any writes accepted by the new stack after
-public traffic reaches it are not automatically present in the previous state;
-preserve the new state for separate reconciliation rather than deleting it
-during rollback.
+configuration. Under either strategy, any writes accepted by the new stack
+after public traffic reaches it are not automatically present in the previous
+state; preserve the new state for separate reconciliation rather than deleting
+it during rollback.
 
 ## Operator-Owned Values
 
@@ -308,8 +244,10 @@ during rollback.
   `OPENAI_API_KEY`.
 - `@ORACY_CONFIG_PATH@`: host path to the backend TOML configuration.
 - `@ORACY_STATE_DIR@`: host directory that persists SQLite and accepted audio.
-- `@ORACY_PUBLIC_PUBLISH@`: public API publish rule, such as
-  `127.0.0.1:8080:8080` or `0.0.0.0:8080:8080`. Omit the rendered public
-  publish line for shared container-network proxy deployments.
 - `@ORACY_OPERATOR_HOST_PORT@`: host loopback port for metrics, normally
   `9090`.
+- `@ORACY_CADDYFILE_PATH@`: host path to the rendered Caddyfile, such as
+  `/var/lib/oracy/Caddyfile`.
+- `@ORACY_PUBLIC_HOSTNAME@`: public DNS hostname for the Oracy API. No sensible
+  default exists; operators provide the real hostname, such as
+  `api.oracy.example`.

--- a/deploy/examples/Caddyfile.in
+++ b/deploy/examples/Caddyfile.in
@@ -1,0 +1,19 @@
+@ORACY_PUBLIC_HOSTNAME@ {
+	log {
+		output stdout
+		format json
+	}
+	reverse_proxy http://oracy:8080 {
+		header_up X-Real-IP {http.request.remote.host}
+		transport http {
+			read_timeout 300s
+			write_timeout 300s
+		}
+	}
+	header {
+		X-Content-Type-Options nosniff
+		X-Frame-Options DENY
+		Referrer-Policy strict-origin-when-cross-origin
+		-Server
+	}
+}

--- a/deploy/quadlet/oracy-caddy-config.volume
+++ b/deploy/quadlet/oracy-caddy-config.volume
@@ -1,0 +1,5 @@
+[Unit]
+Description=Oracy Caddy config state
+
+[Volume]
+VolumeName=oracy-caddy-config

--- a/deploy/quadlet/oracy-caddy-data.volume
+++ b/deploy/quadlet/oracy-caddy-data.volume
@@ -1,0 +1,5 @@
+[Unit]
+Description=Oracy Caddy TLS state
+
+[Volume]
+VolumeName=oracy-caddy-data

--- a/deploy/quadlet/oracy-caddy.container.in
+++ b/deploy/quadlet/oracy-caddy.container.in
@@ -1,0 +1,22 @@
+[Unit]
+Description=Oracy Caddy reverse proxy
+
+[Container]
+Image=docker.io/library/caddy:2
+ContainerName=oracy-caddy
+Network=oracy-ingress.network
+PublishPort=80:80
+PublishPort=443:443
+PublishPort=443:443/udp
+Volume=@ORACY_CADDYFILE_PATH@:/etc/caddy/Caddyfile:ro,Z
+Volume=oracy-caddy-data.volume:/data:rw,Z
+Volume=oracy-caddy-config.volume:/config:rw,Z
+StopTimeout=30
+
+[Service]
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=40
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/oracy-ingress.network
+++ b/deploy/quadlet/oracy-ingress.network
@@ -1,0 +1,8 @@
+[Unit]
+Description=Oracy ingress network
+
+[Network]
+NetworkName=oracy-ingress
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/oracy.container.in
+++ b/deploy/quadlet/oracy.container.in
@@ -9,7 +9,8 @@ Environment=ORACY_CONFIG=/etc/oracy/oracy.toml
 EnvironmentFile=@ORACY_ENV_FILE@
 Volume=@ORACY_CONFIG_PATH@:/etc/oracy/oracy.toml:ro,Z
 Volume=oracy-data.volume:/var/lib/oracy:rw,Z
-PublishPort=@ORACY_PUBLIC_PUBLISH@
+Network=oracy-ingress.network
+NetworkAlias=oracy
 PublishPort=127.0.0.1:@ORACY_OPERATOR_HOST_PORT@:9090
 StopTimeout=30
 

--- a/spec/deployment.md
+++ b/spec/deployment.md
@@ -1,6 +1,6 @@
 # Oracy Deployment Contract
 
-Target release: `v0.1.0`
+Target release: `v0.1.2`
 
 ## Purpose
 
@@ -13,9 +13,10 @@ durability commitments under nominal load.
 behavior. This document describes the infrastructure responsibilities behind
 those settings.
 
-The generic container and Quadlet artifacts that implement this contract ship
-in [`deploy/`](../deploy/). Those artifacts are templates: the repository owns
-the build and service shape, while operators provide concrete host bindings.
+The generic container, Quadlet, and Caddy artifacts that implement this
+contract ship in [`deploy/`](../deploy/). Those artifacts are templates: the
+repository owns the build, service shape, and Oracy-scoped ingress substrate,
+while operators provide concrete host bindings.
 
 ## Audience
 
@@ -119,29 +120,27 @@ either tool is missing or cannot execute.
 
 ## Public API Reverse Proxy
 
-The backend's public API listener is intended to sit behind an
-operator-managed reverse proxy for internet-facing deployments. Operators must
-place the public listener on a network surface reachable by that proxy and not
-broader than the deployment's access-control boundary.
+The backend's public API listener sits behind the Oracy-scoped reverse-proxy
+substrate for internet-facing deployments. The supported `v0.1.2` deployment
+contract is a shared container network: `oracy.container` and
+`oracy-caddy.container` both join `oracy-ingress.network`, the backend exposes
+the public API to that network as `http://oracy:8080`, and Caddy owns the
+public host bindings.
 
-Supported `v0.1.0` reverse-proxy topologies are:
+The shipped ingress substrate is:
 
-- A host-system reverse proxy reaches Oracy through a host-loopback publish.
-- A shared container network lets the proxy reach Oracy by container DNS, with
-  no host public API publish required.
-- An isolated container reverse proxy reaches Oracy through the container
-  runtime's host gateway and a non-loopback host publish.
+- `oracy-ingress.network`, whose Podman network name is `oracy-ingress`.
+- `oracy-caddy.container`, a Caddy reverse-proxy container on that network.
+- `oracy-caddy-data.volume`, which persists Caddy `/data` TLS state.
+- `oracy-caddy-config.volume`, which persists Caddy `/config` state.
+- `deploy/examples/Caddyfile.in`, which templates the public hostname and
+  proxies to `http://oracy:8080`.
 
-Loopback binding is the preferred default when the proxy runs on the host or
-shares the host network namespace. A proxy running in an isolated container
-cannot reach a host-loopback-only publish by using the host gateway; the backend
-must instead share the proxy's container network or publish on a host address
-reachable from that container.
-
-For isolated proxy containers, non-loopback binding is reachability, not protection.
-Operators must provide an operator-managed firewall, host network policy, or
-equivalent control and verify that the published port is blocked from untrusted
-networks.
+The backend public API is not published directly to the host in the shipped
+recipe. Caddy publishes `80`, `443/tcp`, and `443/udp`; on rootless Podman
+hosts, operators must provision the host policy that allows unprivileged
+low-port binding. Operator metrics remain separate from this public route and
+are published to host loopback by the backend Quadlet template.
 
 ## Operator Metrics
 


### PR DESCRIPTION
## Summary

- Completes the Oracy-scoped deployment substrate with committed Quadlet ingress, Caddy reverse-proxy, Caddy state volumes, and a templated Caddyfile.
- Reframes deployment docs and the deployment contract around the supported shared-network Caddy recipe, with an explicit audit of removed alternate topologies.
- Replaces brittle deployment artifact checks with structural positive assertions over shipped files, template variables, README coverage, and contract framing.

## Changes

- Adds `oracy-ingress.network`, `oracy-caddy.container.in`, Caddy state volumes, and `examples/Caddyfile.in`.
- Updates `oracy.container.in` to join `oracy-ingress.network` with `NetworkAlias=oracy` while keeping operator metrics loopback-bound.
- Updates `deploy/README.md`, `spec/deployment.md`, and `CHANGELOG.md` for the Oracy-owned deployment recipe and operator-owned values.

## GitHub Issue(s)

Closes #113

## Test plan

- `cargo test --test deployment_artifacts`
- `cargo test`
- `./scripts/backend-ci`
- `podman build -t localhost/oracy:ci .`
